### PR TITLE
#90 auto selects classes instead of using group id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read all about it at http://pitest.org
 
 ### 1.1.12-SNAPSHOT
 
-Nothing yet
+* 90 - Automatic selection of target classes for maven
 
 ### 1.1.11
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read all about it at http://pitest.org
 
 ### 1.1.12-SNAPSHOT
 
-* 90 - Automatic selection of target classes for maven
+* #215 - Automatic selection of target classes for maven
 
 ### 1.1.11
 

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
@@ -64,6 +65,12 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
         ClassPath.getClassPathElementsAsFiles(), fileToString()));
     when(this.project.getTestClasspathElements()).thenReturn(this.classPath);
     when(this.project.getPackaging()).thenReturn("jar");
+    
+    final Build build = new Build();
+    build.setOutputDirectory("");
+    
+    when(this.project.getBuild()).thenReturn(build);
+    
     when(this.plugins.findToolClasspathPlugins()).thenReturn(
         Collections.emptyList());
     when(this.plugins.findClientClasspathPlugins()).thenReturn(

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -54,6 +55,9 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     this.surefireConverter = Mockito.mock(SurefireConfigConverter.class);
     List<Plugin> mavenPlugins = Collections.singletonList(surefire);
     when(this.project.getBuildPlugins()).thenReturn(mavenPlugins);
+    Build build = new Build();
+    build.setOutputDirectory("");
+    when(this.project.getBuild()).thenReturn(build);
   }
 
   public void testsParsesReportDir() {


### PR DESCRIPTION
Fix for issue 219 - packages filters will now be selected based on the compiled classes in the output dir.

This should simplify configuring pitest for use in multi module projects - in some cases the packages used vary by module.

As the maven plugin always sets the mutable path to match the output dir the primary purpose of this filter is to limit the instrumentation of classes during coverage.

It is still possible to explicitly set the target classes via the mojo to limit the analysis.