### PR TITLE
Added a configuration element to allow classpath elements to be excluded

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -55,6 +55,14 @@ public class MojoToReportOptionsConverter {
     addOwnDependenciesToClassPath(classPath);
 
     classPath.addAll(this.mojo.getAdditionalClasspathElements());
+    
+    for(Object artifact : this.mojo.getProject().getArtifacts()) {
+    	final Artifact dependency = (Artifact) artifact;
+    	
+    	if(this.mojo.getClasspathDependencyExcludes().contains(dependency.getGroupId() + ":" + dependency.getArtifactId())) {
+    		classPath.remove(dependency.getFile().getPath());
+    	}
+    }
 
     return parseReportOptions(classPath);
 

--- a/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
@@ -257,6 +257,15 @@ public class PitMojo extends AbstractMojo {
   private ArrayList<String> additionalClasspathElements;
   
   /**
+   * List of classpath entries, formatted as "groupId:artifactId", which should not be included
+   * in the classpath when running mutation tests. Modelled after the corresponding
+   * Surefire/Failsafe property.
+   * 
+   * @parameter expression="${classpathDependencyExcludes}"
+   */
+  private ArrayList<String> classpathDependencyExcludes;
+  
+  /**
    * When set indicates that analysis of this project should be skipped
    * 
    * @parameter default-value="false"
@@ -492,6 +501,10 @@ public class PitMojo extends AbstractMojo {
 
   public List<String> getAdditionalClasspathElements() {
     return additionalClasspathElements;
+  }
+  
+  public List<String> getClasspathDependencyExcludes() {
+	  return classpathDependencyExcludes;
   }
 
 }

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -19,8 +19,10 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Model;
 import org.mockito.Mockito;
 import org.pitest.functional.predicate.Predicate;
@@ -282,6 +284,24 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
   public void testParsesJavaExecutable() {
     final ReportOptions actual = parseConfig("<jvm>foo</jvm>");
     assertEquals("foo", actual.getJavaExecutable());
+  }
+  
+  public void testParsesExcludedClasspathElements() throws DependencyResolutionRequiredException {
+	  final String sep = File.pathSeparator;
+	  
+	  final Set<Artifact> artifacts = new HashSet<Artifact>();
+	  final Artifact dependency = Mockito.mock(Artifact.class);
+	  when(dependency.getGroupId()).thenReturn("group");
+	  when(dependency.getArtifactId()).thenReturn("artifact");
+	  when(dependency.getFile()).thenReturn(new File("group" + sep + "artifact" + sep + "1.0.0" + sep + "group-artifact-1.0.0.jar"));
+	  artifacts.add(dependency);
+	  when(this.project.getArtifacts()).thenReturn(artifacts);
+	  when(this.project.getTestClasspathElements()).thenReturn(Arrays.asList("group" + sep + "artifact" + sep + "1.0.0" + sep + "group-artifact-1.0.0.jar"));
+	  
+	  final ReportOptions actual = parseConfig("<classpathDependencyExcludes>"
+	  		+ "										<param>group:artifact</param>"
+	  		+ "									</classpathDependencyExcludes>");
+	  assertFalse(actual.getClassPathElements().contains("group" + sep + "artifact" + sep + "1.0.0" + sep + "group-artifact-1.0.0.jar"));
   }
 
   private ReportOptions parseConfig(final String xml) {


### PR DESCRIPTION
Added a configuration element to allow classpath elements to be excluded from mutation testing, for the case when those elements might be troublesome. This mirrors the similar options in Surefire and Failsafe. Added a corresponding unit test to exercise the new config option.

I will be honest, I have not developed a Maven plugin before, so there may be a more efficient/idiomatic way to remove artifacts from the classpath being built up in the MojoToReportOptionsConverter -- so any suggestions or corrections there are welcome. :)