### PR TITLE
Add support for passing long class paths to minions

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -434,6 +434,7 @@ public class OptionsParser {
           ClassPath.getClassPathElementsAsPaths(), this.dependencyFilter));
     }
     if (userArgs.has(this.classPathFile)) {
+      data.setShouldUseClassPathJar(true);
       try (BufferedReader classPathFileBR = new BufferedReader(new FileReader(userArgs.valueOf(this.classPathFile).getAbsoluteFile()))) {
         String element;
         while ((element = classPathFileBR.readLine()) != null) {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -106,6 +106,7 @@ public class ReportOptions {
 
   private boolean                        verbose                        = false;
   private boolean                        failWhenNoMutations            = false;
+  private boolean                        shouldUseClassPathJar          = false;
 
   private final Collection<String>       outputs                        = new LinkedHashSet<>();
 
@@ -135,6 +136,10 @@ public class ReportOptions {
 
   public boolean isVerbose() {
     return this.verbose;
+  }
+
+  public boolean shouldUseClassPathJar() {
+    return this.shouldUseClassPathJar;
   }
 
   /**
@@ -347,6 +352,9 @@ public class ReportOptions {
     this.excludedTestClasses = excludedClasses;
   }
 
+  public void setShouldUseClassPathJar(boolean shouldUseClassPathJar) {
+     this.shouldUseClassPathJar = shouldUseClassPathJar;
+  }
 
   public void addOutputFormats(final Collection<String> formats) {
     this.outputs.addAll(formats);

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -78,6 +78,7 @@ public class MutationCoverage {
   private final CodeSource         code;
   private final File               baseDir;
   private final SettingsFactory    settings;
+  private static boolean           shouldUseClassPathJar;
 
   public MutationCoverage(final MutationStrategies strategies,
       final File baseDir, final CodeSource code, final ReportOptions data,
@@ -88,6 +89,7 @@ public class MutationCoverage {
     this.timings = timings;
     this.code = code;
     this.baseDir = baseDir;
+    shouldUseClassPathJar = this.data.shouldUseClassPathJar();
   }
 
   public CombinedStatistics runReport() throws IOException {
@@ -317,5 +319,8 @@ private int numberOfThreads() {
     };
   }
 
+  public static boolean shouldUseClassPathJar() {
+    return shouldUseClassPathJar;
+  }
 
 }

--- a/pitest/src/main/java/org/pitest/util/CommandLineUtils.java
+++ b/pitest/src/main/java/org/pitest/util/CommandLineUtils.java
@@ -1,0 +1,51 @@
+package org.pitest.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipOutputStream;
+
+public class CommandLineUtils {
+
+    // Method copied from: https://github.com/JetBrains/intellij-community/blob/master/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/ForkedByModuleSplitter.java
+    public static File createClasspathJarFile(Manifest manifest, String classpath) throws IOException {
+        final Attributes attributes = manifest.getMainAttributes();
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        String classpathForManifest = "";
+        int idx = 0;
+        int endIdx = 0;
+        while (endIdx >= 0) {
+            endIdx = classpath.indexOf(File.pathSeparator, idx);
+            String path = endIdx < 0 ? classpath.substring(idx) : classpath.substring(idx, endIdx);
+            if (classpathForManifest.length() > 0) {
+                classpathForManifest += " ";
+            }
+            try {
+                //noinspection Since15
+                classpathForManifest += new File(path).toURI().toURL().toString();
+            } catch (NoSuchMethodError e) {
+                classpathForManifest += new File(path).toURL().toString();
+            }
+            idx = endIdx + File.pathSeparator.length();
+        }
+        attributes.put(Attributes.Name.CLASS_PATH, classpathForManifest);
+
+        File jarFile = File.createTempFile("classpath", ".jar");
+        ZipOutputStream jarPlugin = null;
+        try {
+            BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(jarFile));
+            jarPlugin = new JarOutputStream(out, manifest);
+        } finally {
+            if (jarPlugin != null) {
+                jarPlugin.close();
+            }
+        }
+        jarFile.deleteOnExit();
+        return jarFile;
+    }
+}


### PR DESCRIPTION
This is a fix for this [issue](https://github.com/hcoles/pitest/issues/490)

> In case the test class path is very long, there is an option to supply the class path through a file classPathFile. However, we still run into problems starting the minions, because internally, Pitest doesn't seem to use a file to supply the class path to them

This solution will pack the class path into a jar file, that will be sent to the minions, whenever a class path **file** has been supplied to the MutationCoverage process. The class path jar file gets created in the same way as it does in Intellij. Here's some more background information about the problem: https://blog.jetbrains.com/idea/2017/10/intellij-idea-2017-3-eap-configurable-command-line-shortener-and-more/