### PR TITLE
Add an option to supply the classpath in a file

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -51,10 +51,10 @@ import static org.pitest.mutationtest.config.ConfigOption.TIME_STAMPED_REPORTS;
 import static org.pitest.mutationtest.config.ConfigOption.USE_INLINED_CODE_DETECTION;
 import static org.pitest.mutationtest.config.ConfigOption.VERBOSE;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -415,10 +415,25 @@ public class OptionsParser {
           ClassPath.getClassPathElementsAsPaths(), this.dependencyFilter));
     }
     if (userArgs.has(this.classPathFile)) {
+      BufferedReader classPathFileBR = null;
       try {
-        elements.addAll(Files.readAllLines(userArgs.valueOf(this.classPathFile).toPath(), Charset.forName("UTF-8")));
+        classPathFileBR = new BufferedReader(new FileReader(userArgs.valueOf(this.classPathFile).getAbsoluteFile()));
+        String element;
+        while ((element = classPathFileBR.readLine()) != null) {
+          elements.add(element);
+        }
       } catch (IOException ioe) {
-        LOG.warning("Unable to read class path file:" + userArgs.valueOf(this.classPathFile).getAbsolutePath() + " - " + ioe.getMessage() );
+        LOG.warning("Unable to read class path file:" + userArgs.valueOf(this.classPathFile).getAbsolutePath() + " - "
+                + ioe.getMessage());
+      } finally {
+        try {
+          if (classPathFileBR != null) {
+            classPathFileBR.close();
+          }
+        } catch (IOException ex) {
+          LOG.warning("Error while closing the class path file's buffered reader:" + userArgs.valueOf(this.classPathFile)
+                  .getAbsolutePath() + " - " + ex.getMessage());
+        }
       }
     }
     elements.addAll(userArgs.valuesOf(this.additionalClassPathSpec));

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -17,6 +17,7 @@ package org.pitest.mutationtest.commandline;
 import static org.pitest.mutationtest.config.ConfigOption.AVOID_CALLS;
 import static org.pitest.mutationtest.config.ConfigOption.CHILD_JVM;
 import static org.pitest.mutationtest.config.ConfigOption.CLASSPATH;
+import static org.pitest.mutationtest.config.ConfigOption.CLASSPATH_FILE;
 import static org.pitest.mutationtest.config.ConfigOption.CODE_PATHS;
 import static org.pitest.mutationtest.config.ConfigOption.COVERAGE_THRESHOLD;
 import static org.pitest.mutationtest.config.ConfigOption.DEPENDENCY_DISTANCE;
@@ -52,10 +53,13 @@ import static org.pitest.mutationtest.config.ConfigOption.VERBOSE;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionException;
@@ -72,12 +76,15 @@ import org.pitest.mutationtest.config.ConfigOption;
 import org.pitest.mutationtest.config.ReportOptions;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.util.Glob;
+import org.pitest.util.Log;
 import org.pitest.util.Unchecked;
 
 public class OptionsParser {
 
   private final Predicate<String>                    dependencyFilter;
-
+  
+  private static final Logger LOG = Log.getLogger();
+  
   private final OptionParser                         parser;
   private final ArgumentAcceptingOptionSpec<String>  reportDirSpec;
   private final OptionSpec<String>                   targetClassesSpec;
@@ -99,6 +106,7 @@ public class OptionsParser {
   private final OptionSpec<String>                   excludedClassesSpec;
   private final OptionSpec<String>                   outputFormatSpec;
   private final OptionSpec<String>                   additionalClassPathSpec;
+  private final OptionSpec<File>                     classPathFile;
   private final ArgumentAcceptingOptionSpec<Boolean> failWhenNoMutations;
   private final ArgumentAcceptingOptionSpec<String>  codePaths;
   private final OptionSpec<String>                   excludedGroupsSpec;
@@ -243,6 +251,9 @@ public class OptionsParser {
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("coma separated list of additional classpath elements");
 
+	this.classPathFile = this.parserAccepts(CLASSPATH_FILE).withRequiredArg()
+        .ofType(File.class).describedAs("File with a list of additional classpath elements (one per line)");
+		
     this.failWhenNoMutations = parserAccepts(FAIL_WHEN_NOT_MUTATIONS)
         .withOptionalArg().ofType(Boolean.class).defaultsTo(true)
         .describedAs("whether to throw error if no mutations found");
@@ -402,6 +413,13 @@ public class OptionsParser {
     } else {
       elements.addAll(FCollection.filter(
           ClassPath.getClassPathElementsAsPaths(), this.dependencyFilter));
+    }
+    if (userArgs.has(this.classPathFile)) {
+      try {
+        elements.addAll(Files.readAllLines(userArgs.valueOf(this.classPathFile).toPath(), Charset.forName("UTF-8")));
+      } catch (IOException ioe) {
+        LOG.warning("Unable to read class path file:" + userArgs.valueOf(this.classPathFile).getAbsolutePath() + " - " + ioe.getMessage() );
+      }
     }
     elements.addAll(userArgs.valuesOf(this.additionalClassPathSpec));
     data.setClassPathElements(elements);

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -251,9 +251,9 @@ public class OptionsParser {
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("coma separated list of additional classpath elements");
 
-	this.classPathFile = this.parserAccepts(CLASSPATH_FILE).withRequiredArg()
+    this.classPathFile = this.parserAccepts(CLASSPATH_FILE).withRequiredArg()
         .ofType(File.class).describedAs("File with a list of additional classpath elements (one per line)");
-		
+
     this.failWhenNoMutations = parserAccepts(FAIL_WHEN_NOT_MUTATIONS)
         .withOptionalArg().ofType(Boolean.class).defaultsTo(true)
         .describedAs("whether to throw error if no mutations found");

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -298,13 +298,24 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldAcceptFileWithListOfAdditionalClassPathElements() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    File classPathFile = new File(classLoader.getResource("testClassPathFile.txt").getFile());
+    final ReportOptions ro = parseAddingRequiredArgs("--classPathFile",
+	    classPathFile.getAbsolutePath());
+    final Collection<String> actual = ro.getClassPathElements();
+    assertTrue(actual.contains("C:/foo"));
+    assertTrue(actual.contains("/etc/bar"));
+  }
+  
+  @Test
   public void shouldDetermineIfFailWhenNoMutationsFlagIsSet() {
     assertTrue(parseAddingRequiredArgs("--failWhenNoMutations", "true")
         .shouldFailWhenNoMutations());
     assertFalse(parseAddingRequiredArgs("--failWhenNoMutations", "false")
         .shouldFailWhenNoMutations());
   }
-
+  
   @Test
   public void shouldFailWhenNoMutationsSetByDefault() {
     assertTrue(parseAddingRequiredArgs("").shouldFailWhenNoMutations());

--- a/pitest-command-line/src/test/resources/testClassPathFile.txt
+++ b/pitest-command-line/src/test/resources/testClassPathFile.txt
@@ -1,0 +1,2 @@
+C:/foo
+/etc/bar

--- a/pitest/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -108,6 +108,12 @@ public enum ConfigOption {
    * analyse
    */
   CLASSPATH("classPath"),
+   /**
+   * Same as classPath above, but in a file. The file should contain paths to the jars
+   * to be added to the classpath. one path per line.
+   * This is usually only needed if you are running on windows and have a huge classpath
+   */
+  CLASSPATH_FILE("classPathFile"),
   /**
    * Flag to indicate if an error should be thrown if no mutations found
    */


### PR DESCRIPTION
- This option accepts the classpath in a file.(one element per line)
- This mitigates the issue where you are unable to run pitest on the
  windows command line if the classpath is too big - issue #276

