### PR TITLE
Refactor aggregation mojos

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -1,21 +1,128 @@
 package org.pitest.maven.report;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.reporting.MavenReportException;
+import org.codehaus.plexus.util.FileUtils;
+import org.pitest.aggregate.ReportAggregator;
+import org.pitest.functional.FCollection;
+import org.pitest.maven.DependencyFilter;
+import org.pitest.mutationtest.config.DirectoryResultOutputStrategy;
+import org.pitest.mutationtest.config.PluginServices;
+import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
 
 /**
  * Common code for report aggregation mojo.
  */
 abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
 
-  static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
-  static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
+  private static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
+  private static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
 
   /**
    * The projects in the reactor.
    */
   @Parameter(property = "reactorProjects", readonly = true)
-  protected List<MavenProject> reactorProjects;
+  List<MavenProject> reactorProjects;
+
+  /**
+   * @return  projects to inspect for report files.
+   */
+  abstract Collection<MavenProject> findDependencies();
+
+  @Override
+  protected void executeReport(final Locale locale)
+      throws MavenReportException {
+    try {
+      final Collection<MavenProject> allProjects = findDependencies();
+
+      final ReportAggregator.Builder reportAggregationBuilder = ReportAggregator
+          .builder();
+
+      for (final MavenProject proj : allProjects) {
+        addProjectFiles(reportAggregationBuilder, proj);
+      }
+
+      final ReportAggregator reportAggregator = reportAggregationBuilder
+          .resultOutputStrategy(new DirectoryResultOutputStrategy(
+              getReportsDirectory().getAbsolutePath(),
+              new UndatedReportDirCreationStrategy()))
+          .build();
+
+      reportAggregator.aggregateReport();
+    } catch (final Exception e) {
+      throw new MavenReportException(e.getMessage(), e);
+    }
+  }
+
+  private void addProjectFiles(
+      final ReportAggregator.Builder reportAggregationBuilder,
+      final MavenProject proj) throws IOException, Exception {
+    final File projectBaseDir = proj.getBasedir();
+    List<File> files = getProjectFilesByFilter(projectBaseDir,
+        MUTATION_RESULT_FILTER);
+    for (final File file : files) {
+      reportAggregationBuilder.addMutationResultsFile(file);
+    }
+    files = getProjectFilesByFilter(projectBaseDir, LINECOVERAGE_FILTER);
+    for (final File file : files) {
+      reportAggregationBuilder.addLineCoverageFile(file);
+    }
+    files = convertToRootDirs(proj.getCompileSourceRoots(),
+        proj.getTestCompileSourceRoots());
+    for (final File file : files) {
+      reportAggregationBuilder.addSourceCodeDirectory(file);
+    }
+    files = getCompiledDirs(proj);
+    for (final File file : files) {
+      reportAggregationBuilder.addCompiledCodeDirectory(file);
+    }
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private List<File> convertToRootDirs(final List... directoryLists) {
+    final List<String> roots = new ArrayList<>();
+    for (final List directoryList : directoryLists) {
+      roots.addAll(directoryList);
+    }
+    return FCollection.map(roots, new Function<String, File>() {
+      @Override
+      public File apply(final String a) {
+        return new File(a);
+      }
+    });
+  }
+
+  private List<File> getProjectFilesByFilter(final File projectBaseDir,
+                                             final String filter) throws IOException {
+    final List<File> files = FileUtils.getFiles(projectBaseDir, filter, "");
+    return files == null ? new ArrayList<>() : files;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<File> getCompiledDirs(final MavenProject project)
+      throws Exception {
+    final List<String> sourceRoots = new ArrayList<>();
+    for (final Object artifactObj : FCollection
+        .filter(project.getPluginArtifactMap().values(), new DependencyFilter(
+            new PluginServices(this.getClass().getClassLoader())))) {
+
+      final Artifact artifact = (Artifact) artifactObj;
+      sourceRoots.add(artifact.getFile().getAbsolutePath());
+    }
+    return convertToRootDirs(project.getTestClasspathElements(),
+        Arrays.asList(project.getBuild().getOutputDirectory(),
+            project.getBuild().getTestOutputDirectory()),
+        sourceRoots);
+  }
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -1,5 +1,10 @@
 package org.pitest.maven.report;
 
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
+
 /**
  * Common code for report aggregation mojo.
  */
@@ -8,4 +13,9 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
   static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
   static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
 
+  /**
+   * The projects in the reactor.
+   */
+  @Parameter(property = "reactorProjects", readonly = true)
+  protected List<MavenProject> reactorProjects;
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -5,4 +5,7 @@ package org.pitest.maven.report;
  */
 abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
 
+  static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
+  static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
+
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -1,0 +1,8 @@
+package org.pitest.maven.report;
+
+/**
+ * Common code for report aggregation mojo.
+ */
+abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
+
+}

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
@@ -46,12 +46,6 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 @Mojo(name = "report-aggregate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class PitAggregationMojo extends AbstractPitAggregationReportMojo {
 
-  /**
-   * The projects in the reactor.
-   */
-  @Parameter(property = "reactorProjects", readonly = true)
-  private List<MavenProject>  reactorProjects;
-
   @Override
   public String getDescription(final Locale locale) {
     return getName(locale) + " Coverage Report.";

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
@@ -46,8 +46,6 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 @Mojo(name = "report-aggregate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class PitAggregationMojo extends AbstractPitAggregationReportMojo {
 
-  private static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
-  private static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
   /**
    * The projects in the reactor.
    */

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
@@ -44,7 +44,7 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
  *
  */
 @Mojo(name = "report-aggregate", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
-public class PitAggregationMojo extends PitReportMojo {
+public class PitAggregationMojo extends AbstractPitAggregationReportMojo {
 
   private static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
   private static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitAggregationMojo.java
@@ -1,10 +1,7 @@
 package org.pitest.maven.report;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
@@ -12,17 +9,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.reporting.MavenReportException;
-import org.codehaus.plexus.util.FileUtils;
-import org.pitest.aggregate.ReportAggregator;
-import java.util.function.Function;
-import org.pitest.functional.FCollection;
-import org.pitest.maven.DependencyFilter;
-import org.pitest.mutationtest.config.DirectoryResultOutputStrategy;
-import org.pitest.mutationtest.config.PluginServices;
-import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 
 /**
  * Goal which aggregates the results of multiple tests into a single result.
@@ -51,95 +38,10 @@ public class PitAggregationMojo extends AbstractPitAggregationReportMojo {
     return getName(locale) + " Coverage Report.";
   }
 
-  @Override
-  protected void executeReport(final Locale locale)
-      throws MavenReportException {
-    try {
-      final Collection<MavenProject> allProjects = findDependencies();
-
-      final ReportAggregator.Builder reportAggregationBuilder = ReportAggregator
-          .builder();
-
-      for (final MavenProject proj : allProjects) {
-        addProjectFiles(reportAggregationBuilder, proj);
-      }
-
-      final ReportAggregator reportAggregator = reportAggregationBuilder
-          .resultOutputStrategy(new DirectoryResultOutputStrategy(
-              getReportsDirectory().getAbsolutePath(),
-              new UndatedReportDirCreationStrategy()))
-          .build();
-
-      reportAggregator.aggregateReport();
-    } catch (final Exception e) {
-      throw new MavenReportException(e.getMessage(), e);
-    }
-  }
-
-  private void addProjectFiles(
-      final ReportAggregator.Builder reportAggregationBuilder,
-      final MavenProject proj) throws IOException, Exception {
-    final File projectBaseDir = proj.getBasedir();
-    List<File> files = getProjectFilesByFilter(projectBaseDir,
-        MUTATION_RESULT_FILTER);
-    for (final File file : files) {
-      reportAggregationBuilder.addMutationResultsFile(file);
-    }
-    files = getProjectFilesByFilter(projectBaseDir, LINECOVERAGE_FILTER);
-    for (final File file : files) {
-      reportAggregationBuilder.addLineCoverageFile(file);
-    }
-    files = convertToRootDirs(proj.getCompileSourceRoots(),
-        proj.getTestCompileSourceRoots());
-    for (final File file : files) {
-      reportAggregationBuilder.addSourceCodeDirectory(file);
-    }
-    files = getCompiledDirs(proj);
-    for (final File file : files) {
-      reportAggregationBuilder.addCompiledCodeDirectory(file);
-    }
-  }
-
-  @SuppressWarnings({ "rawtypes", "unchecked" })
-  private List<File> convertToRootDirs(final List... directoryLists) {
-    final List<String> roots = new ArrayList<>();
-    for (final List directoryList : directoryLists) {
-      roots.addAll(directoryList);
-    }
-    return FCollection.map(roots, new Function<String, File>() {
-      @Override
-      public File apply(final String a) {
-        return new File(a);
-      }
-    });
-  }
-
-  private List<File> getProjectFilesByFilter(final File projectBaseDir,
-      final String filter) throws IOException {
-    final List<File> files = FileUtils.getFiles(projectBaseDir, filter, "");
-    return files == null ? new ArrayList<>() : files;
-  }
-
-  @SuppressWarnings("unchecked")
-  private List<File> getCompiledDirs(final MavenProject project)
-      throws Exception {
-    final List<String> sourceRoots = new ArrayList<>();
-    for (final Object artifactObj : FCollection
-        .filter(project.getPluginArtifactMap().values(), new DependencyFilter(
-            new PluginServices(PitAggregationMojo.class.getClassLoader())))) {
-
-      final Artifact artifact = (Artifact) artifactObj;
-      sourceRoots.add(artifact.getFile().getAbsolutePath());
-    }
-    return convertToRootDirs(project.getTestClasspathElements(),
-        Arrays.asList(project.getBuild().getOutputDirectory(),
-            project.getBuild().getTestOutputDirectory()),
-        sourceRoots);
-  }
-
   // this method comes from
   // https://github.com/jacoco/jacoco/blob/master/jacoco-maven-plugin/src/org/jacoco/maven/ReportAggregateMojo.java
-  private List<MavenProject> findDependencies() {
+  @Override
+  List<MavenProject> findDependencies() {
     final List<MavenProject> result = new ArrayList<>();
     final List<String> scopeList = Arrays.asList(Artifact.SCOPE_COMPILE,
         Artifact.SCOPE_RUNTIME, Artifact.SCOPE_PROVIDED, Artifact.SCOPE_TEST);

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
@@ -46,8 +46,6 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 @Mojo(name = "report-aggregate-module", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, aggregator = true)
 public class PitReportAggregationModuleMojo extends AbstractPitAggregationReportMojo {
 
-  private static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
-  private static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";
   /**
    * The projects in the reactor.
    */

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
@@ -44,7 +44,7 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
  *
  */
 @Mojo(name = "report-aggregate-module", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, aggregator = true)
-public class PitReportAggregationModuleMojo extends PitReportMojo {
+public class PitReportAggregationModuleMojo extends AbstractPitAggregationReportMojo {
 
   private static final String MUTATION_RESULT_FILTER = "target/pit-reports/mutations.xml";
   private static final String LINECOVERAGE_FILTER    = "target/pit-reports/linecoverage.xml";

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
@@ -46,14 +46,6 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 @Mojo(name = "report-aggregate-module", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, aggregator = true)
 public class PitReportAggregationModuleMojo extends AbstractPitAggregationReportMojo {
 
-  /**
-   * The projects in the reactor.
-   */
-  @Parameter(property = "reactorProjects", readonly = true)
-  private List<MavenProject>  reactorProjects;
-
-
-
   @Override
   public String getDescription(final Locale locale) {
     return getName(locale) + " Coverage Report.";

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportAggregationModuleMojo.java
@@ -1,27 +1,11 @@
 package org.pitest.maven.report;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Function;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.reporting.MavenReportException;
-import org.codehaus.plexus.util.FileUtils;
-import org.pitest.aggregate.ReportAggregator;
-import org.pitest.functional.FCollection;
-import org.pitest.maven.DependencyFilter;
-import org.pitest.mutationtest.config.DirectoryResultOutputStrategy;
-import org.pitest.mutationtest.config.PluginServices;
-import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 
 /**
  * Goal which aggregates the results of multiple tests into a single result.
@@ -52,90 +36,7 @@ public class PitReportAggregationModuleMojo extends AbstractPitAggregationReport
   }
 
   @Override
-  protected void executeReport(final Locale locale)
-      throws MavenReportException {
-    try {
-
-      final Collection<MavenProject> allProjects = (List<MavenProject>) getProject().getCollectedProjects();
-
-
-      final ReportAggregator.Builder reportAggregationBuilder = ReportAggregator
-          .builder();
-
-      for (final MavenProject proj : allProjects) {
-        addProjectFiles(reportAggregationBuilder, proj);
-      }
-
-      final ReportAggregator reportAggregator = reportAggregationBuilder
-          .resultOutputStrategy(new DirectoryResultOutputStrategy(
-              getReportsDirectory().getAbsolutePath(),
-              new UndatedReportDirCreationStrategy()))
-          .build();
-
-      reportAggregator.aggregateReport();
-    } catch (final Exception e) {
-      throw new MavenReportException(e.getMessage(), e);
-    }
-  }
-
-  private void addProjectFiles(
-      final ReportAggregator.Builder reportAggregationBuilder,
-      final MavenProject proj) throws IOException, Exception {
-    final File projectBaseDir = proj.getBasedir();
-    List<File> files = getProjectFilesByFilter(projectBaseDir,
-        MUTATION_RESULT_FILTER);
-    for (final File file : files) {
-      reportAggregationBuilder.addMutationResultsFile(file);
-    }
-    files = getProjectFilesByFilter(projectBaseDir, LINECOVERAGE_FILTER);
-    for (final File file : files) {
-      reportAggregationBuilder.addLineCoverageFile(file);
-    }
-    files = convertToRootDirs(proj.getCompileSourceRoots(),
-        proj.getTestCompileSourceRoots());
-    for (final File file : files) {
-      reportAggregationBuilder.addSourceCodeDirectory(file);
-    }
-    files = getCompiledDirs(proj);
-    for (final File file : files) {
-      reportAggregationBuilder.addCompiledCodeDirectory(file);
-    }
-  }
-
-  @SuppressWarnings({ "rawtypes", "unchecked" })
-  private List<File> convertToRootDirs(final List... directoryLists) {
-    final List<String> roots = new ArrayList<>();
-    for (final List directoryList : directoryLists) {
-      roots.addAll(directoryList);
-    }
-    return FCollection.map(roots, new Function<String, File>() {
-      @Override
-      public File apply(final String a) {
-        return new File(a);
-      }
-    });
-  }
-
-  private List<File> getProjectFilesByFilter(final File projectBaseDir,
-      final String filter) throws IOException {
-    final List<File> files = FileUtils.getFiles(projectBaseDir, filter, "");
-    return files == null ? new ArrayList<>() : files;
-  }
-
-  @SuppressWarnings("unchecked")
-  private List<File> getCompiledDirs(final MavenProject project)
-      throws Exception {
-    final List<String> sourceRoots = new ArrayList<>();
-    for (final Object artifactObj : FCollection
-        .filter(project.getPluginArtifactMap().values(), new DependencyFilter(
-            new PluginServices(PitReportAggregationModuleMojo.class.getClassLoader())))) {
-
-      final Artifact artifact = (Artifact) artifactObj;
-      sourceRoots.add(artifact.getFile().getAbsolutePath());
-    }
-    return convertToRootDirs(project.getTestClasspathElements(),
-        Arrays.asList(project.getBuild().getOutputDirectory(),
-            project.getBuild().getTestOutputDirectory()),
-        sourceRoots);
+  List<MavenProject> findDependencies() {
+    return getProject().getCollectedProjects();
   }
 }


### PR DESCRIPTION
# Current state
There is two mojos for aggregated reports production :
 - `PitAggregationMojo` that select modules to aggregate based on the dependencies of the module it runs in
 - `PitReportAggregationModuleMojo` that is meant to run with command line and select modules to aggregate based on the submodules of the root project

Both mojos share a lot of behavior, some of it by calling the same objects (`ReportAggregator` for instance), some of it by code duplication. This make it complicated to make some changes that should apply to both mojos. (For instance, both mojos can only work if timestamped reports are disabled. Make them accept timestamped reports would require to make changes on both sides)

# Proposed changes
This pull request introduce an abstract class inherited by both mojo classes.

 - `findDependencies` is made abstract, because this is where the difference between both mojos is.
 - `getDescription` is left in both classes. The implementation is currently the same, but I think each implementation could need to define its own name.

# Notable changes
Changes are not easy to spot in moved code, but fortunately few changes where needed.

The only one to notice is in `getCompiledDirs` :

```
-            new PluginServices(PitAggregationMojo.class.getClassLoader())))) {
```
and
```
-            new PluginServices(PitAggregationMojo.class.getClassLoader())))) {
```
where changed to
```
+            new PluginServices(this.getClass().getClassLoader())))) {
```

In context the new version is :
```
+    for (final Object artifactObj : FCollection
+        .filter(project.getPluginArtifactMap().values(), new DependencyFilter(
+            new PluginServices(this.getClass().getClassLoader())))) {
+
+      final Artifact artifact = (Artifact) artifactObj;
+      sourceRoots.add(artifact.getFile().getAbsolutePath());
+    }
```

# Pings (: 
@sbuisson @rchargel What are you thoughts on that ?