### PR TITLE
sorted mutators in html report

### DIFF
--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
@@ -14,22 +14,19 @@
  */
 package org.pitest.mutationtest.report.html;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
 import org.pitest.classinfo.ClassInfo;
 import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.MutationResult;
 
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 public class MutationTestSummaryData {
 
   private final String                     fileName;
-  private final Set<String>                mutators  = new HashSet<>();
+  private final Set<String>                mutators  = new TreeSet<>();
   private final Collection<MutationResult> mutations = new ArrayList<>();
   private final Set<ClassInfo>             classes   = new HashSet<>();
 

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
@@ -19,7 +19,11 @@ import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.MutationResult;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.TreeSet;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
@@ -1,16 +1,20 @@
 package org.pitest.mutationtest.report.html;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pitest.classinfo.ClassInfo;
 import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
+import org.pitest.mutationtest.engine.gregor.config.Mutator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 public class MutationTestSummaryDataTest {
 
@@ -90,6 +94,17 @@ public class MutationTestSummaryDataTest {
     assertEquals(300 + 100, this.testee.getTotals().getNumberOfLinesCovered());
   }
 
+  @Test
+  public void shouldReturnSortedListOfMutators() {
+    this.testee = buildSummaryDataMutators();
+
+    TreeSet<Object> sortedSet = Mutator.all().stream()
+            .map(MethodMutatorFactory::getName)
+            .collect(TreeSet::new, TreeSet::add, TreeSet::addAll);
+
+    assertEquals(sortedSet, this.testee.getMutators());
+  }
+
   private ClassInfo makeClass() {
     return makeClass(100);
   }
@@ -111,6 +126,15 @@ public class MutationTestSummaryDataTest {
     final Collection<String> mutators = Collections.emptyList();
     return new MutationTestSummaryData(FILE_NAME, results, mutators, classes,
         linesCovered);
+  }
+
+  private MutationTestSummaryData buildSummaryDataMutators() {
+    final Collection<ClassInfo> classes = Collections.emptyList();
+    final Collection<MutationResult> results = Collections.emptyList();
+    final Collection<String> mutators = Mutator.all().stream()
+            .map(MethodMutatorFactory::getName)
+            .collect(Collectors.toList());
+    return new MutationTestSummaryData(FILE_NAME, results, mutators, classes, 0);
   }
 
 }


### PR DESCRIPTION
Hi!

This is a very minor enhancement of the HTML report.
When there are many mutators active, especially the experimental remove switch mutator than the active mutators list gets kind of messy.
So I changed the HashSet to a TreeSet to get a better overview of them.

Btw. if you agree I would also work on a little enhancement to aggregate mutators like the EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_X to something like 
`EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_[1-99]` in the active mutator list.

![grafik](https://user-images.githubusercontent.com/20277801/46442508-266df000-c76a-11e8-9e70-be9ce9e2514a.png)
