### PR TITLE
fixing execution not covered by lifecycle errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 .idea
 *.iml
 dependency-reduced-pom.xml
+.checkstyle
+

--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -58,6 +58,36 @@
 				</executions>
 			</plugin>
 		</plugins>
+        
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-plugin-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>descriptor</goal>
+                                            <goal>helpmojo</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 	</build>
 
 	<dependencies>


### PR DESCRIPTION
When pulling the pit project into STS, I have several errors for the checkstyle, compiler, and maven plugin plugins where their execution is not covered by a lifecycle.  I fixed the checkstyle related errors using Quick Fix to install the correct m2e connector which then created a .checkstyle file (hence the change to .gitignore).  I could not find a connector for the maven-plugin-plugin, so I ignored its goals.  I have not tackled the errors with the maven-compiler-plugin yet.  I may do so later if I have time.