### PR TITLE
Properly filter out files without extensions in paths containing a '.'

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/PathToJavaClassConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PathToJavaClassConverter.java
@@ -26,9 +26,10 @@ class PathToJavaClassConverter implements F<String, Iterable<String>> {
   public Iterable<String> apply(final String a) {
     final File f = new File(a);
     final String modifiedFilePath = f.getAbsolutePath();
+    final String fileName = f.getName();
 
     if (modifiedFilePath.startsWith(this.sourceRoot)
-        && (modifiedFilePath.indexOf('.') != -1)) {
+        && (fileName.indexOf('.') != -1)) {
       return createClassGlobFromFilePath(this.sourceRoot, modifiedFilePath);
     }
     return Collections.emptyList();

--- a/pitest-maven/src/test/java/org/pitest/maven/PathToJavaClassConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PathToJavaClassConverterTest.java
@@ -42,6 +42,11 @@ public class PathToJavaClassConverterTest {
   }
 
   @Test
+  public void shouldConvertFilesWithDotInPath() {
+    assertTrue(this.testee.apply(SRC + "/foo.bar/File.java").iterator().hasNext());
+  }
+
+  @Test
   public void shouldIncludeWildCardInGeneratedGlobToCatchInnerClasses() {
     assertTrue(apply("foo.java").endsWith("*"));
   }


### PR DESCRIPTION
In my environment my working directory is something like `/home/ankon/project-4.4/...`, and the pitest PathToJavaClassConverterTest failed because it treated the dot in the path as an indication for an extension.

Fix this by looking only at the file name itself.

I think there might be another issue here though: the translation from the file name to the regular expression should use `java.util.regex.Pattern#quote()` on each of the segments of the path, otherwise in my case both `project-4.4` and `project-4x4` etc would match.