### PR TITLE
Change report order to make stats summary appear last

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -225,6 +225,15 @@ private int numberOfThreads() {
 
   private void printStats(final MutationStatisticsListener stats) {
     final PrintStream ps = System.out;
+
+    ps.println(StringUtil.separatorLine('='));
+    ps.println("- Mutators");
+    ps.println(StringUtil.separatorLine('='));
+    for (final Score each : stats.getStatistics().getScores()) {
+      each.report(ps);
+      ps.println(StringUtil.separatorLine());
+    }
+
     ps.println(StringUtil.separatorLine('='));
     ps.println("- Timings");
     ps.println(StringUtil.separatorLine('='));
@@ -234,14 +243,6 @@ private int numberOfThreads() {
     ps.println("- Statistics");
     ps.println(StringUtil.separatorLine('='));
     stats.getStatistics().report(ps);
-
-    ps.println(StringUtil.separatorLine('='));
-    ps.println("- Mutators");
-    ps.println(StringUtil.separatorLine('='));
-    for (final Score each : stats.getStatistics().getScores()) {
-      each.report(ps);
-      ps.println(StringUtil.separatorLine());
-    }
   }
 
   private List<MutationAnalysisUnit> buildMutationTests(


### PR DESCRIPTION
As discussed in #493, this makes easier to see the summary of the mutation testing by moving it to the bottom, together with the time stats, since both are small. Detailed info on each mutator appears first, requiring some scroll, since it probably (?) is not as useful in most cases as the remaining.

Let me know if you agree with this change @hcoles 

closes #493 