### PR TITLE
Treat ClassRule as a single unit as JUnit does

### DIFF
--- a/pitest/src/main/java/org/pitest/reflection/IsAnnotatedWith.java
+++ b/pitest/src/main/java/org/pitest/reflection/IsAnnotatedWith.java
@@ -15,6 +15,7 @@
 package org.pitest.reflection;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 
 import org.pitest.functional.predicate.Predicate;
@@ -23,7 +24,7 @@ import org.pitest.functional.predicate.Predicate;
  * @author henry
  * 
  */
-public class IsAnnotatedWith implements Predicate<Method> {
+public class IsAnnotatedWith implements Predicate<AccessibleObject> {
 
   private final Class<? extends Annotation> clazz;
 
@@ -35,7 +36,7 @@ public class IsAnnotatedWith implements Predicate<Method> {
     this.clazz = clazz;
   }
 
-  public Boolean apply(final Method a) {
+  public Boolean apply(final AccessibleObject a) {
     return a.isAnnotationPresent(this.clazz);
   }
 

--- a/pitest/src/main/java/org/pitest/reflection/Reflection.java
+++ b/pitest/src/main/java/org/pitest/reflection/Reflection.java
@@ -14,6 +14,7 @@
  */
 package org.pitest.reflection;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -41,6 +42,14 @@ public abstract class Reflection {
     return ms;
   }
 
+  public static Set<Field> publicFields(final Class<?> clazz) {
+    final Set<Field> fields = new LinkedHashSet<Field>();
+    if (clazz != null) {
+      fields.addAll(Arrays.asList(clazz.getFields()));
+    }
+    return fields;
+  }
+
   public static Set<Method> allMethods(final Class<?> c) {
     final Set<Method> methods = new LinkedHashSet<Method>();
     if (c != null) {
@@ -64,5 +73,4 @@ public abstract class Reflection {
     return publicMethod(clazz, p);
 
   }
-
 }

--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -25,10 +25,9 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import org.jmock.MockObjectTestCase;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -231,6 +230,48 @@ public class JUnitCustomRunnerTestUnitFinderTest {
   @Test
   public void shouldCreateSingleAtomicUnitWhenClassAnnotatedWithAfterClass() {
     final Collection<TestUnit> actual = findWithTestee(HasAfterClassAnnotation.class);
+    assertEquals(1, actual.size());
+  }
+
+  public static class ClassRuleMethod {
+
+    @ClassRule
+    public static TestRule rule() {
+      return new ExternalResource() {};
+    }
+
+    @Test
+    public void testOne() {
+    }
+
+    @Test
+    public void testTwo() {
+    }
+  }
+
+  @Test
+  public void shouldCreateSingleAtomicUnitWhenAnyMethodAnnotatedWithClassRule() throws Exception {
+    final Collection<TestUnit> actual = findWithTestee(ClassRuleMethod.class);
+    assertEquals(1, actual.size());
+  }
+
+  public static class ClassRuleField {
+
+    @ClassRule
+    public static TestRule rule = new ExternalResource() {};
+
+    @Test
+    public void testOne() {
+    }
+
+    @Test
+    public void testTwo() {
+    }
+  }
+
+  @Test
+  public void shouldCreateSingleAtomicUnitWhenAnyFieldAnnotatedWithClassRule() throws Exception {
+    final Collection<TestUnit> actual = findWithTestee(ClassRuleMethod.class);
     assertEquals(1, actual.size());
   }
 

--- a/pitest/src/test/java/org/pitest/reflection/ReflectionTest.java
+++ b/pitest/src/test/java/org/pitest/reflection/ReflectionTest.java
@@ -16,6 +16,7 @@ package org.pitest.reflection;
 
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -24,13 +25,15 @@ import org.junit.Test;
 public class ReflectionTest {
 
   static class Parent {
+    public int first;
     public void foo() {
 
     }
   }
 
   static class Child extends Parent {
-
+    public int second;
+    public static int third;
   }
 
   @Test
@@ -40,4 +43,24 @@ public class ReflectionTest {
     assertTrue(actual.contains(expected));
   }
 
+  @Test
+  public void publicFieldsReturnsFieldsDeclaredInParent() throws Exception {
+    final Set<Field> actual = Reflection.publicFields(Child.class);
+    final Field expected = Parent.class.getField("first");
+    assertTrue(actual.contains(expected));
+  }
+
+  @Test
+  public void publicFieldsReturnsFieldsDeclaredInChild() throws Exception {
+    final Set<Field> actual = Reflection.publicFields(Child.class);
+    final Field expected = Child.class.getField("second");
+    assertTrue(actual.contains(expected));
+  }
+
+  @Test
+  public void publicFieldsReturnsStaticFields() throws Exception {
+    final Set<Field> actual = Reflection.publicFields(Child.class);
+    final Field expected = Child.class.getField("third");
+    assertTrue(actual.contains(expected));
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <asm.version>5.0.3</asm.version>
         <ant.version>1.8.3</ant.version>
         <hamcrest.version>1.3.RC2</hamcrest.version>
-        <junit.version>4.10</junit.version>
+        <junit.version>4.11</junit.version>
         <powermock.version>1.5.3-SNAPSHOT</powermock.version>
         <surefire.version>2.16</surefire.version>
         <testng.version>6.1.1</testng.version>


### PR DESCRIPTION
Fix for #111.
I upgraded to JUnit 4.11 in the process. It adds support for ClassRule on methods which pitest should now also handle correctly.
