### PR TITLE
Add offending file to exception message, see #100

### DIFF
--- a/pitest/src/main/java/org/pitest/classpath/ArchiveClassPathRoot.java
+++ b/pitest/src/main/java/org/pitest/classpath/ArchiveClassPathRoot.java
@@ -113,7 +113,8 @@ public class ArchiveClassPathRoot implements ClassPathRoot {
     try {
       return new ZipFile(this.file);
     } catch (final IOException ex) {
-      throw Unchecked.translateCheckedException(ex);
+      throw Unchecked.translateCheckedException(ex.getMessage() + " (" + this.file + ")",
+    		  ex);
     }
   }
 


### PR DESCRIPTION
Adding a simple message so user would see which file caused an issue with class path. #100
