### PR TITLE
Minor Fixes for PIT Report Mojo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ jdk:
   - openjdk6
   - oraclejdk7
   - oraclejdk8 
-script: travis_wait mvn clean verify
+script: mvn clean verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ jdk:
   - openjdk6
   - oraclejdk7
   - oraclejdk8 
-script: mvn clean verify
+script: travis_wait mvn clean verify

--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -276,6 +276,20 @@ public class PitMojoIT {
   }
   
   /*
+   * Verifies that the build fails when running the report goal without first running the mutationCoverage goal
+   */
+  @Test
+  public void shouldFailIfNoReportAvailable() throws Exception {
+	  prepare("/pit-site-reportonly");
+	  
+	  try{
+		  this.verifier.executeGoals(Arrays.asList("clean", "test", "site"));
+	  }catch(VerificationException e){
+		  assertThat(e.getMessage()).containsSequence("[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:", ":site (default-site) on project pit-site-reportonly: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:", ":site failed: could not find reports directory", "pit-site-reportonly/target/pit-reports");
+	  }
+  }
+  
+  /*
    * verifies that overriding defaults has the expected results
    */
   @Test

--- a/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.example</groupId>
+	<artifactId>pit-site-reportonly</artifactId>
+	<packaging>jar</packaging>
+	<version>1.0-SNAPSHOT</version>
+	<name>pit-site-non-timestamped</name>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pit.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+	</reporting>
+
+</project>

--- a/pitest-maven-verification/src/test/resources/pit-site-reportonly/src/main/java/com/example/Covered.java
+++ b/pitest-maven-verification/src/test/resources/pit-site-reportonly/src/main/java/com/example/Covered.java
@@ -1,0 +1,13 @@
+package com.example;
+
+public class Covered {
+
+  public static int someCode(int i) {
+    if ( i == 0 ) {
+      return 1;
+    }
+    
+    return 1;
+  }
+  
+}

--- a/pitest-maven-verification/src/test/resources/pit-site-reportonly/src/test/java/com/example/AnotherTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-site-reportonly/src/test/java/com/example/AnotherTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnotherTest {
+  
+  @Test
+  public void aTest() {
+    assertEquals(1, Covered.someCode(0));
+  }
+
+  @Test
+  public void anotherTest() {
+    assertEquals(1, Covered.someCode(1));
+  }
+
+}

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
@@ -76,7 +76,7 @@ public class PitReportMojo extends AbstractMavenReport {
      * outputFormats parameter of the mutationCoverage goal.
      * 
      * @parameter default-value="HTML"
-     *            expression="${sourceDataFormats}"
+     *            expression="${pit.report.sourceDataFormats}"
      */
     private List<String> sourceDataFormats;
     


### PR DESCRIPTION
While writing updates to the pit documentation, I noticed one of the user properties was wrong.  I updated the ``sourceDataFormats`` user property from ``${sourceDataFormats}`` to ``${pit.report.sourceDataFormats}``.  The original value was left over from before I settled on a naming strategy for the user properties.  The new value matches the convention for the reporting mojo's user properties to all start with "pit.report."

I added an integration test that verifies the build fails if the reporting mojo is executed without also executing the ``mutationCoverage`` goal.

I also noticed a build had failed because the integration tests ran too long without writing any output.  I added the travis_wait function to the .travis.yml file.  This addition causes a line to be outputted every  minute or so for 20 minutes thus increasing the build timeout from 10 minutes to 20 minutes.