### PR TITLE
Small changes for HTML report generator

### DIFF
--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -52,6 +52,8 @@ public class MutationHtmlReportListener implements MutationResultListener {
   private final CoverageDatabase          coverage;
   private final Set<String> mutatorNames = new HashSet<String>();
 
+  private String css;
+
   public MutationHtmlReportListener(final CoverageDatabase coverage,
       final ResultOutputStrategy outputStrategy, Collection<String> mutatorNames,
       final SourceLocator... locators) {
@@ -61,13 +63,20 @@ public class MutationHtmlReportListener implements MutationResultListener {
     this.mutatorNames.addAll(mutatorNames);
   }
 
+  private synchronized String readCss() throws IOException {
+    if (css == null) {
+      css = FileUtil.readToString(IsolationUtils
+              .getContextClassLoader().getResourceAsStream(
+                      "templates/mutation/style.css"));
+    }
+    return css;
+  }
+
   private void generateAnnotatedSourceFile(
       final MutationTestSummaryData mutationMetaData) {
     try {
 
-      final String css = FileUtil.readToString(IsolationUtils
-          .getContextClassLoader().getResourceAsStream(
-              "templates/mutation/style.css"));
+      final String css = readCss();
 
       final String fileName = mutationMetaData.getPackageName()
           + File.separator + mutationMetaData.getFileName() + ".html";

--- a/pitest/src/main/resources/templates/mutation/style.css
+++ b/pitest/src/main/resources/templates/mutation/style.css
@@ -18,10 +18,12 @@ body{
 }
 
 .src { 
-border: 1px solid #dddddd;
-padding-top: 10px;
-padding-right: 5px;
-padding-left: 5px;
+	border: 1px solid #dddddd;
+	padding-top: 10px;
+	padding-right: 5px;
+	padding-left: 5px;
+	font-family: Consolas, Courier, monospace;
+	font-size: 12px;
 }
 
 


### PR DESCRIPTION
- set monospaced font-family for sources' listings
- cache CSS when writing html report

@hcoles, do mind reviewing it? I believe monospaced text is better for displaying sources