### PR TITLE
add kotlin verification and filter kotlin intrinsics

### DIFF
--- a/pitest-kotlin-verification/pom.xml
+++ b/pitest-kotlin-verification/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pitest-parent</artifactId>
+        <groupId>org.pitest</groupId>
+        <version>1.1.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>pitest-kotlin-verification</artifactId>
+    <packaging>jar</packaging>
+    <name>pitest-kotlin-verification</name>
+    <description>tests for pit kotlin integration</description>
+    <url>http://pitest.org</url>
+    <properties>
+        <kotlin.version>1.0.3</kotlin.version>
+    </properties>
+    <build>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Don't deploy to Maven Central -->
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
+++ b/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
@@ -2,10 +2,7 @@ package org.pitest.kotlin.test
 
 import org.junit.Assert
 import org.junit.Test
-import org.pitest.mutationtest.DetectionStatus
-import org.pitest.mutationtest.MetaDataExtractor
-import org.pitest.mutationtest.MutationResultListener
-import org.pitest.mutationtest.TestMutationTesting
+import org.pitest.mutationtest.*
 import org.pitest.mutationtest.engine.gregor.config.Mutator
 import org.pitest.mutationtest.execute.MutationAnalysisExecutor
 import org.pitest.simpletest.ConfigurationForTesting
@@ -14,7 +11,7 @@ import org.pitest.simpletest.TestAnnotationForTesting
 class KotlinTest {
     private val config = ConfigurationForTesting()
 
-    private var metaDataExtractor = MetaDataExtractor()
+    private var metaDataExtractor = MyMetaDataExtractor()
     private var mae = MutationAnalysisExecutor(1,
             listOf<MutationResultListener>(this.metaDataExtractor))
 
@@ -24,7 +21,7 @@ class KotlinTest {
     fun shouldIgnoreKotlinIntrinsics() {
         TestMutationTesting.`run`(FullyCovereredClass::class.java, FullyCovereredClassTest::class.java,
                 Mutator.defaults(), config, mae)
-        Assert.assertFalse(metaDataExtractor.detectionStatus.contains(DetectionStatus.NO_COVERAGE))
+        metaDataExtractor.results.forEach { if (it.status == DetectionStatus.NO_COVERAGE || it.status == DetectionStatus.SURVIVED) Assert.fail(it.details.toString()) }
     }
 
     class FullyCovereredClass {
@@ -37,6 +34,21 @@ class KotlinTest {
         @TestAnnotationForTesting fun shouldReturn3() {
             Assert.assertEquals(FullyCovereredClass().notNullReturnsInputValue("blubby"), "blubby")
         }
+    }
+
+}
+
+class MyMetaDataExtractor : MutationResultListener{
+    override fun runStart() {
+    }
+
+    val results = mutableListOf<MutationResult>()
+
+    override fun handleMutationResult(results: ClassMutationResults?) {
+        this.results.addAll(results!!.mutations)
+    }
+
+    override fun runEnd() {
     }
 
 }

--- a/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
+++ b/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
@@ -2,36 +2,14 @@ package org.pitest.kotlin.test
 
 import org.junit.Assert
 import org.junit.Test
-import org.pitest.classinfo.ClassInfo
-import org.pitest.classpath.ClassloaderByteArraySource
-import org.pitest.classpath.CodeSource
-import org.pitest.classpath.PathFilter
-import org.pitest.classpath.ProjectClassPaths
-import org.pitest.coverage.execute.CoverageOptions
-import org.pitest.coverage.execute.DefaultCoverageGenerator
-import org.pitest.coverage.export.NullCoverageExporter
-import org.pitest.functional.FCollection
-import org.pitest.functional.predicate.False
-import org.pitest.functional.prelude.Prelude
-import org.pitest.mutationtest.*
-import org.pitest.mutationtest.build.*
-import org.pitest.mutationtest.config.DefaultDependencyPathPredicate
-import org.pitest.mutationtest.config.ReportOptions
-import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory
-import org.pitest.mutationtest.engine.gregor.config.GregorEngineFactory
+import org.pitest.mutationtest.DetectionStatus
+import org.pitest.mutationtest.MetaDataExtractor
+import org.pitest.mutationtest.MutationResultListener
+import org.pitest.mutationtest.TestMutationTesting
 import org.pitest.mutationtest.engine.gregor.config.Mutator
 import org.pitest.mutationtest.execute.MutationAnalysisExecutor
-import org.pitest.mutationtest.filter.UnfilteredMutationFilter
-import org.pitest.mutationtest.tooling.JarCreatingJarFinder
-import org.pitest.process.DefaultJavaExecutableLocator
-import org.pitest.process.JavaAgent
-import org.pitest.process.LaunchOptions
 import org.pitest.simpletest.ConfigurationForTesting
 import org.pitest.simpletest.TestAnnotationForTesting
-import org.pitest.util.Functions
-import org.pitest.util.IsolationUtils
-import org.pitest.util.Timings
-import java.util.*
 
 class KotlinTest {
     private val config = ConfigurationForTesting()
@@ -41,93 +19,11 @@ class KotlinTest {
             listOf<MutationResultListener>(this.metaDataExtractor))
 
 
-    private fun runIt(clazz: Class<*>, test: Class<*>,
-                      mutators: Collection<MethodMutatorFactory>) {
-
-        val data = ReportOptions()
-
-        val tests = setOf(Prelude.isEqualTo(test.name))
-        data.targetTests = tests
-        data.dependencyAnalysisMaxDistance = -1
-
-        val mutees = setOf(Functions.startsWith(clazz.name))
-        data.targetClasses = mutees
-
-        data.timeoutConstant = PercentAndConstantTimeoutStrategy.DEFAULT_CONSTANT
-        data.timeoutFactor = PercentAndConstantTimeoutStrategy.DEFAULT_FACTOR
-
-        val agent = JarCreatingJarFinder()
-
-        try {
-            createEngineAndRun(data, agent, mutators)
-        } finally {
-            agent.close()
-        }
-    }
-
-    private fun createEngineAndRun(data: ReportOptions,
-                                   agent: JavaAgent,
-                                   mutators: Collection<MethodMutatorFactory>) {
-
-        // data.setConfiguration(this.config);
-        val coverageOptions = createCoverageOptions(data)
-
-        val launchOptions = LaunchOptions(agent,
-                DefaultJavaExecutableLocator(), data.jvmArgs,
-                HashMap<String, String>())
-
-        val pf = PathFilter(
-                Prelude.not(DefaultDependencyPathPredicate()),
-                Prelude.not(DefaultDependencyPathPredicate()))
-        val cps = ProjectClassPaths(data.classPath,
-                data.createClassesFilter(), pf)
-
-        val timings = Timings()
-        val code = CodeSource(cps, coverageOptions.getPitConfig().testClassIdentifier())
-
-        val coverageGenerator = DefaultCoverageGenerator(
-                null, coverageOptions, launchOptions, code, NullCoverageExporter(),
-                timings, false)
-
-        val coverageData = coverageGenerator.calculateCoverage()
-
-        val codeClasses = FCollection.map(code.code,
-                ClassInfo.toClassName())
-
-        val engine = GregorEngineFactory().createEngineWithMutators(false, False.instance<String>(),
-                emptyList<String>(), mutators, true)
-
-        val mutationConfig = MutationConfig(engine,
-                launchOptions)
-
-        val bas = ClassloaderByteArraySource(
-                IsolationUtils.getContextClassLoader())
-        val source = MutationSource(mutationConfig,
-                UnfilteredMutationFilter.INSTANCE, DefaultTestPrioritiser(
-                coverageData), bas)
-
-        val wf = WorkerFactory(null,
-                coverageOptions.getPitConfig(), mutationConfig,
-                PercentAndConstantTimeoutStrategy(data.timeoutFactor,
-                        data.timeoutConstant), data.isVerbose, data.classPath.localClassPath)
-
-        val builder = MutationTestBuilder(wf,
-                NullAnalyser(), source, DefaultGrouper(0))
-
-        val tus = builder.createMutationTestUnits(codeClasses)
-
-        this.mae.run(tus)
-    }
-
-    private fun createCoverageOptions(data: ReportOptions): CoverageOptions {
-        return CoverageOptions(data.targetClassesFilter, this.config,
-                data.isVerbose, data.dependencyAnalysisMaxDistance)
-    }
 
     @Test
     fun shouldIgnoreKotlinIntrinsics() {
-        runIt(FullyCovereredClass::class.java, FullyCovereredClassTest::class.java,
-                Mutator.defaults())
+        TestMutationTesting.`run`(FullyCovereredClass::class.java, FullyCovereredClassTest::class.java,
+                Mutator.defaults(), config, mae)
         Assert.assertFalse(metaDataExtractor.detectionStatus.contains(DetectionStatus.NO_COVERAGE))
     }
 

--- a/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
+++ b/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
@@ -1,0 +1,146 @@
+package org.pitest.kotlin.test
+
+import org.junit.Assert
+import org.junit.Test
+import org.pitest.classinfo.ClassInfo
+import org.pitest.classpath.ClassloaderByteArraySource
+import org.pitest.classpath.CodeSource
+import org.pitest.classpath.PathFilter
+import org.pitest.classpath.ProjectClassPaths
+import org.pitest.coverage.execute.CoverageOptions
+import org.pitest.coverage.execute.DefaultCoverageGenerator
+import org.pitest.coverage.export.NullCoverageExporter
+import org.pitest.functional.FCollection
+import org.pitest.functional.predicate.False
+import org.pitest.functional.prelude.Prelude
+import org.pitest.mutationtest.*
+import org.pitest.mutationtest.build.*
+import org.pitest.mutationtest.config.DefaultDependencyPathPredicate
+import org.pitest.mutationtest.config.ReportOptions
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory
+import org.pitest.mutationtest.engine.gregor.config.GregorEngineFactory
+import org.pitest.mutationtest.engine.gregor.config.Mutator
+import org.pitest.mutationtest.execute.MutationAnalysisExecutor
+import org.pitest.mutationtest.filter.UnfilteredMutationFilter
+import org.pitest.mutationtest.tooling.JarCreatingJarFinder
+import org.pitest.process.DefaultJavaExecutableLocator
+import org.pitest.process.JavaAgent
+import org.pitest.process.LaunchOptions
+import org.pitest.simpletest.ConfigurationForTesting
+import org.pitest.simpletest.TestAnnotationForTesting
+import org.pitest.util.Functions
+import org.pitest.util.IsolationUtils
+import org.pitest.util.Timings
+import java.util.*
+
+class KotlinTest {
+    private val config = ConfigurationForTesting()
+
+    private var metaDataExtractor = MetaDataExtractor()
+    private var mae = MutationAnalysisExecutor(1,
+            listOf<MutationResultListener>(this.metaDataExtractor))
+
+
+    private fun runIt(clazz: Class<*>, test: Class<*>,
+                      mutators: Collection<MethodMutatorFactory>) {
+
+        val data = ReportOptions()
+
+        val tests = setOf(Prelude.isEqualTo(test.name))
+        data.targetTests = tests
+        data.dependencyAnalysisMaxDistance = -1
+
+        val mutees = setOf(Functions.startsWith(clazz.name))
+        data.targetClasses = mutees
+
+        data.timeoutConstant = PercentAndConstantTimeoutStrategy.DEFAULT_CONSTANT
+        data.timeoutFactor = PercentAndConstantTimeoutStrategy.DEFAULT_FACTOR
+
+        val agent = JarCreatingJarFinder()
+
+        try {
+            createEngineAndRun(data, agent, mutators)
+        } finally {
+            agent.close()
+        }
+    }
+
+    private fun createEngineAndRun(data: ReportOptions,
+                                   agent: JavaAgent,
+                                   mutators: Collection<MethodMutatorFactory>) {
+
+        // data.setConfiguration(this.config);
+        val coverageOptions = createCoverageOptions(data)
+
+        val launchOptions = LaunchOptions(agent,
+                DefaultJavaExecutableLocator(), data.jvmArgs,
+                HashMap<String, String>())
+
+        val pf = PathFilter(
+                Prelude.not(DefaultDependencyPathPredicate()),
+                Prelude.not(DefaultDependencyPathPredicate()))
+        val cps = ProjectClassPaths(data.classPath,
+                data.createClassesFilter(), pf)
+
+        val timings = Timings()
+        val code = CodeSource(cps, coverageOptions.getPitConfig().testClassIdentifier())
+
+        val coverageGenerator = DefaultCoverageGenerator(
+                null, coverageOptions, launchOptions, code, NullCoverageExporter(),
+                timings, false)
+
+        val coverageData = coverageGenerator.calculateCoverage()
+
+        val codeClasses = FCollection.map(code.code,
+                ClassInfo.toClassName())
+
+        val engine = GregorEngineFactory().createEngineWithMutators(false, False.instance<String>(),
+                emptyList<String>(), mutators, true)
+
+        val mutationConfig = MutationConfig(engine,
+                launchOptions)
+
+        val bas = ClassloaderByteArraySource(
+                IsolationUtils.getContextClassLoader())
+        val source = MutationSource(mutationConfig,
+                UnfilteredMutationFilter.INSTANCE, DefaultTestPrioritiser(
+                coverageData), bas)
+
+        val wf = WorkerFactory(null,
+                coverageOptions.getPitConfig(), mutationConfig,
+                PercentAndConstantTimeoutStrategy(data.timeoutFactor,
+                        data.timeoutConstant), data.isVerbose, data.classPath.localClassPath)
+
+        val builder = MutationTestBuilder(wf,
+                NullAnalyser(), source, DefaultGrouper(0))
+
+        val tus = builder.createMutationTestUnits(codeClasses)
+
+        this.mae.run(tus)
+    }
+
+    private fun createCoverageOptions(data: ReportOptions): CoverageOptions {
+        return CoverageOptions(data.targetClassesFilter, this.config,
+                data.isVerbose, data.dependencyAnalysisMaxDistance)
+    }
+
+    @Test
+    fun shouldDetectedMixOfSurvivingAndKilledMutations() {
+        runIt(FullyCovereredClass::class.java, FullyCovereredClassTest::class.java,
+                Mutator.defaults())
+        Assert.assertFalse(metaDataExtractor.detectionStatus.contains(DetectionStatus.NO_COVERAGE))
+    }
+
+    class FullyCovereredClass {
+        fun notNullReturnsInputValue(s: String): Any {
+            return s
+        }
+    }
+
+    class FullyCovereredClassTest {
+        @TestAnnotationForTesting fun shouldReturn3() {
+            Assert.assertEquals(FullyCovereredClass().notNullReturnsInputValue("blubby"), "blubby")
+        }
+    }
+
+}

--- a/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
+++ b/pitest-kotlin-verification/src/test/kotlin/org/pitest/kotlin/test/KotlinTest.kt
@@ -125,7 +125,7 @@ class KotlinTest {
     }
 
     @Test
-    fun shouldDetectedMixOfSurvivingAndKilledMutations() {
+    fun shouldIgnoreKotlinIntrinsics() {
         runIt(FullyCovereredClass::class.java, FullyCovereredClassTest::class.java,
                 Mutator.defaults())
         Assert.assertFalse(metaDataExtractor.detectionStatus.contains(DetectionStatus.NO_COVERAGE))

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapter.java
@@ -25,6 +25,7 @@ import org.objectweb.asm.Opcodes;
 public class AvoidAssertsMethodAdapter extends MethodVisitor {
 
   private static final String   DISABLE_REASON = "ASSERTS";
+  private static final String DISABLE_REASON_KOTLIN = "KOTLIN_INTRINSICS";
 
   private final MutationContext context;
   private boolean               assertBlockStarted;
@@ -43,8 +44,11 @@ public class AvoidAssertsMethodAdapter extends MethodVisitor {
     if ((opcode == Opcodes.INVOKEVIRTUAL) && "java/lang/Class".equals(owner)
         && "desiredAssertionStatus".equals(name)) {
       this.context.disableMutations(DISABLE_REASON);
+    } else if ("kotlin/jvm/internal/Intrinsics".equals(owner)) {
+        this.context.disableMutations(DISABLE_REASON_KOTLIN);
     }
-    super.visitMethodInsn(opcode, owner, name, desc, itf);
+
+      super.visitMethodInsn(opcode, owner, name, desc, itf);
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapter.java
@@ -25,7 +25,6 @@ import org.objectweb.asm.Opcodes;
 public class AvoidAssertsMethodAdapter extends MethodVisitor {
 
   private static final String   DISABLE_REASON = "ASSERTS";
-  private static final String DISABLE_REASON_KOTLIN = "KOTLIN_INTRINSICS";
 
   private final MutationContext context;
   private boolean               assertBlockStarted;
@@ -44,11 +43,8 @@ public class AvoidAssertsMethodAdapter extends MethodVisitor {
     if ((opcode == Opcodes.INVOKEVIRTUAL) && "java/lang/Class".equals(owner)
         && "desiredAssertionStatus".equals(name)) {
       this.context.disableMutations(DISABLE_REASON);
-    } else if ("kotlin/jvm/internal/Intrinsics".equals(owner)) {
-        this.context.disableMutations(DISABLE_REASON_KOTLIN);
     }
-
-      super.visitMethodInsn(opcode, owner, name, desc, itf);
+    super.visitMethodInsn(opcode, owner, name, desc, itf);
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidKotlinMethodAdapter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AvoidKotlinMethodAdapter.java
@@ -1,0 +1,24 @@
+package org.pitest.mutationtest.engine.gregor;
+
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class AvoidKotlinMethodAdapter extends MethodVisitor {
+    private static final String DISABLE_REASON = "KOTLIN_INTRINSICS";
+    private final MethodMutationContext context;
+
+    AvoidKotlinMethodAdapter(MethodMutationContext context, MethodVisitor delegateMethodVisitor) {
+        super(Opcodes.ASM5, delegateMethodVisitor);
+        this.context = context;
+    }
+
+    @Override
+    public void visitMethodInsn(final int opcode, final String owner,
+                                final String name, final String desc, boolean itf) {
+
+        if ("kotlin/jvm/internal/Intrinsics".equals(owner)) {
+            this.context.disableMutations(DISABLE_REASON);
+        }
+        super.visitMethodInsn(opcode, owner, name, desc, itf);
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
@@ -116,8 +116,8 @@ class MutatingClassVisitor extends ClassVisitor {
 
   private MethodVisitor wrapWithFilters(MethodMutationContext methodContext,
       final MethodVisitor wrappedMethodVisitor) {
-    return wrapWithLineFilter(methodContext,
-        wrapWithAssertFilter(methodContext, wrappedMethodVisitor));
+    return wrapWithKotlinFilter(methodContext, wrapWithLineFilter(methodContext,
+        wrapWithAssertFilter(methodContext, wrappedMethodVisitor)));
   }
 
   private static MethodVisitor wrapWithAssertFilter(
@@ -132,4 +132,9 @@ class MutatingClassVisitor extends ClassVisitor {
         wrappedMethodVisitor);
   }
 
+  private static MethodVisitor wrapWithKotlinFilter(
+          MethodMutationContext methodContext,
+          final MethodVisitor wrappedMethodVisitor) {
+    return new AvoidKotlinMethodAdapter(methodContext, wrappedMethodVisitor);
+  }
 }

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidKotlinMethodAdapterTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidKotlinMethodAdapterTest.java
@@ -1,0 +1,39 @@
+package org.pitest.mutationtest.engine.gregor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.pitest.bytecode.MethodDecoratorTest;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+
+public class AvoidKotlinMethodAdapterTest extends MethodDecoratorTest {
+    @Mock
+    private MethodMutationContext context;
+
+
+    private AvoidKotlinMethodAdapter testee;
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        testee = new AvoidKotlinMethodAdapter(this.context, this.mv);
+    }
+
+    @Override
+    protected MethodVisitor getTesteeVisitor() {
+        return this.testee;
+    }
+
+    @Test
+    public void shouldDisableMutationsForCallsToKotlinIntrinsics() {
+        this.testee.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "kotlin/jvm/internal/Intrinsics",
+                "anyMethodName", "(Ljava/lang/Object;Ljava/lang/String;)V", true);
+        verify(this.context).disableMutations(anyString());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 		<module>pitest-command-line</module>
 		<module>pitest-html-report</module>
 		<module>pitest-maven-verification</module>
+        <module>pitest-kotlin-verification</module>
 	</modules>
 
 	<prerequisites>


### PR DESCRIPTION
My kotlin test duplicates a lot of code because i did not want to refactor your code. I guess createEngineAndRun and the other 2 methods could be made static and optionally moved. 

Also I'm not sure if AvoidAssertsMethodAdapter is the right place for this check, or if it should be a separate adapter. But for now it works and the kotlin code is basically an assert. 
