### PR TITLE
When a test doesn't pass, the log should be severe

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageData.java
@@ -228,7 +228,7 @@ public class CoverageData implements CoverageDatabase {
   private void checkForFailedTest(final CoverageResult cr) {
     if (!cr.isGreenTest()) {
       recordTestFailure();
-      LOG.warning(cr.getTestUnitDescription()
+      LOG.severe(cr.getTestUnitDescription()
           + " did not pass without mutation.");
     }
   }


### PR DESCRIPTION
It's an error, after all. The build halts and `exit 1`. I think this log should be `severe` instead of `warn`.