### PR TITLE
Escape test names when generating coverage xml file

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
@@ -54,7 +54,7 @@ public class DefaultCoverageExporter implements CoverageExporter {
     final List<String> ts = new ArrayList<>(each.getTests());
     Collections.sort(ts);
     for (final String test : ts) {
-      write(out, "<test name='" + test + "'/>\n");
+      write(out, "<test name='" + StringUtil.escapeBasicHtmlChars(test) + "'/>\n");
     }
     write(out, "</tests>\n");
     write(out, "</block>\n");

--- a/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
@@ -66,4 +66,22 @@ public class DefaultCoverageExporterTest {
         "<tests>\n<test name='Test3'/>\n<test name='Test4'/>\n</tests>");
   }
 
+  @Test
+  public void shouldEscapeSpecialCharsInTestName() {
+    final LocationBuilder loc = aLocation().withMethod("method");
+    final BlockLocationBuilder block = aBlockLocation().withBlock(42);
+    final Collection<BlockCoverage> coverage = Collections
+        .singletonList(new BlockCoverage(
+            block.withLocation(loc.withClass(ClassName.fromString("Foo")))
+                .build(),
+            Collections.singletonList(
+                "ParameterizedTest[case='Not so simple quotes']")));
+
+    testee.recordCoverage(coverage);
+
+    final String actual = this.out.toString();
+    assertThat(actual).contains(
+        "<tests>\n<test name='ParameterizedTest[case=&#39;Not so simple quotes&#39;]'/>\n</tests>");
+  }
+
 }


### PR DESCRIPTION
Test names are usually just method names which can be written in xml without escaping. However, when using Junit's parameterized tests, the test name can be any string the developer of the test choose to use.

Before this commit, if the test name include a quote, the generated xml is not valid.

By using `StringUtil.escapeBasicHtmlChars` on the test name, this commit ensures that any test name can be represented as a valid xml value.

For instance, before this commit, a test named `let's test this!` would have appeared in coverage xml file as `<test name='let's go test this!'/>` which is not valid xml. With this commit it will appear as `<test name='let&#39;s go test this!'/>`.
