### PR TITLE
performance improvements when annotating coverage

### DIFF
--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -23,14 +23,14 @@ import org.pitest.functional.predicate.Predicate;
 
 public class Glob implements Predicate<String> {
 
-  private final String regex;
+  private final Pattern regex;
 
   public Glob(final String glob) {
-    this.regex = convertGlobToRegex(glob);
+    this.regex = Pattern.compile(convertGlobToRegex(glob));
   }
 
   public boolean matches(final CharSequence seq) {
-    return Pattern.matches(this.regex, seq);
+    return this.regex.matcher(seq).matches();
   }
 
   public static F<String, Predicate<String>> toGlobPredicate() {
@@ -80,7 +80,7 @@ public class Glob implements Predicate<String> {
 
   @Override
   public String toString() {
-    return this.regex;
+    return this.regex.pattern();
   }
 
 }


### PR DESCRIPTION
I encountered a performance issue when testing PIT at our projects, which did not occur on some small sample projects I tested. After mutation testing was finished, PIT/PITclipse still needed hours to present the results. With profiling, I could trace it back to methods called during the creation of annotated source files (MutationHtmlReportListener.createAnnotatedSourceCodeLines()). Determining the classes contained in a file was very inefficient for large classpaths because some lists were iterated repeatedly. I therefore replaced this structure with a map for the lookups (and made regex matching a little more efficient). This brought runtime down to seconds on my machine.

I would have preferred filling the map in the constructor of CoverageData, but I had to make it lazy because otherwise the mocking that is used in the unit tests for CoverageData did not work anymore.