### PR TITLE
Add some rules regarding issues management

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,36 @@
+## Creating issues
+
+Please provide as much context as possible. If possible, link to a sample project reproducing your problem (yes this is
+often a lot of work, but doing so will make it much easier to pinpoint and fix your problem).
+
+A good way to structure your bug report is to use the following structure:
+ - a short summary
+ - step-by-step instructions to reproduce the problem
+ - what you expected to happen
+ - what actually happened
+ - more info if appropriate (logs, links to samples, hypothesis, ...)
+
+## Closing Issues
+
+### Closing fixed issues
+
+An issue should be closed right after the PR that fixes it is merged.
+
+A comment should be added to indicate the version that will include the fix. Since the actual version is often unknown
+at that time, the recommended format is `> x.y.z` with `x.y.z` the latest _released_ version. That way, it doesn't
+matter if the version turns out to be minor, major or a bug fix, it's always easy to know if the version you are
+currently running contains the fix or not.
+
+### Closing old bugs reports
+
+At the moment, we have a rather long backlog of issues. Some have already been fixed, some are probably so old that no
+one cares anymore. To focus our efforts on the most pressing issues, we close old bugs that do not seem relevant
+anymore.
+
+Here is how it's done :
+ - bugs without activity for more than a year are concerned
+ - old bugs closing starts with the oldest ones
+ - a comment is added to ask if the bug is still a problem (the author is pinged, but anyone can answer)
+   - hopefully it is not a problem anymore, in that case it is closed
+   - if it is still a problem it stays open
+   - without answer within a month, the issue is closed

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ however disabled by default, and the generated errors are correctly handled by P
 
 ## Issues
 
-Issues management is described [here](ISSUES.md).
+Please consult our [issue management rules](ISSUES.md) before creating or working on issues. 
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Read all about it at http://pitest.org
 * #510 - Compute mutation test matrix (thanks @nrainer)
 * #519 - Java 11 support
 
+<details>
+    <summary>Older versions</summary>
+
 ### 1.4.2
 
 * #500 - Support for large classpaths with new `useClasspathJar` option (thanks @jqhan)
@@ -379,6 +382,7 @@ however disabled by default, and the generated errors are correctly handled by P
 ### 0.18
 
 * First public release
+</details>
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,10 @@ however disabled by default, and the generated errors are correctly handled by P
 * First public release
 </details>
 
+## Issues
+
+Issues management is described [here](ISSUES.md).
+
 ## Credits
 
 Pitest is mainly the work of [me](https://twitter.com/0hjc) but has benefited from contributions from many others. 


### PR DESCRIPTION
Hi @hcoles, as discussed together, this is first draft for a set of rules we could apply to be able to work more efficiently with pitest issues.

Anyone should feel free to comment, and propose changes. Once we agree, we can start applying those rules.

The main point of this PR is the `ISSUES.md` file. I also made some changes in `README.md` : in order to have a link to the issue policy that's visible enough I folded most of the versions list. This is easy to undo if needed.