### PR TITLE
Ignore absent code directories when aggregating report

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 import org.pitest.classpath.CodeSource;
 import org.pitest.coverage.BlockCoverage;
@@ -27,6 +28,7 @@ import org.pitest.mutationtest.MutationResultListener;
 import org.pitest.mutationtest.SourceLocator;
 import org.pitest.mutationtest.report.html.MutationHtmlReportListener;
 import org.pitest.mutationtest.tooling.SmartSourceLocator;
+import org.pitest.util.Log;
 import org.pitest.util.ResultOutputStrategy;
 
 public final class ReportAggregator {
@@ -109,6 +111,9 @@ public final class ReportAggregator {
   }
 
   public static class Builder {
+
+    private static final Logger  LOG = Log.getLogger();
+
     private ResultOutputStrategy resultOutputStrategy;
     private final Set<File>      lineCoverageFiles       = new HashSet<>();
     private final Set<File>      mutationResultsFiles    = new HashSet<>();
@@ -158,7 +163,11 @@ public final class ReportAggregator {
 
     public Builder addSourceCodeDirectory(final File sourceCodeDirectory) {
       validateDirectory(sourceCodeDirectory);
-      this.sourceCodeDirectories.add(sourceCodeDirectory);
+      if (sourceCodeDirectory.exists()) {
+        this.sourceCodeDirectories.add(sourceCodeDirectory);
+      } else {
+        LOG.info("ignoring absent source code directory " + sourceCodeDirectory.getAbsolutePath());
+      }
       return this;
     }
 
@@ -172,7 +181,11 @@ public final class ReportAggregator {
 
     public Builder addCompiledCodeDirectory(final File compiledCodeDirectory) {
       validateDirectory(compiledCodeDirectory);
-      this.compiledCodeDirectories.add(compiledCodeDirectory);
+      if (compiledCodeDirectory.exists()) {
+        this.compiledCodeDirectories.add(compiledCodeDirectory);
+      } else {
+        LOG.info("ignoring absent compiled code directory " + compiledCodeDirectory.getAbsolutePath());
+      }
       return this;
     }
 
@@ -231,8 +244,10 @@ public final class ReportAggregator {
       if (directory == null) {
         throw new IllegalArgumentException("directory is null");
       }
-      if (!directory.exists() || !directory.isDirectory()) {
-        throw new IllegalArgumentException(directory.getAbsolutePath() + " does not exist or is not a directory");
+      // For this method, a non existing directory is valid.
+      // It probably needs some special treatment later, but it shouldn't prevent the aggregator to be built.
+      if (directory.exists() && !directory.isDirectory()) {
+        throw new IllegalArgumentException(directory.getAbsolutePath() + " is not a directory");
       }
     }
   }

--- a/pitest-aggregator/src/test/java/org/pitest/aggregate/ReportAggregatorBuilderTest.java
+++ b/pitest-aggregator/src/test/java/org/pitest/aggregate/ReportAggregatorBuilderTest.java
@@ -1,6 +1,7 @@
 package org.pitest.aggregate;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.pitest.aggregate.TestInvocationHelper.getCompiledDirectory;
 import static org.pitest.aggregate.TestInvocationHelper.getCoverageFile;
 import static org.pitest.aggregate.TestInvocationHelper.getMutationFile;
@@ -20,7 +21,7 @@ import org.junit.rules.ExpectedException;
 public class ReportAggregatorBuilderTest {
 
   private static final String NOT_A_FILE = "does not exist or is not a file";
-  private static final String NOT_A_DIR  = "does not exist or is not a directory";
+  private static final String NOT_A_DIR  = "is not a directory";
   private static final String IS_NULL    = "is null";
   @Rule
   public ExpectedException    expected   = ExpectedException.none();
@@ -83,10 +84,10 @@ public class ReportAggregatorBuilderTest {
 
   @Test
   public void testSourceCodeDirectories_withFake() {
-    this.expected.expect(IllegalArgumentException.class);
-    this.expected.expectMessage(Matchers.containsString(NOT_A_DIR));
+    ReportAggregator.Builder builder = ReportAggregator.builder()
+        .sourceCodeDirectories(Arrays.asList(new File("fakedirectory")));
 
-    ReportAggregator.builder().sourceCodeDirectories(Arrays.asList(new File("fakedirectory")));
+    assertTrue(builder.getSourceCodeDirectories().isEmpty());
   }
 
   @Test
@@ -107,10 +108,10 @@ public class ReportAggregatorBuilderTest {
 
   @Test
   public void testCompiledCodeDirectories_withFake() {
-    this.expected.expect(IllegalArgumentException.class);
-    this.expected.expectMessage(Matchers.containsString(NOT_A_DIR));
+    ReportAggregator.Builder builder = ReportAggregator.builder()
+        .compiledCodeDirectories(Arrays.asList(new File("fakedirectory")));
 
-    ReportAggregator.builder().compiledCodeDirectories(Arrays.asList(new File("fakedirectory")));
+    assertTrue(builder.getCompiledCodeDirectories().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Current state

Currently, the ReportAggregator builder requires all code directories it works with to be non null, to exist, and to actually be directories. This is standard argument checking and it works just fine for most cases.

However, this behavior is problematic with some maven project structures.

In a maven project using submodules, one may choose to add a non standard source directory. This may be configured in the root pom and applied to all submodules. If this directory has a special purpose, for instance code generated by a given tool, it may not be used by all submodules.

In such a project, when listing source directories, plugins will see the additional source folder everytime, even for submodules where it is not used.

Because of the checks done in ReportAggregator, pitest report aggregation fails when this directory is not present.

## Proposed solution

Some maven plugins works fine in the same situation, for instance, maven-resources-plugin just logs that a given folder was not found and continues its execution.

I propose we do the same here.