### PR TITLE
using regex in globs

### DIFF
--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -82,8 +82,7 @@ public class OptionsParserTest {
   public void shouldParseCommaSeparatedListOfSourceDirectories() {
     final ReportOptions actual = parseAddingRequiredArgs("--sourceDirs",
         "foo/bar,bar/far");
-    assertEquals(Arrays.asList(new File("foo/bar"), new File("bar/far")),
-        actual.getSourceDirs());
+    assertEquals(Arrays.asList(new File("foo/bar"), new File("bar/far")), actual.getSourceDirs());
   }
 
   @Test
@@ -197,6 +196,20 @@ public class OptionsParserTest {
     assertTrue(actualPredicate.apply("foo_anything"));
     assertTrue(actualPredicate.apply("bar_anything"));
     assertFalse(actualPredicate.apply("notfoobar"));
+  }
+
+  @Test
+  public void shouldParseCommaSeparatedListOfTargetTestClassGlobAsRegex() {
+    ReportOptions actual = parseAddingRequiredArgs("--targetTest",
+            "~foo\\w*,~bar.*");
+    Predicate<String> actualPredicate = actual.getTargetTestsFilter();
+    assertTrue(actualPredicate.apply("foo_anything"));
+    assertTrue(actualPredicate.apply("bar_anything"));
+    assertFalse(actualPredicate.apply("notfoobar"));
+    actual = parseAddingRequiredArgs("--targetTest",
+            "~.*?foo\\w*,~bar.*");
+    actualPredicate = actual.getTargetTestsFilter();
+    assertTrue(actualPredicate.apply("notfoobar"));
   }
 
   @Test

--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -26,7 +26,7 @@ public class Glob implements Predicate<String> {
   private final Pattern regex;
 
   public Glob(final String glob) {
-    if(glob.charAt(0)=='~'){
+    if (glob.charAt(0) == '~') {
       this.regex = Pattern.compile(glob.substring(1));
     } else {
       this.regex = Pattern.compile(convertGlobToRegex(glob)

--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -26,7 +26,12 @@ public class Glob implements Predicate<String> {
   private final Pattern regex;
 
   public Glob(final String glob) {
-    this.regex = Pattern.compile(convertGlobToRegex(glob));
+    if(glob.charAt(0)=='~'){
+      this.regex = Pattern.compile(glob.substring(1));
+    } else {
+      this.regex = Pattern.compile(convertGlobToRegex(glob)
+      );
+    }
   }
 
   public boolean matches(final CharSequence seq) {


### PR DESCRIPTION
Hey,
   We have some patterns that don't work well with the current implementation of globs. For example, we have Spock specs in packages like a.b.c.*Spec, a.b.c.integration.*Spec, a.b.c.integration.ui.*Spec, etc...  now the issue is that we want to run specs from the first 2 packages , but not from the last one and using a pattern like 'a.b.c.*Spec' or a.b.c.integration.*Spec (this is a subset of the first one with the current implementation) includes also the a.b.c.integration.ui.*Spec. 
  In this PR we added a simple convention that if the glob starts with ~ (this is the regex operator in Groovy) we handle it as a Pattern regex. 
 Let me know what you think