### PR TITLE
Object output stream history store

### DIFF
--- a/pitest-entry/pom.xml
+++ b/pitest-entry/pom.xml
@@ -34,7 +34,7 @@
 					</execution>
 				</executions>
 
-			</plugin>		
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
@@ -128,13 +128,17 @@
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm</artifactId>
 			<version>${asm.version}</version>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-util</artifactId>
 			<version>${asm.version}</version>
-		</dependency>		
-		
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.10</version>
+		</dependency>
 		<!-- for the xstream history store. cannot used shaded version -->
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/ClassHistory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/ClassHistory.java
@@ -3,7 +3,9 @@ package org.pitest.mutationtest;
 import org.pitest.classinfo.ClassName;
 import org.pitest.classinfo.HierarchicalClassId;
 
-public class ClassHistory {
+import java.io.Serializable;
+
+public class ClassHistory implements Serializable {
 
   private final HierarchicalClassId id;
   private final String              coverageId;

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStore.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStore.java
@@ -1,0 +1,155 @@
+package org.pitest.mutationtest.incremental;
+
+import org.apache.commons.codec.binary.Base64;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classinfo.HierarchicalClassId;
+import org.pitest.coverage.CoverageDatabase;
+import org.pitest.functional.Option;
+import org.pitest.mutationtest.ClassHistory;
+import org.pitest.mutationtest.HistoryStore;
+import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.MutationStatusTestPair;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.util.Log;
+import org.pitest.util.Unchecked;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class ObjectOutputStreamHistoryStore implements HistoryStore {
+
+    private static final Logger                                   LOG               = Log
+        .getLogger();
+    private final WriterFactory                                   outputFactory;
+    private final BufferedReader                                  input;
+    private final Map<MutationIdentifier, MutationStatusTestPair> previousResults   = new HashMap<MutationIdentifier, MutationStatusTestPair>();
+    private final Map<ClassName, ClassHistory>                    previousClassPath = new HashMap<ClassName, ClassHistory>();
+
+    public ObjectOutputStreamHistoryStore(final WriterFactory output,
+        final Option<Reader> input) {
+        this.outputFactory = output;
+        this.input = createReader(input);
+    }
+
+    private BufferedReader createReader(Option<Reader> input) {
+        if (input.hasSome()) {
+            return new BufferedReader(input.value());
+        }
+        return null;
+    }
+
+    @Override
+    public void recordClassPath(final Collection<HierarchicalClassId> ids,
+        final CoverageDatabase coverageInfo) {
+        final PrintWriter output = this.outputFactory.create();
+        output.println(ids.size());
+        for (final HierarchicalClassId each : ids) {
+            final ClassHistory coverage = new ClassHistory(each, coverageInfo
+                .getCoverageIdForClass(each.getName()).toString(16));
+            output.println(serialize(coverage));
+        }
+        output.flush();
+    }
+
+    @Override
+    public void recordResult(final MutationResult result) {
+        final PrintWriter output = this.outputFactory.create();
+        output.println(serialize(new ObjectOutputStreamHistoryStore.IdResult(result.getDetails().getId(), result
+            .getStatusTestPair())));
+        output.flush();
+    }
+
+    @Override
+    public Map<MutationIdentifier, MutationStatusTestPair> getHistoricResults() {
+        return this.previousResults;
+    }
+
+    @Override
+    public Map<ClassName, ClassHistory> getHistoricClassPath() {
+        return this.previousClassPath;
+    }
+
+    @Override
+    public void initialize() {
+        if (this.input != null) {
+            restoreClassPath();
+            restoreResults();
+            try {
+                this.input.close();
+            } catch (final IOException e) {
+                throw Unchecked.translateCheckedException(e);
+            }
+        }
+    }
+
+    private void restoreResults() {
+        String line;
+        try {
+            line = this.input.readLine();
+            while (line != null) {
+                final IdResult result = deserialize(line, IdResult.class);
+                this.previousResults.put(result.id, result.status);
+                line = this.input.readLine();
+            }
+        } catch (final IOException e) {
+            LOG.warning("Could not read previous results");
+        }
+    }
+
+    private void restoreClassPath() {
+        try {
+            final long classPathSize = Long.valueOf(this.input.readLine());
+            for (int i = 0; i != classPathSize; i++) {
+                final ClassHistory coverage = deserialize(this.input
+                    .readLine(), ClassHistory.class);
+                this.previousClassPath.put(coverage.getName(), coverage);
+            }
+        } catch (final IOException e) {
+            LOG.warning("Could not read previous classpath");
+        }
+    }
+
+    private <T> T deserialize(String string, Class<T> clazz) throws IOException {
+        try {
+            final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(Base64.decodeBase64(string));
+            ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+            return clazz.cast(objectInputStream.readObject());
+        } catch (ClassNotFoundException e) {
+            throw Unchecked.translateCheckedException(e);
+        }
+    }
+
+    private <T> String serialize(T t) {
+        try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+            objectOutputStream.writeObject(t);
+            return Base64.encodeBase64String(byteArrayOutputStream.toByteArray());
+        } catch (IOException e) {
+            throw Unchecked.translateCheckedException(e);
+        }
+    }
+
+    private static class IdResult implements Serializable {
+        final MutationIdentifier     id;
+        final MutationStatusTestPair status;
+
+        IdResult(final MutationIdentifier id, final MutationStatusTestPair status) {
+            this.id = id;
+            this.status = status;
+        }
+
+    }
+
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStoreTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStoreTest.java
@@ -22,10 +22,7 @@ import org.pitest.mutationtest.MutationStatusTestPair;
 import org.pitest.mutationtest.engine.MutationIdentifier;
 import org.pitest.mutationtest.report.MutationTestResultMother;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringReader;
@@ -141,10 +138,6 @@ public class ObjectOutputStreamHistoryStoreTest {
         this.testee.initialize();
 
         assertFalse(this.testee.getHistoricResults().isEmpty());
-    }
-
-    private InputStream convertOutputStreamToInputStream(ByteArrayOutputStream os) {
-        return new ByteArrayInputStream(os.toByteArray());
     }
 
     private void recordClassPathWithTestee(

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStoreTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStoreTest.java
@@ -1,0 +1,158 @@
+package org.pitest.mutationtest.incremental;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.pitest.classinfo.ClassIdentifier;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classinfo.HierarchicalClassId;
+import org.pitest.coverage.CoverageDatabase;
+import org.pitest.functional.Option;
+import org.pitest.mutationtest.ClassHistory;
+import org.pitest.mutationtest.DetectionStatus;
+import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.MutationStatusTestPair;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.mutationtest.report.MutationTestResultMother;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ObjectOutputStreamHistoryStoreTest {
+
+    private static final String             COV           = BigInteger.TEN.toString(16);
+
+    private ObjectOutputStreamHistoryStore  testee;
+
+    @Mock
+    private CoverageDatabase                coverage;
+
+    private final Writer                    output        = new StringWriter();
+
+    private final WriterFactory             writerFactory = new WriterFactory() {
+
+        @Override
+        public PrintWriter create() {
+            return new PrintWriter(
+                ObjectOutputStreamHistoryStoreTest.this.output);
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+    };
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(this.coverage.getCoverageIdForClass(any(ClassName.class))).thenReturn(
+            BigInteger.TEN);
+    }
+
+    @Test
+    public void shouldRecordAndRetrieveClassPath() {
+        final ClassHistory foo = new ClassHistory(new HierarchicalClassId(
+            new ClassIdentifier(0, ClassName.fromString("foo")), ""), COV);
+        final ClassHistory bar = new ClassHistory(new HierarchicalClassId(
+            new ClassIdentifier(0, ClassName.fromString("bar")), ""), COV);
+
+        recordClassPathWithTestee(foo.getId(), bar.getId());
+
+        final Reader reader = new StringReader(this.output.toString());
+        this.testee = new ObjectOutputStreamHistoryStore(this.writerFactory,
+            Option.some(reader));
+        this.testee.initialize();
+
+        final Map<ClassName, ClassHistory> expected = new HashMap<ClassName, ClassHistory>();
+        expected.put(foo.getName(), foo);
+        expected.put(bar.getName(), bar);
+        assertEquals(expected, this.testee.getHistoricClassPath());
+    }
+
+    @Test
+    public void shouldRecordAndRetrieveResults() {
+        final HierarchicalClassId foo = new HierarchicalClassId(
+            new ClassIdentifier(0, ClassName.fromString("foo")), "");
+        recordClassPathWithTestee(foo);
+
+        final MutationResult mr = new MutationResult(
+            MutationTestResultMother.createDetails("foo"),
+            new MutationStatusTestPair(1, DetectionStatus.KILLED, "testName"));
+
+        this.testee.recordResult(mr);
+
+        final Reader reader = new StringReader(this.output.toString());
+        this.testee = new ObjectOutputStreamHistoryStore(this.writerFactory,
+            Option.some(reader));
+        this.testee.initialize();
+        final Map<MutationIdentifier, MutationStatusTestPair> expected = new HashMap<MutationIdentifier, MutationStatusTestPair>();
+        expected.put(mr.getDetails().getId(), mr.getStatusTestPair());
+        assertEquals(expected, this.testee.getHistoricResults());
+    }
+
+    @Test
+    public void shouldNotAttemptToWriteToFileWhenNoneSupplied() {
+        try {
+            this.testee = new ObjectOutputStreamHistoryStore(this.writerFactory,
+                Option.<Reader> none());
+            this.testee.initialize();
+        } catch (final Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldReadCorruptFiles() throws IOException {
+        final HierarchicalClassId foo = new HierarchicalClassId(
+            new ClassIdentifier(0, ClassName.fromString("foo")), "");
+        recordClassPathWithTestee(foo);
+
+        final MutationResult mr = new MutationResult(
+            MutationTestResultMother.createDetails("foo"),
+            new MutationStatusTestPair(1, DetectionStatus.KILLED, "testName"));
+
+        this.testee.recordResult(mr);
+        this.output.append("rubbish");
+
+        final Reader reader = new StringReader(this.output.toString());
+        this.testee = new ObjectOutputStreamHistoryStore(this.writerFactory,
+            Option.some(reader));
+        this.testee.initialize();
+
+        assertFalse(this.testee.getHistoricResults().isEmpty());
+    }
+
+    private InputStream convertOutputStreamToInputStream(ByteArrayOutputStream os) {
+        return new ByteArrayInputStream(os.toByteArray());
+    }
+
+    private void recordClassPathWithTestee(
+        final HierarchicalClassId... classIdentifiers) {
+        this.testee = new ObjectOutputStreamHistoryStore(this.writerFactory,
+            Option.<Reader> none());
+        final Collection<HierarchicalClassId> ids = Arrays.asList(classIdentifiers);
+        this.testee.recordClassPath(ids, this.coverage);
+    }
+
+}

--- a/pitest/src/main/java/org/pitest/classinfo/ClassIdentifier.java
+++ b/pitest/src/main/java/org/pitest/classinfo/ClassIdentifier.java
@@ -1,6 +1,8 @@
 package org.pitest.classinfo;
 
-public final class ClassIdentifier {
+import java.io.Serializable;
+
+public final class ClassIdentifier implements Serializable {
 
   private final long      hash;
   private final ClassName name;

--- a/pitest/src/main/java/org/pitest/classinfo/ClassName.java
+++ b/pitest/src/main/java/org/pitest/classinfo/ClassName.java
@@ -14,14 +14,15 @@
  */
 package org.pitest.classinfo;
 
-import java.util.logging.Logger;
-
 import org.pitest.functional.F;
 import org.pitest.functional.Option;
 import org.pitest.util.IsolationUtils;
 import org.pitest.util.Log;
 
-public final class ClassName implements Comparable<ClassName> {
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+public final class ClassName implements Comparable<ClassName>, Serializable {
 
   private static final Logger LOG = Log.getLogger();
   

--- a/pitest/src/main/java/org/pitest/classinfo/HierarchicalClassId.java
+++ b/pitest/src/main/java/org/pitest/classinfo/HierarchicalClassId.java
@@ -1,8 +1,9 @@
 package org.pitest.classinfo;
 
+import java.io.Serializable;
 import java.math.BigInteger;
 
-public final class HierarchicalClassId {
+public final class HierarchicalClassId implements Serializable {
 
   private final ClassIdentifier classId;
   private final String          hierarchicalHash;

--- a/pitest/src/main/java/org/pitest/functional/Option.java
+++ b/pitest/src/main/java/org/pitest/functional/Option.java
@@ -14,11 +14,12 @@
  */
 package org.pitest.functional;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
-public abstract class Option<T> implements FunctionalIterable<T> {
+public abstract class Option<T> implements FunctionalIterable<T>, Serializable {
 
   @SuppressWarnings({ "rawtypes" })
   private static final None NONE = new None();

--- a/pitest/src/main/java/org/pitest/mutationtest/MutationStatusTestPair.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/MutationStatusTestPair.java
@@ -16,7 +16,9 @@ package org.pitest.mutationtest;
 
 import org.pitest.functional.Option;
 
-public final class MutationStatusTestPair {
+import java.io.Serializable;
+
+public final class MutationStatusTestPair implements Serializable {
 
   private final int             numberOfTestsRun;
   private final DetectionStatus status;

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/Location.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/Location.java
@@ -16,11 +16,13 @@ package org.pitest.mutationtest.engine;
 
 import org.pitest.classinfo.ClassName;
 
+import java.io.Serializable;
+
 /**
  * The co-ordinates of a method within a class.
  *
  */
-public final class Location implements Comparable<Location> {
+public final class Location implements Comparable<Location>, Serializable {
 
   private final ClassName  clazz;
   private final MethodName method;

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/MethodName.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/MethodName.java
@@ -1,6 +1,8 @@
 package org.pitest.mutationtest.engine;
 
-public class MethodName {
+import java.io.Serializable;
+
+public class MethodName implements Serializable {
 
   private final String name;
 

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/MutationIdentifier.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/MutationIdentifier.java
@@ -14,17 +14,18 @@
  */
 package org.pitest.mutationtest.engine;
 
+import org.pitest.classinfo.ClassName;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.pitest.classinfo.ClassName;
-
 /**
  * Uniquely identifies a mutation
  */
-public final class MutationIdentifier implements Comparable<MutationIdentifier> {
+public final class MutationIdentifier implements Comparable<MutationIdentifier>, Serializable {
 
   /**
    * The location at which the mutation occurs


### PR DESCRIPTION
Unfortunately adds commons-codec as a dependency for base 64 encoding

(I experimented with DatatypeConverter, but needing to do --add-modules java.xml.bind when running java/javac in java 9 was proving problematic)

N.B. I've left the XStreamHistoryStore there and that is still the implementation used in EntryPoint.java