### PR TITLE
Small changes for HTML report generator

### DIFF
--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -46,28 +46,38 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
   private final ResultOutputStrategy      outputStrategy;
 
-  private final Collection<SourceLocator> sourceRoots        = new HashSet<SourceLocator>();
+  private final Collection<SourceLocator> sourceRoots;
 
   private final PackageSummaryMap         packageSummaryData = new PackageSummaryMap();
   private final CoverageDatabase          coverage;
-  private final Set<String> mutatorNames = new HashSet<String>();
+  private final Set<String>               mutatorNames;
+
+  private final String css;
 
   public MutationHtmlReportListener(final CoverageDatabase coverage,
       final ResultOutputStrategy outputStrategy, Collection<String> mutatorNames,
       final SourceLocator... locators) {
     this.coverage = coverage;
     this.outputStrategy = outputStrategy;
-    this.sourceRoots.addAll(Arrays.asList(locators));
-    this.mutatorNames.addAll(mutatorNames);
+    this.sourceRoots = new HashSet<SourceLocator>(Arrays.asList(locators));
+    this.mutatorNames = new HashSet<String>(mutatorNames);
+    this.css = loadCss();
+  }
+
+  private String loadCss() {
+    try {
+      return FileUtil.readToString(IsolationUtils
+              .getContextClassLoader().getResourceAsStream(
+                      "templates/mutation/style.css"));
+    } catch (IOException e) {
+      Log.getLogger().log(Level.SEVERE, "Error while loading css", e);
+    }
+    return "";
   }
 
   private void generateAnnotatedSourceFile(
       final MutationTestSummaryData mutationMetaData) {
     try {
-
-      final String css = FileUtil.readToString(IsolationUtils
-          .getContextClassLoader().getResourceAsStream(
-              "templates/mutation/style.css"));
 
       final String fileName = mutationMetaData.getPackageName()
           + File.separator + mutationMetaData.getFileName() + ".html";

--- a/pitest/src/main/resources/templates/mutation/style.css
+++ b/pitest/src/main/resources/templates/mutation/style.css
@@ -18,10 +18,11 @@ body{
 }
 
 .src { 
-border: 1px solid #dddddd;
-padding-top: 10px;
-padding-right: 5px;
-padding-left: 5px;
+	border: 1px solid #dddddd;
+	padding-top: 10px;
+	padding-right: 5px;
+	padding-left: 5px;
+	font-family: Consolas, Courier, monospace;
 }
 
 


### PR DESCRIPTION
- set monospaced font-family for sources' listings
- cache CSS when writing html report

@hcoles, do mind reviewing it? I believe monospaced text is better for displaying sources.
(the previous PR was send from my old account, I've deleted the account and closed the PR)