### PR TITLE
Added configuration parameter to filter executed methods of target tests 

### DIFF
--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -212,6 +212,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
     this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
   }
 
+  public void setIncludedTestMethods(final String value) {
+    this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
+  }
+
   public void setHistoryInputLocation(final String value) {
     this.setOption(ConfigOption.HISTORY_INPUT_LOCATION, value);
   }

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -233,6 +233,13 @@ public class PitestTaskTest {
   }
 
   @Test
+  public void shouldPassIncludedTestMethodsOptionToJavaTask() {
+    this.pitestTask.setIncludedTestMethods("footest");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--includedTestMethods=footest");
+  }
+
+  @Test
   public void shouldPassMutableCodePathsToJavaTask() {
     this.pitestTask.setMutableCodePaths("foo");
     this.pitestTask.execute(this.java);

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -31,6 +31,7 @@ import static org.pitest.mutationtest.config.ConfigOption.FEATURES;
 import static org.pitest.mutationtest.config.ConfigOption.HISTORY_INPUT_LOCATION;
 import static org.pitest.mutationtest.config.ConfigOption.HISTORY_OUTPUT_LOCATION;
 import static org.pitest.mutationtest.config.ConfigOption.INCLUDED_GROUPS;
+import static org.pitest.mutationtest.config.ConfigOption.INCLUDED_TEST_METHODS;
 import static org.pitest.mutationtest.config.ConfigOption.INCLUDE_LAUNCH_CLASSPATH;
 import static org.pitest.mutationtest.config.ConfigOption.JVM_PATH;
 import static org.pitest.mutationtest.config.ConfigOption.MAX_MUTATIONS_PER_CLASS;
@@ -113,6 +114,7 @@ public class OptionsParser {
   private final ArgumentAcceptingOptionSpec<String>  codePaths;
   private final OptionSpec<String>                   excludedGroupsSpec;
   private final OptionSpec<String>                   includedGroupsSpec;
+  private final OptionSpec<String>                   includedTestMethodsSpec;
   private final OptionSpec<Integer>                  mutationUnitSizeSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> timestampedReportsSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> detectInlinedCode;
@@ -282,6 +284,10 @@ public class OptionsParser {
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("TestNG groups/JUnit categories to include");
 
+    this.includedTestMethodsSpec = parserAccepts(INCLUDED_TEST_METHODS).withRequiredArg()
+            .ofType(String.class).withValuesSeparatedBy(',')
+            .describedAs("Test methods that should be included for challenging the mutants");
+
     this.excludedGroupsSpec = parserAccepts(EXCLUDED_GROUPS).withRequiredArg()
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("TestNG groups/JUnit categories to include");
@@ -409,6 +415,8 @@ public class OptionsParser {
     setClassPath(userArgs, data);
 
     setTestGroups(userArgs, data);
+
+    data.setIncludedTestMethods(this.includedTestMethodsSpec.values(userArgs));
     data.setJavaExecutable(this.javaExecutable.value(userArgs));
 
     if (userArgs.has("?")) {

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -329,6 +329,14 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldParseCommaSeparatedListOfIncludedTestMethods() {
+    final ReportOptions actual = parseAddingRequiredArgs("--includedTestMethods",
+            "foo,bar");
+    assertEquals(Arrays.asList("foo", "bar"), actual
+        .getIncludedTestMethods());
+  }
+
+  @Test
   public void shouldParseMutationUnitSize() {
     final ReportOptions actual = parseAddingRequiredArgs("--mutationUnitSize",
         "50");

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -137,6 +137,10 @@ public enum ConfigOption {
    */
   INCLUDED_GROUPS("includedGroups"),
   /**
+   * Test methods that should be included for challenging the mutants
+   */
+  INCLUDED_TEST_METHODS("includedTestMethods"),
+  /**
    * TestNG groupsJUnit categories to exclude
    */
   EXCLUDED_GROUPS("excludedGroups"),

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -129,6 +129,7 @@ public class ReportOptions {
   private int maxSurvivors;
   
   private Collection<String>             excludedRunners                = new ArrayList<>();
+  private Collection<String>             includedTestMethods            = new ArrayList<>();
   
   private String                         testPlugin                     = "";
 
@@ -566,15 +567,24 @@ public class ReportOptions {
     return excludedRunners;
   }
 
+  public Collection<String> getIncludedTestMethods() {
+    return includedTestMethods;
+  }
+
   public void setExcludedRunners(Collection<String> excludedRunners) {
     this.excludedRunners = excludedRunners;
+  }
+
+  public void setIncludedTestMethods(Collection<String> includedTestMethods) {
+    this.includedTestMethods = includedTestMethods;
   }
 
   /**
    * Creates a serializable subset of data for use in child processes
    */
   public TestPluginArguments createMinionSettings() {
-    return new TestPluginArguments(getTestPlugin(), this.getGroupConfig(), this.getExcludedRunners());
+    return new TestPluginArguments(getTestPlugin(), this.getGroupConfig(), this.getExcludedRunners(),
+            this.getIncludedTestMethods());
   }
 
   public String getTestPlugin() {
@@ -610,7 +620,8 @@ public class ReportOptions {
         + mutationEngine + ", javaExecutable=" + javaExecutable
         + ", includeLaunchClasspath=" + includeLaunchClasspath + ", properties="
         + properties + ", maxSurvivors=" + maxSurvivors + ", excludedRunners="
-        + excludedRunners + ", testPlugin=" + testPlugin + "]";
+        + excludedRunners + ", testPlugin=" + testPlugin + ", includedTestMethods="
+        + includedTestMethods + "]";
   }
   
 }

--- a/pitest-groovy-verification/src/test/java/org/pitest/groovy/verification/TestJUnitConfigurationForSpock.java
+++ b/pitest-groovy-verification/src/test/java/org/pitest/groovy/verification/TestJUnitConfigurationForSpock.java
@@ -22,7 +22,8 @@ import com.example.spock.ParametrizedSpockTest;
 
 public class TestJUnitConfigurationForSpock {
   
-  private final JUnitCompatibleConfiguration testee = new JUnitCompatibleConfiguration(new TestGroupConfig(), Collections.<String>emptyList());
+  private final JUnitCompatibleConfiguration testee = new JUnitCompatibleConfiguration(new TestGroupConfig(),
+          Collections.<String>emptyList(), Collections.<String>emptyList());
   private Pitest                             pitest;
   private Container                          container;
 

--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -211,6 +211,11 @@ public class AbstractPitMojo extends AbstractMojo {
   private ArrayList<String>           includedGroups;
 
   /**
+   * Test methods that should be included for challenging the mutants
+   */
+  @Parameter(property = "includedTestMethods")
+  private ArrayList<String>           includedTestMethods;
+  /**
    * Maximum number of mutations to include in a single analysis unit.
    * 
    * If set to 1 will analyse very slowly, but with strong (jvm per mutant)
@@ -528,6 +533,10 @@ public class AbstractPitMojo extends AbstractMojo {
 
   public List<String> getIncludedGroups() {
     return this.includedGroups;
+  }
+
+  public List<String> getIncludedTestMethods() {
+    return this.includedTestMethods;
   }
 
   public int getMutationUnitSize() {

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -144,6 +144,7 @@ public class MojoToReportOptionsConverter {
     data.setMutationEngine(this.mojo.getMutationEngine());
     data.setJavaExecutable(this.mojo.getJavaExecutable());
     data.setFreeFormProperties(createPluginProperties());
+    data.setIncludedTestMethods(this.mojo.getIncludedTestMethods());
 
     return data;
   }

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -256,6 +256,12 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
         .getIncludedGroups());
   }
 
+  public void testParsesTestMethodsToInclude() {
+    final ReportOptions actual = parseConfig("<includedTestMethods><value>foo</value><value>bar</value></includedTestMethods>");
+    assertEquals(Arrays.asList("foo", "bar"), actual
+            .getIncludedTestMethods());
+  }
+
   public void testMaintainsOrderOfClassPath() {
     final ReportOptions actual = parseConfig("<includedGroups><value>foo</value><value>bar</value></includedGroups>");
     assertEquals(this.classPath, actual.getClassPathElements());

--- a/pitest/src/main/java/org/pitest/junit/JUnitCompatibleConfiguration.java
+++ b/pitest/src/main/java/org/pitest/junit/JUnitCompatibleConfiguration.java
@@ -31,19 +31,22 @@ public class JUnitCompatibleConfiguration implements Configuration {
 
   private final TestGroupConfig config;
   private final Collection<String> excludedRunners;
+  private final Collection<String> includedTestMethods;
 
   private static final JUnitVersion MIN_JUNIT_VERSION = JUnitVersion.parse("4.6");
   
-  public JUnitCompatibleConfiguration(TestGroupConfig config, Collection<String> excludedRunners) {
+  public JUnitCompatibleConfiguration(TestGroupConfig config, Collection<String> excludedRunners,
+                                      Collection<String> includedTestMethods) {
     Preconditions.checkNotNull(config);
     this.config = config;
     this.excludedRunners = excludedRunners;
+    this.includedTestMethods = includedTestMethods;
   }
 
   @Override
   public TestUnitFinder testUnitFinder() {
     return new CompoundTestUnitFinder(Arrays.asList(
-        new JUnitCustomRunnerTestUnitFinder(config, excludedRunners),
+        new JUnitCustomRunnerTestUnitFinder(config, excludedRunners, includedTestMethods),
         new ParameterisedJUnitTestFinder()));
   }
 

--- a/pitest/src/main/java/org/pitest/junit/JUnitTestPlugin.java
+++ b/pitest/src/main/java/org/pitest/junit/JUnitTestPlugin.java
@@ -33,9 +33,9 @@ public class JUnitTestPlugin implements TestPluginFactory {
 
   @Override
   public Configuration createTestFrameworkConfiguration(TestGroupConfig config,
-      ClassByteArraySource source, Collection<String> excludedRunners) {
+      ClassByteArraySource source, Collection<String> excludedRunners, Collection<String> includedTestMethods) {
     Preconditions.checkNotNull(config);
-    return new JUnitCompatibleConfiguration(config, excludedRunners);
+    return new JUnitCompatibleConfiguration(config, excludedRunners, includedTestMethods);
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/mutationtest/config/MinionSettings.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/MinionSettings.java
@@ -30,7 +30,8 @@ public class MinionSettings {
       if (each.name().equals(options.getTestPlugin())) {
         return each.createTestFrameworkConfiguration(options.getGroupConfig(),
             source,
-            options.getExcludedRunners());
+            options.getExcludedRunners(),
+            options.getIncludedTestMethods());
       }
     }
     throw new PitError("Could not load requested test plugin "

--- a/pitest/src/main/java/org/pitest/mutationtest/config/TestPluginArguments.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/TestPluginArguments.java
@@ -14,25 +14,29 @@ public class TestPluginArguments implements Serializable {
   
   private final String testPlugin;
   private final TestGroupConfig groupConfig;
+  private final Collection<String> includedTestMethods;
   private final Collection<String> excludedRunners;
    
   public TestPluginArguments(String testPlugin,
       TestGroupConfig groupConfig,
-      Collection<String> excludedRunners) {
+      Collection<String> excludedRunners,
+      Collection<String> includedTestMethods) {
     Preconditions.checkNotNull(testPlugin);
     Preconditions.checkNotNull(groupConfig);
     Preconditions.checkNotNull(excludedRunners);    
     this.testPlugin = testPlugin;
     this.groupConfig = groupConfig;
     this.excludedRunners = excludedRunners;
+    this.includedTestMethods = includedTestMethods;
   }
 
   public static TestPluginArguments defaults() {
-    return new TestPluginArguments(JUnitTestPlugin.NAME, new TestGroupConfig(), Collections.<String>emptyList());
+    return new TestPluginArguments(JUnitTestPlugin.NAME, new TestGroupConfig(), Collections.<String>emptyList(),
+            Collections.<String>emptyList());
   }
   
   public TestPluginArguments withTestPlugin(String plugin) {
-    return new TestPluginArguments(plugin, groupConfig, excludedRunners);
+    return new TestPluginArguments(plugin, groupConfig, excludedRunners, includedTestMethods);
   }
   
   public TestGroupConfig getGroupConfig() {
@@ -41,6 +45,10 @@ public class TestPluginArguments implements Serializable {
 
   public Collection<String> getExcludedRunners() {
     return excludedRunners;
+  }
+
+  public Collection<String> getIncludedTestMethods() {
+    return includedTestMethods;
   }
 
   public String getTestPlugin() {

--- a/pitest/src/main/java/org/pitest/testapi/TestPluginFactory.java
+++ b/pitest/src/main/java/org/pitest/testapi/TestPluginFactory.java
@@ -8,7 +8,7 @@ import org.pitest.plugin.ClientClasspathPlugin;
 public interface TestPluginFactory extends ClientClasspathPlugin {
 
   Configuration createTestFrameworkConfiguration(TestGroupConfig config,
-      ClassByteArraySource source, Collection<String> excludedRunners);
+      ClassByteArraySource source, Collection<String> excludedRunners, Collection<String> includedTestMethods);
 
   String name();
 

--- a/pitest/src/main/java/org/pitest/testng/TestNGConfiguration.java
+++ b/pitest/src/main/java/org/pitest/testng/TestNGConfiguration.java
@@ -14,6 +14,7 @@
  */
 package org.pitest.testng;
 
+import java.util.Collection;
 import org.pitest.extension.common.NoTestSuiteFinder;
 import org.pitest.functional.Option;
 import org.pitest.help.PitHelpError;
@@ -25,14 +26,16 @@ import org.pitest.testapi.TestUnitFinder;
 public class TestNGConfiguration implements Configuration {
 
   private final TestGroupConfig config;
+  private final Collection<String> includedTestMethods;
 
-  public TestNGConfiguration(final TestGroupConfig config) {
+  public TestNGConfiguration(final TestGroupConfig config, final Collection<String> includedTestMethods) {
     this.config = config;
+    this.includedTestMethods = includedTestMethods;
   }
 
   @Override
   public TestUnitFinder testUnitFinder() {
-    return new TestNGTestUnitFinder(this.config);
+    return new TestNGTestUnitFinder(this.config, this.includedTestMethods);
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/testng/TestNGPlugin.java
+++ b/pitest/src/main/java/org/pitest/testng/TestNGPlugin.java
@@ -16,8 +16,8 @@ public class TestNGPlugin implements TestPluginFactory {
 
   @Override
   public Configuration createTestFrameworkConfiguration(TestGroupConfig config,
-      ClassByteArraySource source, Collection<String> excludedRunners) {
-    return new TestNGConfiguration(config);
+      ClassByteArraySource source, Collection<String> excludedRunner, Collection<String> includedTestMethods) {
+    return new TestNGConfiguration(config, includedTestMethods);
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/testng/TestNGTestUnitFinder.java
+++ b/pitest/src/main/java/org/pitest/testng/TestNGTestUnitFinder.java
@@ -15,6 +15,7 @@
 package org.pitest.testng;
 
 import java.lang.reflect.Modifier;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,17 +29,17 @@ import org.pitest.testapi.TestUnitFinder;
 public class TestNGTestUnitFinder implements TestUnitFinder {
 
   private final TestGroupConfig config;
+  private final Collection<String> includedTestMethods;
 
-  public TestNGTestUnitFinder(final TestGroupConfig config) {
+  public TestNGTestUnitFinder(final TestGroupConfig config, final Collection<String> includedTestMethods) {
     this.config = config;
+    this.includedTestMethods = includedTestMethods;
   }
 
   @Override
   public List<TestUnit> findTestUnits(final Class<?> clazz) {
-
     if (!isAbstract(clazz) && (hasClassAnnotation(clazz) || hasMethodAnnotation(clazz))) {
-      return Collections.<TestUnit> singletonList(new TestNGTestUnit(clazz,
-          this.config));
+      return Collections.<TestUnit> singletonList(new TestNGTestUnit(clazz, this.config, this.includedTestMethods));
     }
     return Collections.emptyList();
 

--- a/pitest/src/test/java/org/pitest/TestJUnitConfiguration.java
+++ b/pitest/src/test/java/org/pitest/TestJUnitConfiguration.java
@@ -54,6 +54,7 @@ public class TestJUnitConfiguration {
 
   private  JUnitCompatibleConfiguration testee = new JUnitCompatibleConfiguration(
                                                         new TestGroupConfig(), 
+                                                        Collections.<String>emptyList(),
                                                         Collections.<String>emptyList());
   private Pitest                             pitest;
   private Container                          container;
@@ -629,7 +630,7 @@ public class TestJUnitConfiguration {
     List<String> include = Collections.emptyList();
     testee = new JUnitCompatibleConfiguration(
             new TestGroupConfig(include,exclude), 
-            Collections.<String>emptyList());
+            Collections.<String>emptyList(), Collections.<String>emptyList());
   }
 
   private void run(final Class<?> clazz) {

--- a/pitest/src/test/java/org/pitest/junit/JUnitCompatibleConfigurationTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCompatibleConfigurationTest.java
@@ -15,7 +15,8 @@ public class JUnitCompatibleConfigurationTest {
   @Before
   public void setUp() throws Exception {
 
-    this.testee = new JUnitCompatibleConfiguration(new TestGroupConfig(), Collections.<String>emptyList());
+    this.testee = new JUnitCompatibleConfiguration(new TestGroupConfig(), Collections.<String>emptyList(),
+            Collections.<String>emptyList());
   }
 
   @Test

--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.pitest.testapi.TestGroupConfig.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,7 +63,18 @@ public class JUnitCustomRunnerTestUnitFinderTest {
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
-    this.testee = new JUnitCustomRunnerTestUnitFinder(new TestGroupConfig(), Collections.<String>emptyList());
+    this.testee = new JUnitCustomRunnerTestUnitFinder(new TestGroupConfig(), Collections.<String>emptyList(),
+            Collections.<String>emptyList());
+  }
+
+  @Test
+  public void shouldFindTheoryTestViaMethodNameTest() {
+    List<String> includedMethods = new ArrayList<>();
+    includedMethods.add("testTheory1");
+    includedMethods.add("testTheory3");
+    setIncludedTestMethods(includedMethods);
+    final Collection<TestUnit> actual = findWithTestee(TheoryTest.class);
+    assertEquals(2, actual.size());
   }
 
   @Test
@@ -427,7 +439,7 @@ public class JUnitCustomRunnerTestUnitFinderTest {
   
   private void setConfig(TestGroupConfig config) {
     testee = new JUnitCustomRunnerTestUnitFinder(
-        config, Collections.<String>emptyList()); 
+        config, Collections.<String>emptyList(), Collections.<String>emptyList());
   }
 
   
@@ -435,7 +447,15 @@ public class JUnitCustomRunnerTestUnitFinderTest {
     List<String> include = Collections.<String>emptyList();
     List<String> exclude = Collections.<String>emptyList();
     testee = new JUnitCustomRunnerTestUnitFinder(
-            new TestGroupConfig(include,exclude), Collections.singletonList(class1.getName()));
+            new TestGroupConfig(include,exclude), Collections.singletonList(class1.getName()),
+            Collections.<String>emptyList());
+  }
+
+  private void setIncludedTestMethods(Collection<String> includedTestMethods) {
+    List<String> include = Collections.<String>emptyList();
+    List<String> exclude = Collections.<String>emptyList();
+    testee = new JUnitCustomRunnerTestUnitFinder(
+            new TestGroupConfig(include,exclude), Collections.<String>emptyList(), includedTestMethods);
   }
 
   

--- a/pitest/src/test/java/org/pitest/simpletest/SimpleTestPlugin.java
+++ b/pitest/src/test/java/org/pitest/simpletest/SimpleTestPlugin.java
@@ -18,7 +18,7 @@ public class SimpleTestPlugin implements TestPluginFactory {
 
   @Override
   public Configuration createTestFrameworkConfiguration(TestGroupConfig config,
-      ClassByteArraySource source, Collection<String> excludedRunners) {
+      ClassByteArraySource source, Collection<String> excludedRunners, Collection<String> includedMethods) {
     return new ConfigurationForTesting();
   }
 

--- a/pitest/src/test/java/org/pitest/testng/TestNGConfigurationTest.java
+++ b/pitest/src/test/java/org/pitest/testng/TestNGConfigurationTest.java
@@ -16,6 +16,7 @@ package org.pitest.testng;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.functional.Option;
@@ -27,7 +28,7 @@ public class TestNGConfigurationTest {
 
   @Before
   public void setUp() {
-    this.testee = new TestNGConfiguration(new TestGroupConfig(null, null));
+    this.testee = new TestNGConfiguration(new TestGroupConfig(null, null), Collections.<String> emptyList());
   }
 
   @Test

--- a/pitest/src/test/java/org/pitest/testng/TestNGTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/testng/TestNGTestUnitFinderTest.java
@@ -34,7 +34,7 @@ public class TestNGTestUnitFinderTest {
   public void setUp() {
     final TestGroupConfig config = new TestGroupConfig(
         Collections.<String> emptyList(), Collections.<String> emptyList());
-    this.testee = new TestNGTestUnitFinder(config);
+    this.testee = new TestNGTestUnitFinder(config, Collections.<String> emptyList());
   }
 
   @Test


### PR DESCRIPTION
This is a pull request for issue #437 

I tried to be as close as possible to the naming convention and coding style of the project. I also made sure that the tests are running and I created a few new tests for the change.

The goal of this change is to filter the executed tests of a test class.  Hence, I added a new configuration parameter (includedTestMethods) for pitest in which you can put in a name (or names) of a test method and pitest only executes these methods for the targeted tests. The idea is to change the  *TestUnitFinder classes. There, I implemented something similar to the Category-based filtering mechanism.
