### PR TITLE
run only the mutation on the src who are in the origin branch but not in the destination branch

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
@@ -21,6 +21,7 @@ import org.apache.maven.scm.ChangeFile;
 import org.apache.maven.scm.ChangeSet;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmBranch;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.command.changelog.ChangeLogScmRequest;
@@ -65,6 +66,13 @@ public class ScmMojo extends AbstractPitMojo {
    */
   @Parameter(defaultValue = "false", property = "analyseLastCommit")
   private boolean analyseLastCommit;
+
+
+  @Parameter(property = "originBranch")
+  private String originBranch;
+
+  @Parameter(property = "destinationBranch", defaultValue = "master")
+  private String destinationBranch;
 
   /**
    * Connection type to use when querying scm for changed files. Can either be
@@ -121,7 +129,7 @@ public class ScmMojo extends AbstractPitMojo {
   }
 
   private void defaultTargetTestsToGroupNameIfNoValueSet() {
-    if (this.getTargetTests() == null) {
+    if (this.getTargetTests() == null || this.getTargetTests().isEmpty()) {
       this.targetTests = makeConcreteList(Collections.singletonList(this
           .getProject().getGroupId() + "*"));
     }
@@ -155,6 +163,8 @@ public class ScmMojo extends AbstractPitMojo {
 
       if (analyseLastCommit) {
         lastCommitChanges(statusToInclude, modifiedPaths, repository, scmRoot);
+      } else if (originBranch != null && destinationBranch != null) {
+        changesBetweenBranchs(originBranch, destinationBranch, statusToInclude, modifiedPaths, repository, scmRoot);
       } else {
         localChanges(statusToInclude, modifiedPaths, repository, scmRoot);
       }
@@ -178,6 +188,26 @@ public class ScmMojo extends AbstractPitMojo {
         for (final ChangeFile changeFile : files) {
           if (statusToInclude.contains(changeFile.getAction())) {
             modifiedPaths.add(changeFile.getName());
+          }
+        }
+      }
+    }
+  }
+
+  private void changesBetweenBranchs(String origine, String destination, Set<ScmFileStatus> statusToInclude, List<String> modifiedPaths, ScmRepository repository, File scmRoot) throws ScmException {
+    ChangeLogScmRequest scmRequest = new ChangeLogScmRequest(repository, new ScmFileSet(scmRoot));
+    scmRequest.setScmBranch(new ScmBranch(destination + ".." + origine));
+    ChangeLogScmResult changeLogScmResult = this.manager.changeLog(scmRequest);
+    if (changeLogScmResult.isSuccess()) {
+      List<ChangeSet> changeSets = changeLogScmResult.getChangeLog().getChangeSets();
+      if (!changeSets.isEmpty()) {
+        for (ChangeSet change : changeSets) {
+          List<ChangeFile> files = change.getFiles();
+
+          for (final ChangeFile changeFile : files) {
+            if (statusToInclude.contains(changeFile.getAction())) {
+              modifiedPaths.add(changeFile.getName());
+            }
           }
         }
       }


### PR DESCRIPTION
with the param originBranch and destinationBranch, you can run only the mutation test in the modified code. 

By example, It will allow to run the mutation test only on the impacted code of a PR. Moderne build factory can publish this report as comment of the PR ( or at least a link to the repport)

I test-it in my  project,(it work !) but I don't have any idea how create a IT test for this .

