### PR TITLE
Implements #285

### DIFF
--- a/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityInsideSwitchTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityInsideSwitchTestee.java
@@ -1,0 +1,28 @@
+package com.example.java7;
+
+public class HasIfOnAStringEqualityInsideSwitchTestee {
+  public String ifStringInsideSwitch(final String input, final String input2) {
+    final String result;
+
+    switch (input) {
+    case "a":
+      if (input2.equals("a")) {
+        result = "A";
+      } else {
+        result = "AX";
+      }
+      break;
+    case "b":
+      result = "B";
+      break;
+    case "c":
+      result = "C";
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported input");
+    }
+
+    return result;
+  }
+
+}

--- a/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityInsideSwitchTesteeTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityInsideSwitchTesteeTest.java
@@ -1,0 +1,76 @@
+package com.example.java7;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HasIfOnAStringEqualityInsideSwitchTesteeTest {
+
+  private final HasIfOnAStringEqualityInsideSwitchTestee testee = new HasIfOnAStringEqualityInsideSwitchTestee();
+
+  @Test
+  public void stringSwitchShouldReturnA() throws Exception {
+    // given
+    final String input = "a";
+    final String input2 = "a";
+
+    // when
+    final String result = testee.ifStringInsideSwitch(input, input2);
+
+    // then
+    assertThat(result).isEqualTo("A");
+  }
+  
+  @Test
+  public void stringSwitchShouldReturnAX() throws Exception {
+    // given
+    final String input = "a";
+    final String input2 = "other";
+
+    // when
+    final String result = testee.ifStringInsideSwitch(input, input2);
+
+    // then
+    assertThat(result).isEqualTo("AX");
+  }
+
+  @Test
+  public void stringSwitchShouldReturnB() throws Exception {
+    // given
+    final String input = "b";
+    final String input2 = "x";
+
+    // when
+    final String result = testee.ifStringInsideSwitch(input, input2);
+
+    // then
+    assertThat(result).isEqualTo("B");
+  }
+
+  @Test
+  public void stringSwitchShouldReturnC() throws Exception {
+    // given
+    final String input = "c";
+    final String input2 = "x";
+
+    // when
+    final String result = testee.ifStringInsideSwitch(input, input2);
+
+    // then
+    assertThat(result).isEqualTo("C");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void stringSwitchShouldThrowIllegalArgumentException()
+      throws Exception {
+    // given
+    final String input = "x";
+    final String input2 = "x";
+
+    // when
+    testee.ifStringInsideSwitch(input, input2);
+
+    // then
+    // exception
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityTestee.java
@@ -1,0 +1,20 @@
+package com.example.java7;
+
+public class HasIfOnAStringEqualityTestee {
+  public String ifString(final String input) {
+    final String result;
+
+    if (input.equals("a")) {
+      result = "A";
+    } else if (input.equals("b")) {
+      result = "B";
+    } else if (input.equals("c")) {
+      result = "C";
+    } else {
+      throw new IllegalArgumentException("Unsupported input");
+    }
+
+    return result;
+  }
+
+}

--- a/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityTesteeTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasIfOnAStringEqualityTesteeTest.java
@@ -1,0 +1,58 @@
+package com.example.java7;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HasIfOnAStringEqualityTesteeTest {
+
+  private final HasIfOnAStringEqualityTestee testee = new HasIfOnAStringEqualityTestee();
+
+  @Test
+  public void ifStringShouldReturnA() throws Exception {
+    // given
+    final String input = "a";
+
+    // when
+    final String result = testee.ifString(input);
+
+    // then
+    assertThat(result).isEqualTo("A");
+  }
+
+  @Test
+  public void ifStringShouldReturnB() throws Exception {
+    // given
+    final String input = "b";
+
+    // when
+    final String result = testee.ifString(input);
+
+    // then
+    assertThat(result).isEqualTo("B");
+  }
+
+  @Test
+  public void ifStringShouldReturnC() throws Exception {
+    // given
+    final String input = "c";
+
+    // when
+    final String result = testee.ifString(input);
+
+    // then
+    assertThat(result).isEqualTo("C");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void ifStringShouldThrowIllegalArgumentException() throws Exception {
+    // given
+    final String input = "x";
+
+    // when
+    testee.ifString(input);
+
+    // then
+    // exception
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/java7/HasSwitchOnStringTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasSwitchOnStringTestee.java
@@ -1,0 +1,62 @@
+package com.example.java7;
+
+public class HasSwitchOnStringTestee {
+
+  public String switchIntegerAndThenSwitchString(final Integer input) {
+    final String partial;
+
+    switch (input) {
+    case 1:
+      partial = "A";
+      break;
+    case 2:
+      partial = "B";
+      break;
+    case 3:
+      partial = "C";
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported input");
+    }
+
+    final String result;
+
+    switch (partial) {
+    case "A":
+      result = "A1";
+      break;
+    case "B":
+      result = "B1";
+      break;
+    case "C":
+      result = "C1";
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported input");
+    }
+
+    return result;
+  }
+
+  public String switchString(final String input) {
+
+    final String result;
+
+    switch (input) {
+    case "a":
+      result = "A";
+      break;
+    case "b":
+      result = "B";
+      break;
+    case "c":
+      result = "C";
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported input");
+    }
+
+    return result;
+  }
+
+}

--- a/pitest-java8-verification/src/test/java/com/example/java7/HasSwitchOnStringTesteeTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/java7/HasSwitchOnStringTesteeTest.java
@@ -1,0 +1,110 @@
+package com.example.java7;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HasSwitchOnStringTesteeTest {
+
+  private final HasSwitchOnStringTestee testee = new HasSwitchOnStringTestee();
+
+  @Test
+  public void stringSwitchShouldReturnA() throws Exception {
+    // given
+    final String input = "a";
+
+    // when
+    final String result = testee.switchString(input);
+
+    // then
+    assertThat(result).isEqualTo("A");
+  }
+
+  @Test
+  public void stringSwitchShouldReturnB() throws Exception {
+    // given
+    final String input = "b";
+
+    // when
+    final String result = testee.switchString(input);
+
+    // then
+    assertThat(result).isEqualTo("B");
+  }
+
+  @Test
+  public void stringSwitchShouldReturnC() throws Exception {
+    // given
+    final String input = "c";
+
+    // when
+    final String result = testee.switchString(input);
+
+    // then
+    assertThat(result).isEqualTo("C");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void stringSwitchShouldThrowIllegalArgumentException()
+      throws Exception {
+    // given
+    final String input = "x";
+
+    // when
+    testee.switchString(input);
+
+    // then
+    // exception
+  }
+
+  @Test
+  public void switchIntegerAndThenSwitchStringShouldReturnA1()
+      throws Exception {
+    // given
+    final int input = 1;
+
+    // when
+    final String result = testee.switchIntegerAndThenSwitchString(input);
+
+    // then
+    assertThat(result).isEqualTo("A1");
+  }
+
+  @Test
+  public void switchIntegerAndThenSwitchStringShouldReturnB1()
+      throws Exception {
+    // given
+    final int input = 2;
+
+    // when
+    final String result = testee.switchIntegerAndThenSwitchString(input);
+
+    // then
+    assertThat(result).isEqualTo("B1");
+  }
+
+  @Test
+  public void switchIntegerAndThenSwitchStringShouldReturnC1()
+      throws Exception {
+    // given
+    final int input = 3;
+
+    // when
+    final String result = testee.switchIntegerAndThenSwitchString(input);
+
+    // then
+    assertThat(result).isEqualTo("C1");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void switchIntegerAndThenSwitchStringShouldThrowIllegalArgumentException()
+      throws Exception {
+    // given
+    final int input = 4;
+
+    // when
+    testee.switchIntegerAndThenSwitchString(input);
+
+    // then
+  }
+}

--- a/pitest-java8-verification/src/test/java/org/pitest/java7/verification/VerifyJava7IT.java
+++ b/pitest-java8-verification/src/test/java/org/pitest/java7/verification/VerifyJava7IT.java
@@ -1,0 +1,29 @@
+package org.pitest.java7.verification;
+
+import static org.pitest.mutationtest.DetectionStatus.KILLED;
+
+import org.junit.Test;
+import org.pitest.mutationtest.ReportTestBase;
+
+public class VerifyJava7IT extends ReportTestBase {
+
+  @Test
+  public void shouldMutateIfElseOnAStringEqualityWithREMOVE_CONDITIONALS() {
+    setMutators("REMOVE_CONDITIONALS");
+    this.data.setTargetClasses(
+        predicateFor("com.example.java7.HasIfOnAStringEqualityTestee*"));
+    this.data.setVerbose(true);
+    createAndRun();
+    verifyResults(KILLED, KILLED, KILLED, KILLED, KILLED, KILLED);
+  }
+
+  @Test
+  public void shouldNotMutateSwitchOnAStringWithREMOVE_CONDITIONALS() {
+    setMutators("REMOVE_CONDITIONALS");
+    this.data.setTargetClasses(
+        predicateFor("com.example.java7.HasSwitchOnStringTestee*"));
+    this.data.setVerbose(true);
+    createAndRun();
+    verifyResults();
+  }
+}

--- a/pitest-java8-verification/src/test/java/org/pitest/java7/verification/VerifyJava7IT.java
+++ b/pitest-java8-verification/src/test/java/org/pitest/java7/verification/VerifyJava7IT.java
@@ -18,6 +18,16 @@ public class VerifyJava7IT extends ReportTestBase {
   }
 
   @Test
+  public void shouldMutateIfElseOnAStringEqualityWithREMOVE_CONDITIONALSWhenInsideSwitchOnString() {
+    setMutators("REMOVE_CONDITIONALS");
+    this.data.setTargetClasses(predicateFor(
+        "com.example.java7.HasIfOnAStringEqualityInsideSwitchTestee*"));
+    this.data.setVerbose(true);
+    createAndRun();
+    verifyResults(KILLED, KILLED);
+  }
+
+  @Test
   public void shouldNotMutateSwitchOnAStringWithREMOVE_CONDITIONALS() {
     setMutators("REMOVE_CONDITIONALS");
     this.data.setTargetClasses(

--- a/pitest/src/main/java/org/pitest/coverage/analysis/Block.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/Block.java
@@ -58,4 +58,11 @@ public final class Block {
     return this.lines;
   }
 
+  public int getFirstInstruction() {
+    return firstInstruction;
+  }
+
+  public int getLastInstruction() {
+    return lastInstruction;
+  }
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilter.java
@@ -35,24 +35,24 @@ class RemoveConditionalMutationForSwitchOnStringFilter
         Prelude.not(isRemoveConditionalMutationForSwitchOnString()));
   }
 
+  private boolean isMutationOnSwitchInstruction(
+      final MutationDetails mutation) {
+    return mutationOnSwitchInstructionLookup
+        .isMutationOnSwitchInstruction(mutation, this.source);
+  }
+
+  private boolean isRemoveConditionalMutation(final MutationDetails mutation) {
+    return mutation.getId().getMutator().startsWith(
+        "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL");
+  }
+
   private F<MutationDetails, Boolean> isRemoveConditionalMutationForSwitchOnString() {
     return new F<MutationDetails, Boolean>() {
       @Override
       public Boolean apply(final MutationDetails mutation) {
-        if (mutation.getId().getMutator().startsWith(
-            "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL")) {
-
-          final boolean mutationOnSwitchInstruction = mutationOnSwitchInstructionLookup
-              .isMutationOnSwitchInstruction(mutation,
-                  RemoveConditionalMutationForSwitchOnStringFilter.this.source);
-          if (mutationOnSwitchInstruction) {
-            return true;
-          }
-
-        }
-        return false;
+        return isRemoveConditionalMutation(mutation)
+            && isMutationOnSwitchInstruction(mutation);
       }
-
     };
   }
 

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilter.java
@@ -1,0 +1,59 @@
+package org.pitest.mutationtest.filter;
+
+import java.util.Collection;
+
+import org.pitest.classpath.CodeSource;
+import org.pitest.functional.F;
+import org.pitest.functional.FCollection;
+import org.pitest.functional.prelude.Prelude;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.filter.support.MutationOnSwitchInstructionLookup;
+
+/**
+ * Filters out RemoveConditional EQUAL mutations that are created for switch
+ * with String.
+ */
+class RemoveConditionalMutationForSwitchOnStringFilter
+    implements MutationFilter {
+
+  private final MutationOnSwitchInstructionLookup mutationOnSwitchInstructionLookup;
+
+  private final CodeSource                        source;
+
+  RemoveConditionalMutationForSwitchOnStringFilter(
+      final MutationOnSwitchInstructionLookup mutationOnSwitchInstructionLookup,
+      final CodeSource source) {
+    this.mutationOnSwitchInstructionLookup = mutationOnSwitchInstructionLookup;
+    this.source = source;
+  }
+
+  @Override
+  public Collection<MutationDetails> filter(
+      final Collection<MutationDetails> mutations) {
+
+    return FCollection.filter(mutations,
+        Prelude.not(isRemoveConditionalMutationForSwitchOnString()));
+  }
+
+  private F<MutationDetails, Boolean> isRemoveConditionalMutationForSwitchOnString() {
+    return new F<MutationDetails, Boolean>() {
+      @Override
+      public Boolean apply(final MutationDetails mutation) {
+        if (mutation.getId().getMutator().startsWith(
+            "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL")) {
+
+          final boolean mutationOnSwitchInstruction = mutationOnSwitchInstructionLookup
+              .isMutationOnSwitchInstruction(mutation,
+                  RemoveConditionalMutationForSwitchOnStringFilter.this.source);
+          if (mutationOnSwitchInstruction) {
+            return true;
+          }
+
+        }
+        return false;
+      }
+
+    };
+  }
+
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilterFactory.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilterFactory.java
@@ -1,0 +1,23 @@
+package org.pitest.mutationtest.filter;
+
+import java.util.Properties;
+
+import org.pitest.classpath.CodeSource;
+import org.pitest.mutationtest.filter.support.MutationOnSwitchInstructionLookupImpl;
+
+public class RemoveConditionalMutationForSwitchOnStringFilterFactory
+    implements MutationFilterFactory {
+
+  @Override
+  public MutationFilter createFilter(final Properties props,
+      final CodeSource source, final int maxMutationsPerClass) {
+    final MutationOnSwitchInstructionLookupImpl mutationOnSwitchInstructionLookup = new MutationOnSwitchInstructionLookupImpl();
+    return new RemoveConditionalMutationForSwitchOnStringFilter(
+        mutationOnSwitchInstructionLookup, source);
+  }
+
+  @Override
+  public String description() {
+    return "Remove Conditional Mutation for Switch On String Filter";
+  }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/support/ControlFlowAnalyserWrapper.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/support/ControlFlowAnalyserWrapper.java
@@ -1,0 +1,11 @@
+package org.pitest.mutationtest.filter.support;
+
+import java.util.List;
+
+import org.objectweb.asm.tree.MethodNode;
+import org.pitest.coverage.analysis.Block;
+
+public interface ControlFlowAnalyserWrapper {
+
+  List<Block> analyze(MethodNode methodNode);
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/support/ControlFlowAnalyserWrapperImpl.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/support/ControlFlowAnalyserWrapperImpl.java
@@ -1,0 +1,16 @@
+package org.pitest.mutationtest.filter.support;
+
+import java.util.List;
+
+import org.objectweb.asm.tree.MethodNode;
+import org.pitest.coverage.analysis.Block;
+import org.pitest.coverage.analysis.ControlFlowAnalyser;
+
+public class ControlFlowAnalyserWrapperImpl
+    implements ControlFlowAnalyserWrapper {
+
+  @Override
+  public List<Block> analyze(final MethodNode methodNode) {
+    return ControlFlowAnalyser.analyze(methodNode);
+  }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookup.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookup.java
@@ -1,0 +1,10 @@
+package org.pitest.mutationtest.filter.support;
+
+import org.pitest.classpath.CodeSource;
+import org.pitest.mutationtest.engine.MutationDetails;
+
+public interface MutationOnSwitchInstructionLookup {
+
+  boolean isMutationOnSwitchInstruction(MutationDetails mutation,
+      CodeSource source);
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookupImpl.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookupImpl.java
@@ -1,0 +1,117 @@
+package org.pitest.mutationtest.filter.support;
+
+import java.util.List;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classpath.CodeSource;
+import org.pitest.coverage.ClassLine;
+import org.pitest.coverage.analysis.Block;
+import org.pitest.functional.F;
+import org.pitest.functional.Option;
+import org.pitest.mutationtest.engine.MethodName;
+import org.pitest.mutationtest.engine.MutationDetails;
+
+public class MutationOnSwitchInstructionLookupImpl
+    implements MutationOnSwitchInstructionLookup {
+
+  private static final Supplier<ClassNode>            SIMPLE_CLASS_NODE_SUPPLIER           = new Supplier<ClassNode>() {
+                                                                                             @Override
+                                                                                             public ClassNode get() {
+                                                                                               return new ClassNode();
+                                                                                             }
+                                                                                           };
+
+  private static final F<byte[], ClassReader>         SIMPLE_CLASS_READER_FUNCTION         = new F<byte[], ClassReader>() {
+                                                                                             @Override
+                                                                                             public ClassReader apply(
+                                                                                                 final byte[] bytes) {
+                                                                                               return new ClassReader(
+                                                                                                   bytes);
+                                                                                             }
+                                                                                           };
+
+  private static final ControlFlowAnalyserWrapperImpl SIMPLE_CONTROL_FLOW_ANALYSER_WRAPPER = new ControlFlowAnalyserWrapperImpl();
+
+  private final Supplier<ClassNode>                   classNodeSupplier;
+
+  private final F<byte[], ClassReader>                classReaderFunction;
+
+  private final ControlFlowAnalyserWrapper            controlFlowAnalyserWrapper;
+
+  public MutationOnSwitchInstructionLookupImpl() {
+    this(SIMPLE_CLASS_NODE_SUPPLIER, SIMPLE_CLASS_READER_FUNCTION,
+        SIMPLE_CONTROL_FLOW_ANALYSER_WRAPPER);
+  }
+
+  public MutationOnSwitchInstructionLookupImpl(
+      final Supplier<ClassNode> classNodeSupplier,
+      final F<byte[], ClassReader> classReaderFunction,
+      final ControlFlowAnalyserWrapper controlFlowAnalyserWrapper) {
+    this.classNodeSupplier = classNodeSupplier;
+    this.classReaderFunction = classReaderFunction;
+    this.controlFlowAnalyserWrapper = controlFlowAnalyserWrapper;
+  }
+
+  private boolean isBlockForMutatedLine(final Block block,
+      final int lineNumber) {
+    return block.getLines().contains(lineNumber);
+  }
+
+  @Override
+  public boolean isMutationOnSwitchInstruction(final MutationDetails mutation,
+      final CodeSource source) {
+    final ClassName className = mutation.getClassName();
+
+    final Option<byte[]> maybeBytes = source.fetchClassBytes(className);
+
+    if (maybeBytes.hasSome()) {
+      final byte[] bytes = maybeBytes.value();
+      final ClassReader cr = classReaderFunction.apply(bytes);
+      final ClassNode classNode = classNodeSupplier.get();
+
+      cr.accept(classNode, ClassReader.EXPAND_FRAMES);
+
+      for (final Object m : classNode.methods) {
+        final MethodNode methodNode = (MethodNode) m;
+        final MethodName methodName = MethodName.fromString(methodNode.name);
+        if (methodName.equals(mutation.getMethod())) {
+
+          final List<Block> blocks = controlFlowAnalyserWrapper
+              .analyze(methodNode);
+          for (final Block block : blocks) {
+            final ClassLine classLine = mutation.getClassLine();
+            final int lineNumber = classLine.getLineNumber();
+            if (isBlockForMutatedLine(block, lineNumber)) {
+              final int firstInstruction = block.getFirstInstruction();
+              final int lastInstruction = block.getLastInstruction();
+
+              for (int i = firstInstruction; i <= lastInstruction; i++) {
+                final AbstractInsnNode abstractInsnNode = methodNode.instructions
+                    .get(i);
+                final boolean isSwitchInstruction = isSwitchInstruction(
+                    abstractInsnNode);
+                if (isSwitchInstruction) {
+                  return true;
+                }
+              }
+
+            }
+          }
+        }
+
+      }
+    }
+    return false;
+  }
+
+  private boolean isSwitchInstruction(final AbstractInsnNode abstractInsnNode) {
+    return abstractInsnNode instanceof TableSwitchInsnNode
+        || abstractInsnNode instanceof LookupSwitchInsnNode;
+  }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/filter/support/Supplier.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/filter/support/Supplier.java
@@ -1,0 +1,6 @@
+package org.pitest.mutationtest.filter.support;
+
+public interface Supplier<T> {
+
+  T get();
+}

--- a/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.filter.MutationFilterFactory
+++ b/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.filter.MutationFilterFactory
@@ -1,2 +1,3 @@
 org.pitest.mutationtest.filter.LimitNumberOfMutationsPerClassFilterFactory
 org.pitest.mutationtest.filter.KotlinFilterFactory
+org.pitest.mutationtest.filter.RemoveConditionalMutationForSwitchOnStringFilterFactory

--- a/pitest/src/test/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilterTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/filter/RemoveConditionalMutationForSwitchOnStringFilterTest.java
@@ -1,0 +1,129 @@
+package org.pitest.mutationtest.filter;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.pitest.mutationtest.LocationMother.aMutationId;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.pitest.classpath.CodeSource;
+import org.pitest.mutationtest.LocationMother.MutationIdentifierBuilder;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.MutationDetailsMother;
+import org.pitest.mutationtest.filter.support.MutationOnSwitchInstructionLookup;
+
+public class RemoveConditionalMutationForSwitchOnStringFilterTest {
+
+  @Test
+  public void shouldFilterOutRemoveConditionalMutator_EQUAL_IF_MutationOnSwitch()
+      throws Exception {
+    // given
+    final CodeSource source = mock(CodeSource.class);
+    final MutationOnSwitchInstructionLookup mutationOnSwitchInstructionLookup = mock(
+        MutationOnSwitchInstructionLookup.class);
+    final RemoveConditionalMutationForSwitchOnStringFilter filter = new RemoveConditionalMutationForSwitchOnStringFilter(
+        mutationOnSwitchInstructionLookup, source);
+
+    final MutationDetails firstMutation = MutationDetailsMother
+        .aMutationDetail()
+        .withId(aMutationId()
+            .withMutator(
+                "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF")
+            .withIndex(1))
+        .build();
+
+    final MutationDetails secondMutation = MutationDetailsMother
+        .aMutationDetail()
+        .withId(aMutationId()
+            .withMutator(
+                "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF_ELSE")
+            .withIndex(2))
+        .build();
+
+    given(mutationOnSwitchInstructionLookup
+        .isMutationOnSwitchInstruction(firstMutation, source)).willReturn(true);
+    given(mutationOnSwitchInstructionLookup
+        .isMutationOnSwitchInstruction(secondMutation, source))
+            .willReturn(true);
+
+    // when
+    final Collection<MutationDetails> filtered = filter
+        .filter(asList(firstMutation, secondMutation));
+
+    // then
+    assertThat(filtered).isEmpty();
+  }
+
+  @Test
+  public void shouldLeaveMutationsOtherThan_RemoveConditionalMutator_EQUAL_IF()
+      throws Exception {
+    // given
+    final CodeSource source = mock(CodeSource.class);
+    final MutationOnSwitchInstructionLookup mutationOnSwitchInstructionLookup = mock(
+        MutationOnSwitchInstructionLookup.class);
+    final RemoveConditionalMutationForSwitchOnStringFilter filter = new RemoveConditionalMutationForSwitchOnStringFilter(
+        mutationOnSwitchInstructionLookup, source);
+
+    final MutationIdentifierBuilder id = aMutationId()
+        .withMutator("SOME_OTHER_MUTATION");
+
+    final MutationDetails firstMutation = MutationDetailsMother
+        .aMutationDetail().withId(id.withIndex(1)).build();
+
+    final MutationDetails secondMutation = MutationDetailsMother
+        .aMutationDetail().withId(id.withIndex(2)).build();
+
+    // when
+    final Collection<MutationDetails> filtered = filter
+        .filter(asList(firstMutation, secondMutation));
+
+    // then
+    assertThat(filtered).containsOnly(firstMutation, secondMutation);
+    verifyZeroInteractions(mutationOnSwitchInstructionLookup);
+  }
+
+  @Test
+  public void shouldLeaveRemoveConditionalMutator_EQUAL_IF_MutationNotOnSwitch()
+      throws Exception {
+    // given
+    final CodeSource source = mock(CodeSource.class);
+    final MutationOnSwitchInstructionLookup mutationOnSwitchInstructionLookup = mock(
+        MutationOnSwitchInstructionLookup.class);
+    final RemoveConditionalMutationForSwitchOnStringFilter filter = new RemoveConditionalMutationForSwitchOnStringFilter(
+        mutationOnSwitchInstructionLookup, source);
+
+    final MutationDetails firstMutation = MutationDetailsMother
+        .aMutationDetail()
+        .withId(aMutationId()
+            .withMutator(
+                "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF")
+            .withIndex(1))
+        .build();
+
+    final MutationDetails secondMutation = MutationDetailsMother
+        .aMutationDetail()
+        .withId(aMutationId()
+            .withMutator(
+                "org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF_ELSE")
+            .withIndex(2))
+        .build();
+
+    given(mutationOnSwitchInstructionLookup
+        .isMutationOnSwitchInstruction(firstMutation, source))
+            .willReturn(false);
+    given(mutationOnSwitchInstructionLookup
+        .isMutationOnSwitchInstruction(secondMutation, source))
+            .willReturn(false);
+
+    // when
+    final Collection<MutationDetails> filtered = filter
+        .filter(asList(firstMutation, secondMutation));
+
+    // then
+    assertThat(filtered).containsOnly(firstMutation, secondMutation);
+  }
+}

--- a/pitest/src/test/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookupImplTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/filter/support/MutationOnSwitchInstructionLookupImplTest.java
@@ -1,0 +1,290 @@
+package org.pitest.mutationtest.filter.support;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.pitest.mutationtest.LocationMother.aLocation;
+import static org.pitest.mutationtest.LocationMother.aMutationId;
+import static org.pitest.mutationtest.engine.MutationDetailsMother.aMutationDetail;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classpath.CodeSource;
+import org.pitest.coverage.analysis.Block;
+import org.pitest.functional.F;
+import org.pitest.functional.Option;
+import org.pitest.mutationtest.ReportTestBase;
+import org.pitest.mutationtest.engine.MutationDetails;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MutationOnSwitchInstructionLookupImplTest extends ReportTestBase {
+
+  @Mock
+  private CodeSource                 source;
+
+  @Mock
+  private ClassReader                classReader;
+
+  @Mock
+  private ControlFlowAnalyserWrapper controlFlowAnalyserWrapper;
+
+  private Block createBlock(final int firstInstruction,
+      final int lastInstruction, final int lineNo) {
+    final HashSet<Integer> lines = new HashSet<Integer>();
+    lines.add(lineNo);
+    return new Block(firstInstruction, lastInstruction, lines);
+  }
+
+  private LookupSwitchInsnNode createLookupSwitchInsnNode() {
+    return new LookupSwitchInsnNode(new LabelNode(), new int[] {},
+        new LabelNode[] {});
+  }
+
+  private ClassNode prepareClassNode(final ClassName className,
+      final String method, final int mutationLineNumber,
+      final AbstractInsnNode instructionFromMutatedBlock) {
+
+    given(source.fetchClassBytes(className))
+        .willReturn(Option.some(new byte[] {}));
+
+    final ClassNode classNode = new ClassNode();
+    classNode.methods = new ArrayList();
+
+    final MethodNode methodNode = new MethodNode();
+    methodNode.name = method;
+    classNode.methods.add(methodNode);
+
+    methodNode.instructions = new InsnList();
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(instructionFromMutatedBlock);
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+    methodNode.instructions.add(new LabelNode());
+
+    final List<Block> blocks = asList(createBlock(0, 1, 5),
+        createBlock(2, 3, 5), createBlock(4, 5, mutationLineNumber),
+        createBlock(6, 7, 14));
+    given(controlFlowAnalyserWrapper.analyze(methodNode)).willReturn(blocks);
+
+    return classNode;
+  }
+
+  private MutationOnSwitchInstructionLookupImpl prepareTestee(
+      final ClassNode classNode) {
+    return new MutationOnSwitchInstructionLookupImpl(new Supplier<ClassNode>() {
+      @Override
+      public ClassNode get() {
+        return classNode;
+      }
+    }, new F<byte[], ClassReader>() {
+      @Override
+      public ClassReader apply(final byte[] bytes) {
+        return classReader;
+      }
+    }, controlFlowAnalyserWrapper) {
+      ;
+    };
+  }
+
+  @Test
+  public void shouldReturnFalseWhenCodeSourceReturnsNoneClassBytes()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int lineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(lineNumber).build();
+
+    given(source.fetchClassBytes(className)).willReturn(Option.<byte[]> none());
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(
+        new ClassNode());
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isFalse();
+  }
+
+  @Test
+  public void shouldReturnFalseWhenMutationMethodNotFoundInClass()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int mutationLineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(mutationLineNumber).build();
+
+    final String otherMethod = "baz";
+    given(source.fetchClassBytes(className))
+        .willReturn(Option.some(new byte[] {}));
+
+    final ClassNode classNode = new ClassNode();
+    classNode.methods = new ArrayList();
+
+    final MethodNode methodNode = new MethodNode();
+    methodNode.name = otherMethod;
+
+    classNode.methods.add(methodNode);
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(classNode);
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isFalse();
+    verify(classReader).accept(classNode, ClassReader.EXPAND_FRAMES);
+    verifyZeroInteractions(controlFlowAnalyserWrapper);
+  }
+
+  @Test
+  public void shouldReturnFalseWhenMutationOnDifferentLineThenSwitchInstructionBlock()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int mutationLineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(mutationLineNumber).build();
+
+    final TableSwitchInsnNode instructionFromMutatedBlock = new TableSwitchInsnNode(
+        1, 1, new LabelNode());
+
+    final int mutationLineNumber1 = 66;
+    final ClassNode classNode = prepareClassNode(className, method,
+        mutationLineNumber1, instructionFromMutatedBlock);
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(classNode);
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isFalse();
+    verify(classReader).accept(classNode, ClassReader.EXPAND_FRAMES);
+  }
+
+  @Test
+  public void shouldReturnFalseWhenMutationOnMethodWithoutSwitchInstruction()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int mutationLineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(mutationLineNumber).build();
+    final LabelNode instructionFromMutatedBlock = new LabelNode();
+
+    final ClassNode classNode = prepareClassNode(className, method,
+        mutationLineNumber, instructionFromMutatedBlock);
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(classNode);
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isFalse();
+    verify(classReader).accept(classNode, ClassReader.EXPAND_FRAMES);
+  }
+
+  @Test
+  public void shouldReturnTrueWhenMutationOnMethodWithLookupSwitchInstruction()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int mutationLineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(mutationLineNumber).build();
+
+    final LookupSwitchInsnNode instructionFromMutatedBlock = createLookupSwitchInsnNode();
+
+    final ClassNode classNode = prepareClassNode(className, method,
+        mutationLineNumber, instructionFromMutatedBlock);
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(classNode);
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isTrue();
+    verify(classReader).accept(classNode, ClassReader.EXPAND_FRAMES);
+  }
+
+  @Test
+  public void shouldReturnTrueWhenMutationOnMethodWithTableSwitchInstruction()
+      throws Exception {
+    // given
+    final ClassName className = new ClassName("Foo");
+    final String method = "bar";
+    final int mutationLineNumber = 12;
+
+    final MutationDetails mutation = aMutationDetail()
+        .withId(aMutationId()
+            .withLocation(aLocation().withClass(className).withMethod(method)))
+        .withLineNumber(mutationLineNumber).build();
+
+    final TableSwitchInsnNode instructionFromMutatedBlock = new TableSwitchInsnNode(
+        1, 1, new LabelNode());
+
+    final ClassNode classNode = prepareClassNode(className, method,
+        mutationLineNumber, instructionFromMutatedBlock);
+
+    final MutationOnSwitchInstructionLookup testee = prepareTestee(classNode);
+
+    // when
+    final boolean mutationOnSwitchInstruction = testee
+        .isMutationOnSwitchInstruction(mutation, source);
+
+    // then
+    assertThat(mutationOnSwitchInstruction).isTrue();
+    verify(classReader).accept(classNode, ClassReader.EXPAND_FRAMES);
+  }
+}


### PR DESCRIPTION
RemoveConditionalMutator_EQUAL_IF creates mutations for switch on string value and this mutations cannot be killed. This is fixed by implementing filter that removes this particular mutation in case when
it was done on switch instruction.
