### PR TITLE
provide aggregated name for mutator if generated as a collection

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutator.java
@@ -22,21 +22,15 @@ public class RemoveSwitchMutator implements MethodMutatorFactory {
   private static final int GENERATE_UPTO_EXCLUDING = 100;
 
   private final int key;
-  private final boolean isGeneratedAsCollection;
 
-  public RemoveSwitchMutator(final int i) {
-    this(i, false);
-  }
-
-  private RemoveSwitchMutator(final int i, final boolean isGeneratedAsCollection) {
+  RemoveSwitchMutator(final int i) {
     this.key = i;
-    this.isGeneratedAsCollection = isGeneratedAsCollection;
   }
 
   public static Iterable<MethodMutatorFactory> makeMutators() {
     final List<MethodMutatorFactory> variations = new ArrayList<>();
     for (int i = GENERATE_FROM_INCLUDING; i != GENERATE_UPTO_EXCLUDING; i++) {
-      variations.add(new RemoveSwitchMutator(i, true));
+      variations.add(new RemoveSwitchMutator(i));
     }
     return variations;
   }
@@ -54,11 +48,7 @@ public class RemoveSwitchMutator implements MethodMutatorFactory {
 
   @Override
   public String getName() {
-    if (isGeneratedAsCollection) {
-      return REMOVE_SWITCH_MUTATOR_NAME + "[" + GENERATE_FROM_INCLUDING + "-" + (GENERATE_UPTO_EXCLUDING - 1) + "]";
-    } else {
-      return toString();
-    }
+    return REMOVE_SWITCH_MUTATOR_NAME + "[" + GENERATE_FROM_INCLUDING + "-" + (GENERATE_UPTO_EXCLUDING - 1) + "]";
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutator.java
@@ -17,16 +17,26 @@ import org.pitest.mutationtest.engine.gregor.MutationContext;
  */
 public class RemoveSwitchMutator implements MethodMutatorFactory {
   // EXPERIMENTAL_REMOVE_SWITCH_MUTATOR;
+  private static final String REMOVE_SWITCH_MUTATOR_NAME = "EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_";
+  private static final int GENERATE_FROM_INCLUDING = 0;
+  private static final int GENERATE_UPTO_EXCLUDING = 100;
+
   private final int key;
+  private final boolean isGeneratedAsCollection;
 
   public RemoveSwitchMutator(final int i) {
+    this(i, false);
+  }
+
+  private RemoveSwitchMutator(final int i, final boolean isGeneratedAsCollection) {
     this.key = i;
+    this.isGeneratedAsCollection = isGeneratedAsCollection;
   }
 
   public static Iterable<MethodMutatorFactory> makeMutators() {
     final List<MethodMutatorFactory> variations = new ArrayList<>();
-    for (int i = 0; i != 100; i++) {
-      variations.add(new RemoveSwitchMutator(i));
+    for (int i = GENERATE_FROM_INCLUDING; i != GENERATE_UPTO_EXCLUDING; i++) {
+      variations.add(new RemoveSwitchMutator(i, true));
     }
     return variations;
   }
@@ -44,12 +54,16 @@ public class RemoveSwitchMutator implements MethodMutatorFactory {
 
   @Override
   public String getName() {
-    return toString();
+    if (isGeneratedAsCollection) {
+      return REMOVE_SWITCH_MUTATOR_NAME + "[" + GENERATE_FROM_INCLUDING + "-" + (GENERATE_UPTO_EXCLUDING - 1) + "]";
+    } else {
+      return toString();
+    }
   }
 
   @Override
   public String toString() {
-    return "EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_" + this.key;
+    return REMOVE_SWITCH_MUTATOR_NAME + this.key;
   }
 
   private final class RemoveSwitchMethodVisitor extends MethodVisitor {

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutatorTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
 import org.pitest.mutationtest.engine.gregor.MutatorTestBase;
 
 public class RemoveSwitchMutatorTest extends MutatorTestBase {
@@ -35,6 +36,15 @@ public class RemoveSwitchMutatorTest extends MutatorTestBase {
   public void shouldProvideAMeaningfulName() {
     assertEquals("EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_2",
         new RemoveSwitchMutator(2).getName());
+  }
+
+  @Test
+  public void shouldProvideAMeaningfulAggregatedName() {
+    Iterable<MethodMutatorFactory> mutators = RemoveSwitchMutator.makeMutators();
+    for (MethodMutatorFactory mutator : mutators) {
+      assertEquals("EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_[0-99]",
+              mutator.getName());
+    }
   }
 
   private static class HasIntSwitchWithDefault implements Callable<Integer> {

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/RemoveSwitchMutatorTest.java
@@ -34,7 +34,7 @@ public class RemoveSwitchMutatorTest extends MutatorTestBase {
 
   @Test
   public void shouldProvideAMeaningfulName() {
-    assertEquals("EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_2",
+    assertEquals("EXPERIMENTAL_REMOVE_SWITCH_MUTATOR_[0-99]",
         new RemoveSwitchMutator(2).getName());
   }
 


### PR DESCRIPTION
Hi, as I mentioned in my other PR here is also some minor enhancement to aggregate the EXPERIMENTAL_REMOVE_SWITCH_MUTATOR in the report.

Best regards,
ThLeu