### PR TITLE
Got logs under slf4j

### DIFF
--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -120,6 +120,22 @@
 			<artifactId>maven-toolchain</artifactId>
 			<version>${maven.version}</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>jul-to-slf4j</artifactId>
+		    <version>1.7.5</version>
+		</dependency>
+		<dependency>
+		    <groupId>uk.org.lidalia</groupId>
+		    <artifactId>sysout-over-slf4j</artifactId>
+		    <version>1.0.2</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>1.7.5</version>
+		    <scope>provided</scope>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
@@ -4,6 +4,9 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
@@ -19,6 +22,9 @@ import org.pitest.mutationtest.statistics.MutationStatistics;
 import org.pitest.mutationtest.tooling.CombinedStatistics;
 import org.pitest.plugin.ClientClasspathPlugin;
 import org.pitest.plugin.ToolClasspathPlugin;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J;
 
 /**
  * Goal which runs a coverage mutation report
@@ -30,7 +36,15 @@ import org.pitest.plugin.ToolClasspathPlugin;
  * @phase integration-test
  */
 public class PitMojo extends AbstractMojo {
-  
+
+  static {
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
+    Logger.getLogger("PIT").addHandler(new SLF4JBridgeHandler());
+
+    SysOutOverSLF4J.sendSystemOutAndErrToSLF4J();
+  }
+
   protected final Predicate<Artifact> filter;
   
   protected final PluginServices plugins;


### PR DESCRIPTION
Hi,

Since maven 3.1.0, all logs are handled by slf4j.
http://maven.apache.org/maven-logging.html

But, pitest use both java.util.logging and System.out.

I just placed all logs under slf4j.