### PR TITLE
Argument propagation mutator: fix test setup for test case where no mutation is expected

### DIFF
--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/ArgumentPropagationMutatorTest.java
@@ -108,9 +108,13 @@ public class ArgumentPropagationMutatorTest extends MutatorTestBase {
     assertNoMutants(ReturnsDifferentType.class);
   }
 
-  class ReturnsDifferentType {
-    public String aMethodReturningADifferentTypeThanItsArgument(Object arg) {
-      return String.valueOf(arg);
+  class ReturnsDifferentType implements Callable<String> {
+    public String call() {
+      return addThreeAndConvertToString(3);
+    }
+
+    private String addThreeAndConvertToString(int argument) {
+      return String.valueOf(3 + argument);
     }
   }
 


### PR DESCRIPTION
Because the mutation engine is created with a filter for only mutating
methods with name "call" the old version of the test could never fail.

Changing the setup to mutate all methods, e.g.
```java
@Before
public void setupEngineToUseReplaceMethodWithArgumentOfSameTypeAsReturnValueMutator() {
  createTesteeWith(True. <MethodInfo> all(), ARGUMENT_PROPAGATION_MUTATOR);
}
```
might also solve the issue but I don't know whether this has other unwanted side effects.