### PR TITLE
build on java 9 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 env:
   global:

--- a/pitest-maven-verification/pom.xml
+++ b/pitest-maven-verification/pom.xml
@@ -14,6 +14,15 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
 			<!-- Don't deploy to Maven Central -->
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>

--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.File;
 import java.io.IOException;
@@ -156,6 +157,7 @@ public class PitMojoIT {
   @Test
   //@Ignore("test is flakey, possibly due to real non deterministic issue with powermock")
   public void shouldWorkWithPowerMock() throws Exception {
+    assumeFalse(System.getProperty("java.version").equals("9"));
     File testDir = prepare("/pit-powermock");
     verifier.addCliOption("-DtimeoutConstant=10000");
     verifier.executeGoal("test");
@@ -329,6 +331,7 @@ public class PitMojoIT {
 
   @Test
   public void shouldWorkWithGWTMockito() throws Exception {
+    assumeFalse(System.getProperty("java.version").equals("9"));
     File testDir = prepare("/pit-183-gwtmockito");
     verifier.executeGoal("test");
     verifier.executeGoal("org.pitest:pitest-maven:mutationCoverage");

--- a/pitest-maven-verification/src/test/resources/pit-158-coverage/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-158-coverage/pom.xml
@@ -28,15 +28,23 @@
 
 	<build>
 		<plugins>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
 			    <version>${pit.version}</version>
 				<configuration>
 					<verbose>true</verbose>
-				    <outputFormats><value>XML</value></outputFormats>	
-				    <timestampedReports>false</timestampedReports>				
+				    <outputFormats><value>XML</value></outputFormats>
+				    <timestampedReports>false</timestampedReports>
 					<exportLineCoverage>true</exportLineCoverage>
 					<mutators>
 						<mutator>VOID_METHOD_CALLS</mutator>

--- a/pitest-maven-verification/src/test/resources/pit-183-gwtmockito/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-183-gwtmockito/pom.xml
@@ -10,21 +10,30 @@
   <artifactId>gwtmockito-sample</artifactId>
 
   <build>
-    <plugins>
- 	<plugin>
-	  <groupId>org.pitest</groupId>
-	  <artifactId>pitest-maven</artifactId>
-	  <version>${pit.version}</version>
-	  <configuration>
-	      <exportLineCoverage>true</exportLineCoverage>
-	      <outputFormats><value>XML</value></outputFormats>
-	      <maxMutationsPerClass>6</maxMutationsPerClass>
-	      <timestampedReports>false</timestampedReports>
-	      <targetClasses><param>sample*</param></targetClasses>
-	      <verbose>true</verbose>
-	  </configuration>
-	</plugin>
-    </plugins>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>${pit.version}</version>
+                <configuration>
+                    <exportLineCoverage>true</exportLineCoverage>
+                    <outputFormats><value>XML</value></outputFormats>
+                    <maxMutationsPerClass>6</maxMutationsPerClass>
+                    <timestampedReports>false</timestampedReports>
+                    <targetClasses><param>sample*</param></targetClasses>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+      </plugins>
   </build>
 
 

--- a/pitest-maven-verification/src/test/resources/pit-263-yatspec/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-263-yatspec/pom.xml
@@ -10,6 +10,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
                 <version>${pit.version}</version>

--- a/pitest-maven-verification/src/test/resources/pit-33-setUserDir/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-33-setUserDir/pom.xml
@@ -20,8 +20,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pitest-maven-verification/src/test/resources/pit-deterministic-coverage/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-deterministic-coverage/pom.xml
@@ -20,8 +20,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pitest-maven-verification/src/test/resources/pit-process-hang/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-process-hang/pom.xml
@@ -24,13 +24,22 @@
 		<plugins>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
 			    <version>${pit.version}</version>
 				<configuration>
 					<verbose>true</verbose>
-				    <outputFormats><value>XML</value></outputFormats>	
-				    <timestampedReports>false</timestampedReports>				
+				    <outputFormats><value>XML</value></outputFormats>
+				    <timestampedReports>false</timestampedReports>
 					<exportLineCoverage>true</exportLineCoverage>
 					<mutators>
 						<mutator>VOID_METHOD_CALLS</mutator>

--- a/pitest-maven-verification/src/test/resources/pit-testng-jmockit/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-testng-jmockit/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>org.jmockit</groupId>
             <artifactId>jmockit</artifactId>
-            <version>1.13</version>
+            <version>1.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pitest/src/main/java/org/pitest/coverage/CoverageTransformer.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageTransformer.java
@@ -32,7 +32,7 @@ public class CoverageTransformer implements ClassFileTransformer {
     final boolean include = shouldInclude(className);
     if (include) {
       try {
-        return transformBytes(loader, className, classfileBuffer);
+        return transformBytes(pickLoader(loader), className, classfileBuffer);
       } catch (final RuntimeException t) {
         System.err.println("RuntimeException while transforming  " + className);
         t.printStackTrace();
@@ -58,6 +58,13 @@ public class CoverageTransformer implements ClassFileTransformer {
 
   private boolean shouldInclude(final String className) {
     return this.filter.apply(className);
+  }
+
+  private ClassLoader pickLoader(ClassLoader loader) {
+    if (loader != null) {
+      return loader;
+    }
+    return ClassLoader.getSystemClassLoader();
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
+					<version>3.7.0</version>
 					<configuration>
 						<source>1.6</source>
 						<target>1.6</target>
@@ -237,7 +237,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.0.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -277,7 +277,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.3</version>
+					<version>3.0.0-M1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
test results can be seen here - https://travis-ci.org/kiftio/pitest/

- update maven-compiler, maven-source, maven-javadoc plugins
- update travis.yml to add oraclejdk9
- use system classloader if null passed to transformer in CoverageTransformer

Also a few tweaks in pitest-maven-verification to ensure projects are compiled with >= 1.6, and skipping a couple of tests (under java 9) that use powermock 1.x