### PR TITLE
Fix for #102, show offending class if it is not found

### DIFF
--- a/pitest/src/main/java/org/pitest/util/Functions.java
+++ b/pitest/src/main/java/org/pitest/util/Functions.java
@@ -68,10 +68,11 @@ public abstract class Functions {
           return Option.<Class<?>> some(clazz);
         } catch (final ClassNotFoundException e) {
           LOG.warning("Could not load " + className
-              + " (ClassNotFoundException)");
+              + " (ClassNotFoundException: " + e.getMessage() + ")");
           return Option.none();
         } catch (final NoClassDefFoundError e) {
-          LOG.warning("Could not load " + className + " (NoClassDefFoundError)");
+          LOG.warning("Could not load " + className
+        		  + " (NoClassDefFoundError: " + e.getMessage() + ")");
           return Option.none();
         } catch (final LinkageError e) {
           LOG.warning("Could not load " + className + " " + e.getMessage());


### PR DESCRIPTION
With this change, output is

10:11:00 PIT >> INFO : SLAVE : 10:11:00 PIT >> WARNING : Could not load com.tonicsystems.jarjar.util.AntJarProcessorTest$7 (NoClassDefFoundError: com/tonicsystems/jarjar/util/AntJarProcessor)

10:11:00 PIT >> INFO : SLAVE : 10:11:00 PIT >> WARNING : Could not load com.tonicsystems.jarjar.util.AntJarProcessorTest$8 (NoClassDefFoundError: com/tonicsystems/jarjar/util/AntJarProcessor)

10:11:00 PIT >> INFO : SLAVE : 10:11:00 PIT >> WARNING : Could not load com.tonicsystems.jarjar.util.AntJarProcessorTest$9 (NoClassDefFoundError: com/tonicsystems/jarjar/util/AntJarProcessor)

10:11:00 PIT >> INFO : SLAVE : 10:11:00 PIT >> WARNING : Could not load com.tonicsystems.jarjar.util.JarTransformerTest$1 (NoClassDefFoundError: com/tonicsystems/jarjar/util/JarTransformer)

10:11:00 PIT >> INFO : SLAVE : 10:11:00 PIT >> WARNING : Could not load com.tonicsystems.jarjar.util.JarTransformerTest$2 (NoClassDefFoundError: com/tonicsystems/jarjar/util/JarTransformer)

so the culprit can be found and classpath fixed.
