### PR TITLE
Use Implementation-Vendor-Id instead of Implementation-Vendor

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/DependencyFilter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/DependencyFilter.java
@@ -91,8 +91,6 @@ public class DependencyFilter implements Predicate<Artifact> {
       while (urls.hasMoreElements()) {
         URL url = urls.nextElement();
 
-        String urlStr = url.toString();
-
         Manifest manifest = new Manifest(url.openStream());
         Attributes attributes = manifest.getMainAttributes();
         String vendor = attributes.getValue("Implementation-Vendor");

--- a/pitest/src/main/java/org/pitest/util/StringUtil.java
+++ b/pitest/src/main/java/org/pitest/util/StringUtil.java
@@ -67,4 +67,8 @@ public class StringUtil {
     }
   }
 
+  public static boolean isNullOrEmpty(final String s) {
+    return s == null || s.isEmpty();
+  }
+
 }


### PR DESCRIPTION
Changed the code of DependencyFilter so plugins are matched against Implementation-Vendor-Id instead of Implementation-Vendor. This way the plugin discovering is compliant with the default behavior in maven that sets groupId to Implementation-Vendor-Id in the META-INF/MANIFEST.MF