### PR TITLE
Replace method with parameter of matching type (fix for issue #139)

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -41,7 +41,7 @@ import org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator.Choice;
-import org.pitest.mutationtest.engine.gregor.mutators.ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveIncrementsMutator;
@@ -139,8 +139,8 @@ public final class Mutator {
     add("EXPERIMENTAL_SWITCH",
         new org.pitest.mutationtest.engine.gregor.mutators.experimental.SwitchMutator());
 
-    add("REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR",
-        ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator.REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR);
+    add("ARGUMENT_PROPAGATION",
+        ArgumentPropagationMutator.ARGUMENT_PROPAGATION_MUTATOR);
 
     addGroup("REMOVE_SWITCH", RemoveSwitchMutator.makeMutators());
     addGroup("DEFAULTS", defaults());

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutator.java
@@ -45,14 +45,14 @@ import org.pitest.mutationtest.engine.gregor.MutationContext;
  *   }
  * </pre>
  */
-public enum ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator
+public enum ArgumentPropagationMutator
     implements MethodMutatorFactory {
 
-  REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR;
+  ARGUMENT_PROPAGATION_MUTATOR;
 
   public MethodVisitor create(final MutationContext context,
       final MethodInfo methodInfo, final MethodVisitor methodVisitor) {
-    return new ReplaceMethodWithParameterOfSameTypeAsReturnValueVisitor(
+    return new ArgumentPropagationVisitor(
         context, methodVisitor, this);
   }
 

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationVisitor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationVisitor.java
@@ -25,15 +25,14 @@ import static java.util.Arrays.asList;
 import static org.objectweb.asm.Opcodes.POP;
 import static org.objectweb.asm.Opcodes.POP2;
 
-class ReplaceMethodWithParameterOfSameTypeAsReturnValueVisitor
+class ArgumentPropagationVisitor
     extends MethodVisitor {
 
   private final MethodMutatorFactory factory;
   private final MutationContext      context;
 
-  public ReplaceMethodWithParameterOfSameTypeAsReturnValueVisitor(
-      final MutationContext context, final MethodVisitor writer,
-      final MethodMutatorFactory factory) {
+  public ArgumentPropagationVisitor(final MutationContext context,
+      final MethodVisitor writer, final MethodMutatorFactory factory) {
     super(Opcodes.ASM5, writer);
     this.factory = factory;
     this.context = context;

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/config/MutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/config/MutatorTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
 import org.pitest.mutationtest.engine.gregor.mutators.InvertNegsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.MathMutator;
-import org.pitest.mutationtest.engine.gregor.mutators.ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator;
 
 public class MutatorTest {
 
@@ -53,6 +53,6 @@ public class MutatorTest {
   @Test
   public void allContainsReplaceMethodMutator() throws Exception {
     assertThat(Mutator.all()).contains(
-        ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator.REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR);
+        ArgumentPropagationMutator.ARGUMENT_PROPAGATION_MUTATOR);
   }
 }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutatorTest.java
@@ -24,15 +24,15 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import static java.util.Arrays.asList;
-import static org.pitest.mutationtest.engine.gregor.mutators.ReplaceMethodWithParameterOfSameTypeAsReturnValueMutator.REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR;
+import static org.pitest.mutationtest.engine.gregor.mutators.ArgumentPropagationMutator.ARGUMENT_PROPAGATION_MUTATOR;
 
-public class ReplaceMethodWithParameterOfSameTypeAsReturnValueMutatorTest
+public class ArgumentPropagationMutatorTest
     extends MutatorTestBase {
 
   @Before
   public void setupEngineToUseReplaceMethodWithParameterOfSameTypeAsReturnValueMutator() {
     createTesteeWith(mutateOnlyCallMethod(),
-        REPLACE_METHOD_WITH_PARAMETER_OF_SAME_TYPE_AS_RETURN_VALUE_MUTATOR);
+        ARGUMENT_PROPAGATION_MUTATOR);
   }
 
   @Test


### PR DESCRIPTION
This adds a mutator that replaces non-void method calls with one of its
parameters of the same type as the return value in case such a parameter
exists (cf. issue #139).

Thanks to @smandel for showing me how to use ASM and working on a first
draft of this with me.
