### PR TITLE
Naked receiver mutator

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -38,6 +38,7 @@ import org.pitest.mutationtest.engine.gregor.mutators.IncrementsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.InlineConstantMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.InvertNegsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.MathMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.NakedReceiverMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator;
@@ -152,6 +153,11 @@ public final class Mutator {
      */
     add("EXPERIMENTAL_ARGUMENT_PROPAGATION",
         ArgumentPropagationMutator.ARGUMENT_PROPAGATION_MUTATOR);
+
+    /**
+     * Experimental mutator that replaces method call with this
+     */
+    add("NAKED_RECEIVER", NakedReceiverMutator.NAKED_RECEIVER);
 
     addGroup("REMOVE_SWITCH", RemoveSwitchMutator.makeMutators());
     addGroup("DEFAULTS", defaults());

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
@@ -27,16 +27,13 @@ import org.pitest.mutationtest.engine.gregor.MutationContext;
  * Mutator for non-void methods whos return type matches
  * the receiver's type that replaces the method call with the receiver.
  * E. g. the method call
- * <p/>
  * <pre>
  *   public int originalMethod() {
  *     String someString = "pit";
  *     return someString.toUpperCase();
  *   }
  * </pre>
- * <p/>
  * is mutated to
- * <p/>
  * <pre>
  *   public int mutatedMethod() {
  *     String someString = "pit";

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 Urs Metz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.pitest.mutationtest.engine.gregor.mutators;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
+import org.pitest.mutationtest.engine.gregor.MutationContext;
+
+/**
+ * Mutator for non-void methods whos return type matches
+ * the receiver's type that replaces the method call with the receiver.
+ * E. g. the method call
+ * <p/>
+ * <pre>
+ *   public int originalMethod() {
+ *     String someString = "pit";
+ *     return someString.toUpperCase();
+ *   }
+ * </pre>
+ * <p/>
+ * is mutated to
+ * <p/>
+ * <pre>
+ *   public int mutatedMethod() {
+ *     String someString = "pit";
+ *     return someString;
+ *   }
+ * </pre>
+ */
+public enum NakedReceiverMutator implements MethodMutatorFactory {
+
+  NAKED_RECEIVER;
+
+  public MethodVisitor create(final MutationContext context,
+      final MethodInfo methodInfo, final MethodVisitor methodVisitor) {
+    return new ReplaceMethodCallWithObjectVisitor(context, methodVisitor, this);
+  }
+
+  public String getGloballyUniqueId() {
+    return this.getClass().getName();
+  }
+
+  public String getName() {
+    return name();
+  }
+
+  static class ReplaceMethodCallWithObjectVisitor extends MethodVisitor {
+
+    private final MethodMutatorFactory factory;
+    private final MutationContext      context;
+
+    public ReplaceMethodCallWithObjectVisitor(final MutationContext context,
+        final MethodVisitor writer, final MethodMutatorFactory factory) {
+      super(Opcodes.ASM5, writer);
+      this.factory = factory;
+      this.context = context;
+    }
+
+    @Override
+    public void visitMethodInsn(final int opcode, final String owner,
+        final String name, final String desc, final boolean itf) {
+      if (hasReturnTypeMatchingReceiverType(desc, owner)) {
+        final MutationIdentifier newId = this.context
+            .registerMutation(this.factory,
+                "replaced call to " + owner + "::" + name + " with receiver");
+      } else {
+        this.mv.visitMethodInsn(opcode, owner, name, desc, itf);
+      }
+    }
+
+    private boolean hasReturnTypeMatchingReceiverType(final String desc,
+        String owner) {
+      return Type.getObjectType(owner).equals(Type.getReturnType(desc));
+    }
+
+  }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutator.java
@@ -77,6 +77,11 @@ public enum NakedReceiverMutator implements MethodMutatorFactory {
         final MutationIdentifier newId = this.context
             .registerMutation(this.factory,
                 "replaced call to " + owner + "::" + name + " with receiver");
+        if (context.shouldMutate(newId)) {
+          // remove call to method by swallowing the visitMethodInsn call
+          return;
+        }
+        this.mv.visitMethodInsn(opcode, owner, name, desc, itf);
       } else {
         this.mv.visitMethodInsn(opcode, owner, name, desc, itf);
       }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutatorTest.java
@@ -47,7 +47,7 @@ public class NakedReceiverMutatorTest extends MutatorTestBase {
   }
 
   @Test
-  public void shouldNotReplaceVoidMethodCall()
+  public void shouldNotMutateVoidMethodCall()
       throws Exception {
     assertNoMutants(HasVoidMethodCall.class);
   }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/NakedReceiverMutatorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Urs Metz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.pitest.mutationtest.engine.gregor.mutators;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pitest.functional.predicate.True;
+import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
+
+import java.util.concurrent.Callable;
+
+import static org.pitest.mutationtest.engine.gregor.mutators.NakedReceiverMutator.NAKED_RECEIVER;
+
+public class NakedReceiverMutatorTest extends MutatorTestBase {
+
+  @Before
+  public void setupEngineToUseReplaceMethodWithArgumentOfSameTypeAsReturnValueMutator() {
+    createTesteeWith(True.<MethodInfo> all(), NAKED_RECEIVER);
+  }
+
+  @Test
+  public void shouldReplaceMethodCallOnString() throws Exception {
+    final Mutant mutant = getFirstMutant(HasStringMethodCall.class);
+    assertMutantCallableReturns(new HasStringMethodCall("EXAMPLE"), mutant,
+        "EXAMPLE");
+  }
+
+  @Test
+  public void shouldNotReplaceMethodCallWhenDifferentReturnType()
+      throws Exception {
+    assertNoMutants(HasMethodWithDifferentReturnType.class);
+  }
+
+  @Test
+  public void shouldNotReplaceVoidMethodCall()
+      throws Exception {
+    assertNoMutants(HasVoidMethodCall.class);
+  }
+
+  private static class HasStringMethodCall implements Callable<String> {
+    private String arg;
+
+    public HasStringMethodCall(String arg) {
+      this.arg = arg;
+    }
+
+    public String call() throws Exception {
+      return arg.toLowerCase();
+    }
+  }
+
+  private static class HasMethodWithDifferentReturnType {
+    public int call() throws Exception {
+      return "".length();
+    }
+  }
+
+  private static class HasVoidMethodCall {
+    public void call() throws Exception {
+    }
+  }
+
+}


### PR DESCRIPTION
Mutator that replaces a method call with the object on which the method
is called in case the return type of the method matches the type of the
object.

It is named after @mbj mutation operator in [mutant](https://github.com/mbj/mutant) performing the same mutation.
