### PR TITLE
Quick fix for compatibility with yatspec runners

### DIFF
--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -343,6 +343,20 @@ public class PitMojoIT {
     assertThat(actual).doesNotContain("status='RUN_ERROR'");
   }
 
+  @Test
+  public void shouldWorkWithYatspec() throws Exception {
+    File testDir = prepare("/pit-263-yatspec");
+    verifier.executeGoal("test");
+    verifier.executeGoal("org.pitest:pitest-maven:mutationCoverage");
+
+    String actual = readResults(testDir);
+    assertThat(actual)
+            .contains(
+                    "<mutation detected='true' status='KILLED'><sourceFile>SomeClass.java</sourceFile>");
+    assertThat(actual).doesNotContain("status='NO_COVERAGE'");
+    assertThat(actual).doesNotContain("status='RUN_ERROR'");
+  }
+
   private static String readResults(File testDir) throws IOException {
     File mutationReport = new File(testDir.getAbsoluteFile() + File.separator
         + "target" + File.separator + "pit-reports" + File.separator

--- a/pitest-maven-verification/src/test/resources/pit-263-yatspec/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-263-yatspec/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+    <groupId>sample</groupId>
+    <artifactId>pit-yatspec</artifactId>
+    <version>DEV-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pit.version}</version>
+                <configuration>
+                    <exportLineCoverage>true</exportLineCoverage>
+                    <outputFormats>
+                        <value>XML</value>
+                    </outputFormats>
+                    <timestampedReports>false</timestampedReports>
+                    <targetClasses>
+                        <param>sample*</param>
+                    </targetClasses>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>repo.bodar.com</id>
+            <url>http://repo.bodar.com</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.yatspec</groupId>
+            <artifactId>yatspec</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pitest-maven-verification/src/test/resources/pit-263-yatspec/src/main/java/sample/SomeClass.java
+++ b/pitest-maven-verification/src/test/resources/pit-263-yatspec/src/main/java/sample/SomeClass.java
@@ -1,0 +1,12 @@
+package sample;
+
+public class SomeClass {
+
+    public int theAnswer(String question) {
+        if ("life the universe and everything".equals(question)) {
+            return 42;
+        } else {
+            return -1;
+        }
+    }
+}

--- a/pitest-maven-verification/src/test/resources/pit-263-yatspec/src/test/java/sample/SomeClassTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-263-yatspec/src/test/java/sample/SomeClassTest.java
@@ -1,0 +1,22 @@
+package sample;
+
+import com.googlecode.yatspec.junit.Row;
+import com.googlecode.yatspec.junit.Table;
+import com.googlecode.yatspec.junit.TableRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(TableRunner.class)
+public class SomeClassTest {
+
+    @Table({
+        @Row({"life the universe and everything", "42"}),
+        @Row({"everything else", "-1"})
+    })
+    @Test
+    public void testTheAnswer(String question, String answer) {
+        assertEquals(new SomeClass().theAnswer(question), Integer.parseInt(answer));
+    }
+}

--- a/pitest/src/main/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinder.java
+++ b/pitest/src/main/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinder.java
@@ -108,6 +108,7 @@ public class JUnitCustomRunnerTestUnitFinder implements TestUnitFinder {
     return runnerName.equals("junitparams.JUnitParamsRunner")
         || runnerName.startsWith("org.spockframework.runtime.Sputnik")
         || runnerName.startsWith("com.insightfullogic.lambdabehave")
+        || runnerName.startsWith("com.googlecode.yatspec")
         || runnerName.startsWith("com.google.gwtmockito.GwtMockitoTestRunner");
   }
 


### PR DESCRIPTION
This is a quick fix for #263 

As a long term solution, I think the list of runners in runnerCannotBeSplit should be part of the configuration