### PR TITLE
PitMojo.java - make execute() non-final

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
@@ -332,7 +332,7 @@ public class PitMojo extends AbstractMojo {
     this.plugins = plugins;
   }
 
-  public final void execute() throws MojoExecutionException,
+  public void execute() throws MojoExecutionException,
   MojoFailureException {
 
     switchLogging();


### PR DESCRIPTION
I want to implement a new MutationResultListener, but it needs additional configuration which the api doesn't provide for. So my intention is to extend PitMojo, add my extra params, store them statically, and use them in my MutationResultListener.