### PR TITLE
Modifying linecoverage reporter to include method desc

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
+++ b/pitest/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
@@ -48,7 +48,7 @@ public class DefaultCoverageExporter implements CoverageExporter {
         out,
         "<block classname='" + l.getClassName().asJavaName() + "'"
             + " method='"
-            + StringUtil.escapeBasicHtmlChars(l.getMethodName().name())
+            + StringUtil.escapeBasicHtmlChars(l.getMethodName().name()) + StringUtil.escapeBasicHtmlChars(l.getMethodDesc())
             + "' number='" + each.getBlock().getBlock() + "'>");
     write(out, "<tests>\n");
     final List<String> ts = new ArrayList<String>(each.getTests());

--- a/pitest/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
@@ -64,9 +64,9 @@ public class DefaultCoverageExporterTest {
 
     String actual = this.out.toString();
     assertThat(actual).contains(
-        "<block classname='Foo' method='method' number='42'>");
+        "<block classname='Foo' method='method()I' number='42'>");
     assertThat(actual).contains(
-        "<block classname='Bar' method='method' number='42'>");
+        "<block classname='Bar' method='method()I' number='42'>");
     assertThat(actual).contains(
         "<tests>\n<test name='Test1'/>\n<test name='Test2'/>\n</tests>");
     assertThat(actual).contains(


### PR DESCRIPTION
Currently, when reporting line coverage in XML format, methods are identified by name only. There will then be duplicate blocks in the report when there are overloaded methods. This pull request simply adds the method description along with the method name in the report so overloaded methods can be distinguished from one another in the report.