### PR TITLE
load css from separate file to allow styles to be displayed in jenkins

### DIFF
--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -181,6 +181,17 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
   public void onRunEnd() {
     createIndexPages();
+    createCssFile();
+  }
+
+  private void createCssFile() {
+    final Writer cssWriter = this.outputStrategy.createWriterForFile("style.css");
+    try {
+      cssWriter.write(css);
+      cssWriter.close();
+    } catch (final IOException e) {
+      e.printStackTrace();
+    }
   }
 
   private void createIndexPages() {
@@ -237,6 +248,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
   @Override
   public void runEnd() {
     createIndexPages();
+    createCssFile();
   }
 
   @Override

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
@@ -79,6 +79,12 @@ public class MutationHtmlReportListenerTest {
     verify(this.outputStrategy).createWriterForFile("index.html");
   }
 
+  @Test
+  public void shouldCreateACssFile() {
+    this.testee.onRunEnd();
+    verify(this.outputStrategy).createWriterForFile("style.css");
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void shouldTryToLocateSourceFilesFromMutatedClasses() {

--- a/pitest/src/main/resources/templates/mutation/mutation_package_index.st
+++ b/pitest/src/main/resources/templates/mutation/mutation_package_index.st
@@ -1,62 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-  
-    <style type='text/css'>
-    $css$
-   
-   .tests {
-     width: 50%;
-     float: left;
-   }
-   
-   .mutees {
-     float: right;
-     width: 50%;
-   }
-   
-   .unit {
-     padding-top: 20px;
-     clear: both;
-   }
-   
-   .coverage_bar {
-     display: inline-block;
-     height: 1.1em;
-     width: 130px;
-     background: #FAA;
-     margin: 0 5px;
-     vertical-align: middle;
-     border: 1px solid #AAA;
-     position: relative;
-   }
-   
-   .coverage_complete {
-     display: inline-block;
-     height: 100%;
-     background: #DFD;
-     float: left;
-   }
-   
-   .coverage_legend {
-     position: absolute;
-     height: 100%;
-     width: 100%;
-     left: 0;
-     top: 0;
-     text-align: center;
-   }
-   
-   .line, .mut {
-     vertical-align: middle;
-   }
-   
-   .coverage_percentage {
-     display: inline-block;
-     width: 3em;
-     text-align: right;
-   }
-  </style>
-  
+    <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
 
@@ -74,8 +19,8 @@
     <tbody>
         <tr>
             <td>$totals.numberOfFiles$</td>
-            <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete" style="width:$totals.lineCoverage$%"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
-            <td>$totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete" style="width:$totals.mutationCoverage$%"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
+            <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
+            <td>$totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.mutationCoverage$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
         </tr>
     </tbody>
 </table>
@@ -96,8 +41,8 @@ $packageSummaries:{ summary |
         <tr>
             <td><a href="./$summary.packageDirectory$/index.html">$summary.packageName$</a></td>
             <td>$summary.totals.numberOfFiles$</td>
-            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete" style="width:$summary.totals.lineCoverage$%"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
-            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete" style="width:$summary.totals.mutationCoverage$%"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
         </tr>
 }$
      </tbody>

--- a/pitest/src/main/resources/templates/mutation/mutation_report.st
+++ b/pitest/src/main/resources/templates/mutation/mutation_report.st
@@ -1,15 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-<style type='text/css'>
-$css$
-
-.pop {outline:none; }
-.pop strong {line-height:30px;}
-.pop {text-decoration:none;}
-.pop span { z-index:10; display:none; padding:14px 20px; margin-top:-30px; margin-left:28px; width:800px; line-height:16px; word-wrap:break-word; border-radius:4px; -moz-border-radius: 4px; -webkit-border-radius: 4px; -moz-box-shadow: 5px 5px 8px #CCC; -webkit-box-shadow: 5px 5px 8px #CCC; box-shadow: 5px 5px 8px #CCC; }
-.pop:hover span{ display:inline; position:absolute; color:#111; border:1px solid #DCA; background:#fffAF0;}
-</style>
-
+    <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
 

--- a/pitest/src/main/resources/templates/mutation/package_index.st
+++ b/pitest/src/main/resources/templates/mutation/package_index.st
@@ -1,62 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
-  
-    <style type='text/css'>
-    $css$
-   
-   .tests {
-     width: 50%;
-     float: left;
-   }
-   
-   .mutees {
-     float: right;
-     width: 50%;
-   }
-   
-   .unit {
-     padding-top: 20px;
-     clear: both;
-   }
-   
-   .coverage_bar {
-     display: inline-block;
-     height: 1.1em;
-     width: 130px;
-     background: #FAA;
-     margin: 0 5px;
-     vertical-align: middle;
-     border: 1px solid #AAA;
-     position: relative;
-   }
-   
-   .coverage_complete {
-     display: inline-block;
-     height: 100%;
-     background: #DFD;
-     float: left;
-   }
-   
-   .coverage_legend {
-     position: absolute;
-     height: 100%;
-     width: 100%;
-     left: 0;
-     top: 0;
-     text-align: center;
-   }
-   
-   .line, .mut {
-     vertical-align: middle;
-   }
-   
-   .coverage_percentage {
-     display: inline-block;
-     width: 3em;
-     text-align: right;
-   }
-  </style>
-  
+    <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
 <body>
 
@@ -74,8 +19,8 @@
     <tbody>
         <tr>
             <td>$packageData.totals.numberOfFiles$</td>
-            <td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete" style="width:$packageData.totals.lineCoverage$%"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
-            <td>$packageData.totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete" style="width:$packageData.totals.mutationCoverage$%"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
+            <td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
+            <td>$packageData.totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.mutationCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
         </tr>
     </tbody>
 </table>
@@ -94,8 +39,8 @@
 $packageData.summaryData:{ summary | 
         <tr>
             <td><a href="./$summary.fileName$.html">$summary.fileName$</a></td>
-            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete" style="width:$summary.totals.lineCoverage$%"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
-            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete" style="width:$summary.totals.mutationCoverage$%"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
         </tr>
 }$
      </tbody>

--- a/pitest/src/main/resources/templates/mutation/style.css
+++ b/pitest/src/main/resources/templates/mutation/style.css
@@ -33,11 +33,11 @@ body{
     background-color: #ffdddd;
 }
 
-.killed {
+.killed, .KILLED {
     background-color: #aaffaa;
 }
 
-.survived {
+.survived, .SURVIVED {
     background-color: #ffaaaa;
 }
 

--- a/pitest/src/main/resources/templates/mutation/style.css
+++ b/pitest/src/main/resources/templates/mutation/style.css
@@ -1,40 +1,563 @@
 html, body, div, span, p, blockquote, pre {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	outline: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 100%;
-	font-family: inherit;
-	vertical-align: baseline;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    font-weight: inherit;
+    font-style: inherit;
+    font-size: 100%;
+    font-family: inherit;
+    vertical-align: baseline;
 }
 
 body{
-	line-height: 1;
-	color: black;
-	background: white;
-	margin-left: 20px;
+    line-height: 1;
+    color: black;
+    background: white;
+    margin-left: 20px;
 }
 
 .src { 
-	border: 1px solid #dddddd;
-	padding-top: 10px;
-	padding-right: 5px;
-	padding-left: 5px;
-	font-family: Consolas, Courier, monospace;
+    border: 1px solid #dddddd;
+    padding-top: 10px;
+    padding-right: 5px;
+    padding-left: 5px;
+    font-family: Consolas, Courier, monospace;
 }
 
+.covered {
+    background-color: #ddffdd;
+}
 
-.covered {background-color: #ddffdd}
-.uncovered {background-color: #ffdddd}
-.killed {background-color: #aaffaa}
-.survived {background-color: #ffaaaa}
-.uncertain {background-color: #dde7ef}
-.run_error {background-color: #dde7ef}
-.na {background-color: #eeeeee}
-.timed_out {background-color: #dde7ef}
-.non_viable {background-color: #aaffaa}
-.memory_error {background-color: #dde7ef}
-.not_started {background-color: #dde7ef; color : red}
-.no_coverage {background-color: #ffaaaa}
+.uncovered {
+    background-color: #ffdddd;
+}
+
+.killed {
+    background-color: #aaffaa;
+}
+
+.survived {
+    background-color: #ffaaaa;
+}
+
+.uncertain {
+    background-color: #dde7ef;
+}
+
+.run_error {
+    background-color: #dde7ef;
+}
+
+.na {
+    background-color: #eeeeee;
+}
+
+.timed_out {
+    background-color: #dde7ef;
+}
+
+.non_viable {
+    background-color: #aaffaa;
+}
+
+.memory_error {
+    background-color: #dde7ef;
+}
+
+.not_started {
+    background-color: #dde7ef; color : red
+}
+
+.no_coverage {
+    background-color: #ffaaaa;
+}
+
+.tests {
+    width: 50%;
+    float: left;
+}
+
+.mutees {
+    float: right;
+    width: 50%;
+}
+
+.unit {
+    padding-top: 20px;
+    clear: both;
+}
+
+.coverage_bar {
+    display: inline-block;
+    height: 1.1em;
+    width: 130px;
+    background: #FAA;
+    margin: 0 5px;
+    vertical-align: middle;
+    border: 1px solid #AAA;
+    position: relative;
+}
+
+.coverage_complete {
+    display: inline-block;
+    height: 100%;
+    background: #DFD;
+    float: left;
+}
+
+.coverage_legend {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    left: 0;
+    top: 0;
+    text-align: center;
+}
+
+.line, .mut {
+    vertical-align: middle;
+}
+
+.coverage_percentage {
+    display: inline-block;
+    width: 3em;
+    text-align: right;
+}
+
+.pop {
+    outline:none;
+}
+
+.pop strong {
+    line-height: 30px;
+}
+
+.pop {
+    text-decoration: none;
+}
+
+.pop span {
+    z-index: 10;
+    display: none;
+    padding: 14px 20px;
+    margin-top: -30px;
+    margin-left: 28px;
+    width: 800px;
+    line-height: 16px;
+    word-wrap: break-word;
+    border-radius: 4px;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    -moz-box-shadow: 5px 5px 8px #CCC;
+    -webkit-box-shadow: 5px 5px 8px #CCC;
+    box-shadow: 5px 5px 8px #CCC;
+}
+
+.pop:hover span {
+    display: inline;
+    position: absolute;
+    color: #111;
+    border: 1px solid #DCA;
+    background: #fffAF0;
+}
+
+.width-1 {
+    width: 1%;
+}
+
+.width-2 {
+    width: 2%;
+}
+
+.width-3 {
+    width: 3%;
+}
+
+.width-4 {
+    width: 4%;
+}
+
+.width-5 {
+    width: 5%;
+}
+
+.width-6 {
+    width: 6%;
+}
+
+.width-7 {
+    width: 7%;
+}
+
+.width-8 {
+    width: 8%;
+}
+
+.width-9 {
+    width: 9%;
+}
+
+.width-10 {
+    width: 10%;
+}
+
+.width-11 {
+    width: 11%;
+}
+
+.width-12 {
+    width: 12%;
+}
+
+.width-13 {
+    width: 13%;
+}
+
+.width-14 {
+    width: 14%;
+}
+
+.width-15 {
+    width: 15%;
+}
+
+.width-16 {
+    width: 16%;
+}
+
+.width-17 {
+    width: 17%;
+}
+
+.width-18 {
+    width: 18%;
+}
+
+.width-19 {
+    width: 19%;
+}
+
+.width-20 {
+    width: 20%;
+}
+
+.width-21 {
+    width: 21%;
+}
+
+.width-22 {
+    width: 22%;
+}
+
+.width-23 {
+    width: 23%;
+}
+
+.width-24 {
+    width: 24%;
+}
+
+.width-25 {
+    width: 25%;
+}
+
+.width-26 {
+    width: 26%;
+}
+
+.width-27 {
+    width: 27%;
+}
+
+.width-28 {
+    width: 28%;
+}
+
+.width-29 {
+    width: 29%;
+}
+
+.width-30 {
+    width: 30%;
+}
+
+.width-31 {
+    width: 31%;
+}
+
+.width-32 {
+    width: 32%;
+}
+
+.width-33 {
+    width: 33%;
+}
+
+.width-34 {
+    width: 34%;
+}
+
+.width-35 {
+    width: 35%;
+}
+
+.width-36 {
+    width: 36%;
+}
+
+.width-37 {
+    width: 37%;
+}
+
+.width-38 {
+    width: 38%;
+}
+
+.width-39 {
+    width: 39%;
+}
+
+.width-40 {
+    width: 40%;
+}
+
+.width-41 {
+    width: 41%;
+}
+
+.width-42 {
+    width: 42%;
+}
+
+.width-43 {
+    width: 43%;
+}
+
+.width-44 {
+    width: 44%;
+}
+
+.width-45 {
+    width: 45%;
+}
+
+.width-46 {
+    width: 46%;
+}
+
+.width-47 {
+    width: 47%;
+}
+
+.width-48 {
+    width: 48%;
+}
+
+.width-49 {
+    width: 49%;
+}
+
+.width-50 {
+    width: 50%;
+}
+
+.width-51 {
+    width: 51%;
+}
+
+.width-52 {
+    width: 52%;
+}
+
+.width-53 {
+    width: 53%;
+}
+
+.width-54 {
+    width: 54%;
+}
+
+.width-55 {
+    width: 55%;
+}
+
+.width-56 {
+    width: 56%;
+}
+
+.width-57 {
+    width: 57%;
+}
+
+.width-58 {
+    width: 58%;
+}
+
+.width-59 {
+    width: 59%;
+}
+
+.width-60 {
+    width: 60%;
+}
+
+.width-61 {
+    width: 61%;
+}
+
+.width-62 {
+    width: 62%;
+}
+
+.width-63 {
+    width: 63%;
+}
+
+.width-64 {
+    width: 64%;
+}
+
+.width-65 {
+    width: 65%;
+}
+
+.width-66 {
+    width: 66%;
+}
+
+.width-67 {
+    width: 67%;
+}
+
+.width-68 {
+    width: 68%;
+}
+
+.width-69 {
+    width: 69%;
+}
+
+.width-70 {
+    width: 70%;
+}
+
+.width-71 {
+    width: 71%;
+}
+
+.width-72 {
+    width: 72%;
+}
+
+.width-73 {
+    width: 73%;
+}
+
+.width-74 {
+    width: 74%;
+}
+
+.width-75 {
+    width: 75%;
+}
+
+.width-76 {
+    width: 76%;
+}
+
+.width-77 {
+    width: 77%;
+}
+
+.width-78 {
+    width: 78%;
+}
+
+.width-79 {
+    width: 79%;
+}
+
+.width-80 {
+    width: 80%;
+}
+
+.width-81 {
+    width: 81%;
+}
+
+.width-82 {
+    width: 82%;
+}
+
+.width-83 {
+    width: 83%;
+}
+
+.width-84 {
+    width: 84%;
+}
+
+.width-85 {
+    width: 85%;
+}
+
+.width-86 {
+    width: 86%;
+}
+
+.width-87 {
+    width: 87%;
+}
+
+.width-88 {
+    width: 88%;
+}
+
+.width-89 {
+    width: 89%;
+}
+
+.width-90 {
+    width: 90%;
+}
+
+.width-91 {
+    width: 91%;
+}
+
+.width-92 {
+    width: 92%;
+}
+
+.width-93 {
+    width: 93%;
+}
+
+.width-94 {
+    width: 94%;
+}
+
+.width-95 {
+    width: 95%;
+}
+
+.width-96 {
+    width: 96%;
+}
+
+.width-97 {
+    width: 97%;
+}
+
+.width-98 {
+    width: 98%;
+}
+
+.width-99 {
+    width: 99%;
+}
+
+.width-100 {
+    width: 100%;
+}


### PR DESCRIPTION
to fix issues 403 & 256

- Remove styles from html template and append to style.css
- Reference external stylesheet from html template
- Write out style.css when writing index page

The trickier/uglier part... Setting coverage complete width (green bar) without javascript or inline-styles.  I've added a class for each percentage in style.css and then setting the classname in the template.