### PR TITLE
[#179] Fix problem with using launch classpath

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -63,7 +63,6 @@ import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
 
 import org.pitest.classpath.ClassPath;
-import org.pitest.functional.FArray;
 import org.pitest.functional.FCollection;
 import org.pitest.functional.predicate.Predicate;
 import org.pitest.mutationtest.config.ConfigOption;
@@ -397,10 +396,10 @@ public class OptionsParser {
 
     final List<String> elements = new ArrayList<String>();
     if (data.isIncludeLaunchClasspath()) {
-      elements.addAll(Arrays.asList(ClassPath.getClassPathElements()));
+      elements.addAll(ClassPath.getClassPathElementsAsPaths());
     } else {
-      elements.addAll(FArray.filter(ClassPath.getClassPathElements(),
-          dependencyFilter));
+      elements.addAll(FCollection.filter(ClassPath.getClassPathElementsAsPaths(),
+              dependencyFilter));
     }
     elements.addAll(userArgs.valuesOf(this.additionalClassPathSpec));
     data.setClassPathElements(elements);
@@ -413,7 +412,6 @@ public class OptionsParser {
         this.includedGroupsSpec.values(userArgs));
 
     data.setGroupConfig(conf);
-
   }
 
   /**

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/PluginFilterTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/PluginFilterTest.java
@@ -9,23 +9,28 @@ import org.pitest.mutationtest.engine.gregor.GregorMutationEngine;
 import org.pitest.mutationtest.report.html.HtmlReportFactory;
 import org.pitest.util.IsolationUtils;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
 public class PluginFilterTest {
 
   private PluginFilter testee = new PluginFilter(new PluginServices(
                                   IsolationUtils.getContextClassLoader()));
 
   @Test
-  public void shouldExcludeHtmlReportPlugin() {
-    String pluginLocation = HtmlReportFactory.class.getProtectionDomain()
-        .getCodeSource().getLocation().getFile();
+  public void shouldExcludeHtmlReportPlugin() throws Exception {
+    String pluginLocation = getClassLocationAsCanonicalPath(HtmlReportFactory.class);
     assertFalse(testee.apply(pluginLocation));
   }
 
   @Test
-  public void shouldIncludeMutationEngine() {
-    String pluginLocation = GregorMutationEngine.class.getProtectionDomain()
-        .getCodeSource().getLocation().getFile();
+  public void shouldIncludeMutationEngine() throws Exception {
+    String pluginLocation = getClassLocationAsCanonicalPath(GregorMutationEngine.class);
     assertTrue(testee.apply(pluginLocation));
   }
 
+  private String getClassLocationAsCanonicalPath(Class clazz) throws URISyntaxException, IOException {
+    return new File(clazz.getProtectionDomain().getCodeSource().getLocation().toURI()).getCanonicalPath();
+  }
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -104,7 +104,7 @@ public enum ConfigOption {
    */
   PROJECT_FILE("configFile"),
   /**
-   * Classpath entries to ahalyse. Although classes on the laucnh classpath will also be
+   * Classpath entries to analyse. Although classes on the launch classpath will also be
    * analysed, this is the preferred place to specify the code to analyse
    */
   CLASSPATH("classPath"),

--- a/pitest/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -565,7 +565,8 @@ public class ReportOptions {
         + this.exportLineCoverage + ", mutationThreshold="
         + this.mutationThreshold + ", coverageThreshold="
         + this.coverageThreshold + ", mutationEngine=" + this.mutationEngine
-        + ", javaExecutable=" + this.javaExecutable + "]";
+        + ", javaExecutable=" + this.javaExecutable + ", includeLaunchClasspath="
+        + this.includeLaunchClasspath + "]";
   }
 
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/tooling/JarCreatingJarFinder.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/tooling/JarCreatingJarFinder.java
@@ -89,7 +89,7 @@ public class JarCreatingJarFinder implements JavaAgent {
       global.put(Attributes.Name.MANIFEST_VERSION, "1.0");
     }
     final File mylocation = new File(location);
-    global.putValue(BOOT_CLASSPATH, getBoothClassPath(mylocation));
+    global.putValue(BOOT_CLASSPATH, getBootClassPath(mylocation));
     global.putValue(PREMAIN_CLASS, AGENT_CLASS_NAME);
     global.putValue(CAN_REDEFINE_CLASSES, "true");
     global.putValue(CAN_SET_NATIVE_METHOD, "true");
@@ -101,7 +101,7 @@ public class JarCreatingJarFinder implements JavaAgent {
     jos.close();
   }
 
-  private String getBoothClassPath(final File mylocation) {
+  private String getBootClassPath(final File mylocation) {
     return mylocation.getAbsolutePath().replace('\\', '/');
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
@@ -248,7 +248,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
       this.data.setTargetTests(predicateFor("com.outofclasspath.*"));
       
       List<String> cp = new ArrayList<String>();
-      cp.addAll(Arrays.asList(ClassPath.getClassPathElements()));
+      cp.addAll(ClassPath.getClassPathElementsAsPaths());
       cp.add(location);
       
       this.data.setClassPathElements(cp);


### PR DESCRIPTION
Paths are compared as canonical paths to prevent comparison problem on Windows (and in some cases also on Linux). Fixes #179.

Unfortunately code became less readable, but collection mapping isn't compact in Java (especially <8 and especialy with checked exceptions). I had problem with testing it automatically and end up creating quite hacky integration test which doesn't match other unit tests in `OptionsParserTest` (should be moved to a separate file?). Maybe you have a better idea how to test it in a reliable way.

It is possible that similar problem with paths appears also in some fragments of code.