### PR TITLE
produce valid xml for null-byte in test name

### DIFF
--- a/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
@@ -70,18 +70,22 @@ public class DefaultCoverageExporterTest {
   public void shouldEscapeSpecialCharsInTestName() {
     final LocationBuilder loc = aLocation().withMethod("method");
     final BlockLocationBuilder block = aBlockLocation().withBlock(42);
-    final Collection<BlockCoverage> coverage = Collections
-        .singletonList(new BlockCoverage(
-            block.withLocation(loc.withClass(ClassName.fromString("Foo")))
-                .build(),
-            Collections.singletonList(
-                "ParameterizedTest[case='Not so simple quotes']")));
+    final Collection<BlockCoverage> coverage = Arrays.asList(
+        new BlockCoverage(
+            block.withLocation(loc.withClass(ClassName.fromString("Foo"))).build(),
+            Collections.singletonList("ParameterizedTest[case='Not so simple quotes']")),
+        new BlockCoverage(
+            block.withLocation(loc.withClass(ClassName.fromString("Foo"))).build(),
+            Collections.singletonList("ParameterizedTest[case=\0 Null-Byte]"))
+        );
 
     testee.recordCoverage(coverage);
 
     final String actual = this.out.toString();
     assertThat(actual).contains(
         "<tests>\n<test name='ParameterizedTest[case=&#39;Not so simple quotes&#39;]'/>\n</tests>");
+    assertThat(actual).contains(
+        "<tests>\n<test name='ParameterizedTest[case=\\0 Null-Byte]'/>\n</tests>");
   }
 
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/xml/XMLReportListenerTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/xml/XMLReportListenerTest.java
@@ -65,6 +65,14 @@ public class XMLReportListenerTest {
     assertTrue(this.out.toString().contains("&#60;foo&#62;"));
   }
 
+  @Test
+  public void shouldEscapeNullBytes() {
+    final MutationResult mr = createdKilledMutationWithKillingTestOf("\0 Null-Byte");
+    this.testee
+            .handleMutationResult(MutationTestResultMother.createClassResults(mr));
+    assertTrue(this.out.toString().contains("\\0 Null-Byte"));
+  }
+
   private MutationResult createdKilledMutationWithKillingTestOf(
       final String killingTest) {
     final MutationResult mr = new MutationResult(

--- a/pitest/src/main/java/org/pitest/util/StringUtil.java
+++ b/pitest/src/main/java/org/pitest/util/StringUtil.java
@@ -55,6 +55,12 @@ public class StringUtil {
     for (int i = 0; i < s.length(); i++) {
       final char c = s.charAt(i);
       final int v = c;
+
+      if (v == 0) {
+        out.append("\\0");
+        continue;
+      }
+
       if ((v < 32) || (v > 127) || (v == 38) || (v == 39) || (v == 60)
           || (v == 62) || (v == 34)) {
         out.append('&');


### PR DESCRIPTION
This solve #468.

A parameterized test name can be anything, and it can even include the null-byte.

It seems that the null-byte is not part of the valid character range for xml (see [Character Range in xml](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Char)), so we can not _encode_ it. But nothing prevents us from _representing_ it somehow, and this is what is proposed here.

With this PR, when we need to represent a null-byte in xml, we output `\0` instead. This is not perfect, reversible, a parser would not return a null-byte when reading `\0`, but I believe it to be good enough for reports generation.