### PR TITLE
Enhance block coverage to correctly track coverage in presence of exceptions; Base mutant-test-pairs on blocks (not lines)

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/BlockCoverageDataLoader.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/BlockCoverageDataLoader.java
@@ -16,6 +16,8 @@ class BlockCoverageDataLoader extends DataLoader<BlockCoverage> {
   private static final String CLASSNAME  = "classname";
   private static final String NUMBER     = "number";
   private static final String TESTS      = "tests";
+  private static final String FIRST_INSN = "firstInstruction";
+  private static final String LAST_INSN  = "lastInstruction";
 
   private static final String OPEN_PAREN = "(";
 
@@ -29,7 +31,8 @@ class BlockCoverageDataLoader extends DataLoader<BlockCoverage> {
     final Location location = new Location(ClassName.fromString((String) map.get(CLASSNAME)),
         MethodName.fromString(method.substring(0, method.indexOf(OPEN_PAREN))), method.substring(method.indexOf(OPEN_PAREN)));
 
-    final BlockLocation blockLocation = new BlockLocation(location, Integer.parseInt((String) map.get(NUMBER)));
+    final BlockLocation blockLocation = new BlockLocation(location, Integer.parseInt((String) map.get(NUMBER)),
+        Integer.parseInt((String) map.get(FIRST_INSN)),Integer.parseInt((String) map.get(LAST_INSN)));
 
     @SuppressWarnings("unchecked")
     final Collection<String> tests = (Collection<String>) map.get(TESTS);

--- a/pitest-aggregator/src/test/resources/full-data/linecoverage.xml
+++ b/pitest-aggregator/src/test/resources/full-data/linecoverage.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <coverage>
-    <block classname="com.example.DividerTest" method="testDivide()V" number="0">
+    <block classname="com.example.DividerTest" method="testDivide()V" number="0" firstInstruction="1" lastInstruction="2">
         <tests>
             <test name="com.example.DividerTest.testDivide(com.example.DividerTest)"/>
         </tests>
     </block>
-    <block classname="com.example.Divider" method="divide(DD)D" number="2">
+    <block classname="com.example.Divider" method="divide(DD)D" number="2" firstInstruction="1" lastInstruction="2">
         <tests>
             <test name="com.example.DividerTest.testDivide(com.example.DividerTest)"/>
         </tests>
     </block>
-    <block classname="com.example.DividerTest" method="&lt;init&gt;()V" number="0">
+    <block classname="com.example.DividerTest" method="&lt;init&gt;()V" number="0" firstInstruction="1" lastInstruction="2">
         <tests>
             <test name="com.example.DividerTest.testDivide(com.example.DividerTest)"/>
         </tests>
     </block>
-    <block classname="com.example.Divider" method="&lt;init&gt;()V" number="0">
+    <block classname="com.example.Divider" method="&lt;init&gt;()V" number="0" firstInstruction="1" lastInstruction="2">
         <tests>
             <test name="com.example.DividerTest.testDivide(com.example.DividerTest)"/>
         </tests>
     </block>
-    <block classname="com.example.Divider" method="divide(DD)D" number="0">
+    <block classname="com.example.Divider" method="divide(DD)D" number="0" firstInstruction="1" lastInstruction="2">
         <tests>
             <test name="com.example.DividerTest.testDivide(com.example.DividerTest)"/>
         </tests>

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
@@ -74,6 +74,11 @@ public class CoverageData implements CoverageDatabase {
   }
 
   @Override
+  public Collection<TestInfo> getTestsForBlockLocation(BlockLocation location) {
+    return this.blockCoverage.get(location);
+  }
+
+  @Override
   public Collection<TestInfo> getTestsForClassLine(final ClassLine classLine) {
     final Collection<TestInfo> result = getTestsForClassName(
         classLine.getClassName()).get(classLine);

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
@@ -49,7 +49,7 @@ public class CoverageData implements CoverageDatabase {
   // We calculate block coverage, but everything currently runs on line
   // coverage. Ugly mess of maps below should go when
   // api changed to work via blocks
-  private final Map<BlockLocation, Set<TestInfo>>             blockCoverage;
+  private final Map<InstructionLocation, Set<TestInfo>>       instructionCoverage;
   private final Map<BlockLocation, Set<Integer>>              blocksToLines = new LinkedHashMap<>();
   private final Map<ClassName, Map<ClassLine, Set<TestInfo>>> lineCoverage  = new LinkedHashMap<>();
   private final Map<String, Collection<ClassInfo>>            classesForFile;
@@ -61,12 +61,12 @@ public class CoverageData implements CoverageDatabase {
   private final List<Description>                             failingTestDescriptions = new ArrayList<>();
 
   public CoverageData(final CodeSource code, final LineMap lm) {
-    this(code, lm, new LinkedHashMap<BlockLocation, Set<TestInfo>>());
+    this(code, lm, new LinkedHashMap<InstructionLocation, Set<TestInfo>>());
   }
 
 
-  public CoverageData(final CodeSource code, final LineMap lm, Map<BlockLocation, Set<TestInfo>> blockCoverage) {
-    this.blockCoverage = blockCoverage;
+  public CoverageData(final CodeSource code, final LineMap lm, Map<InstructionLocation, Set<TestInfo>> instructionCoverage) {
+    this.instructionCoverage = instructionCoverage;
     this.code = code;
     this.lm = lm;
     this.classesForFile = FCollection.bucket(this.code.getCode(),
@@ -74,8 +74,9 @@ public class CoverageData implements CoverageDatabase {
   }
 
   @Override
-  public Collection<TestInfo> getTestsForBlockLocation(BlockLocation location) {
-    return this.blockCoverage.get(location);
+  public Collection<TestInfo> getTestsForInstructionLocation(
+      InstructionLocation location) {
+    return this.instructionCoverage.get(location);
   }
 
   @Override
@@ -115,7 +116,7 @@ public class CoverageData implements CoverageDatabase {
   public Collection<TestInfo> getTestsForClass(final ClassName clazz) {
     final Set<TestInfo> tis = new TreeSet<>(
         new TestInfoNameComparator());
-    tis.addAll(this.blockCoverage.entrySet().stream().filter(isFor(clazz))
+    tis.addAll(this.instructionCoverage.entrySet().stream().filter(isFor(clazz))
         .flatMap(toTests())
         .collect(Collectors.toList())
         );
@@ -128,15 +129,18 @@ public class CoverageData implements CoverageDatabase {
     final TestInfo ti = this.createTestInfo(cr.getTestUnitDescription(),
         cr.getExecutionTime(), cr.getNumberOfCoveredBlocks());
     for (final BlockLocation each : cr.getCoverage()) {
-      addTestsToBlockMap(ti, each);
+      for (int i = each.getFirstInsnInBlock();
+           i <= each.getLastInsnInBlock(); i++) {
+        addTestsToBlockMap(ti, new InstructionLocation(each, i));
+      }
     }
   }
 
-  private void addTestsToBlockMap(final TestInfo ti, BlockLocation each) {
-    Set<TestInfo> tests = this.blockCoverage.get(each);
+  private void addTestsToBlockMap(final TestInfo ti, InstructionLocation each) {
+    Set<TestInfo> tests = this.instructionCoverage.get(each);
     if (tests == null) {
       tests = new TreeSet<>(new TestInfoNameComparator());
-      this.blockCoverage.put(each, tests);
+      this.instructionCoverage.put(each, tests);
     }
     tests.add(ti);
   }
@@ -152,11 +156,11 @@ public class CoverageData implements CoverageDatabase {
   }
 
   public List<BlockCoverage> createCoverage() {
-    return FCollection.map(this.blockCoverage.entrySet(), toBlockCoverage());
+    return FCollection.map(this.instructionCoverage.entrySet(), toBlockCoverage());
   }
 
-  private static Function<Entry<BlockLocation, Set<TestInfo>>, BlockCoverage> toBlockCoverage() {
-    return a -> new BlockCoverage(a.getKey(), FCollection.map(a.getValue(),
+  private static Function<Entry<InstructionLocation, Set<TestInfo>>, BlockCoverage> toBlockCoverage() {
+    return a -> new BlockCoverage(a.getKey().getBlockLocation(), FCollection.map(a.getValue(),
         TestInfo.toName()));
   }
 
@@ -267,20 +271,20 @@ public class CoverageData implements CoverageDatabase {
       return map;
     }
 
-    return convertBlockCoverageToLineCoverageForClass(clazz);
+    return convertInstructionCoverageToLineCoverageForClass(clazz);
 
   }
 
-  private Map<ClassLine, Set<TestInfo>> convertBlockCoverageToLineCoverageForClass(
+  private Map<ClassLine, Set<TestInfo>> convertInstructionCoverageToLineCoverageForClass(
       ClassName clazz) {
-    final List<Entry<BlockLocation, Set<TestInfo>>> tests = FCollection.filter(
-        this.blockCoverage.entrySet(), isFor(clazz));
+    final List<Entry<InstructionLocation, Set<TestInfo>>> tests = FCollection.filter(
+        this.instructionCoverage.entrySet(), isFor(clazz));
 
     final Map<ClassLine, Set<TestInfo>> linesToTests = new LinkedHashMap<>(
         0);
 
-    for (final Entry<BlockLocation, Set<TestInfo>> each : tests) {
-      for (final int line : getLinesForBlock(each.getKey())) {
+    for (final Entry<InstructionLocation, Set<TestInfo>> each : tests) {
+      for (final int line : getLinesForBlock(each.getKey().getBlockLocation())) {
         final Set<TestInfo> tis = getLineTestSet(clazz, linesToTests, each, line);
         tis.addAll(each.getValue());
       }
@@ -292,7 +296,7 @@ public class CoverageData implements CoverageDatabase {
 
   private static Set<TestInfo> getLineTestSet(ClassName clazz,
       Map<ClassLine, Set<TestInfo>> linesToTests,
-      Entry<BlockLocation, Set<TestInfo>> each, int line) {
+      Entry<InstructionLocation, Set<TestInfo>> each, int line) {
     final ClassLine cl = new ClassLine(clazz, line);
     Set<TestInfo> tis = linesToTests.get(cl);
     if (tis == null) {
@@ -325,11 +329,11 @@ public class CoverageData implements CoverageDatabase {
     this.failingTestDescriptions.add(testDescription);
   }
 
-  private Function<Entry<BlockLocation, Set<TestInfo>>, Stream<TestInfo>> toTests() {
+  private Function<Entry<InstructionLocation, Set<TestInfo>>, Stream<TestInfo>> toTests() {
     return a -> a.getValue().stream();
   }
 
-  private Predicate<Entry<BlockLocation, Set<TestInfo>>> isFor(
+  private Predicate<Entry<InstructionLocation, Set<TestInfo>>> isFor(
       final ClassName clazz) {
     return a -> a.getKey().isFor(clazz);
   }

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
@@ -14,6 +14,8 @@ public interface CoverageDatabase {
 
   Collection<TestInfo> getTestsForClass(ClassName clazz);
 
+  Collection<TestInfo> getTestsForBlockLocation(BlockLocation location);
+
   Collection<TestInfo> getTestsForClassLine(ClassLine classLine);
 
   BigInteger getCoverageIdForClass(ClassName clazz);

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
@@ -14,7 +14,7 @@ public interface CoverageDatabase {
 
   Collection<TestInfo> getTestsForClass(ClassName clazz);
 
-  Collection<TestInfo> getTestsForBlockLocation(BlockLocation location);
+  Collection<TestInfo> getTestsForInstructionLocation(InstructionLocation location);
 
   Collection<TestInfo> getTestsForClassLine(ClassLine classLine);
 

--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/Receive.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/Receive.java
@@ -61,7 +61,7 @@ final class Receive implements ReceiveStrategy {
       // nb, convert from classwide id to method scoped index within
       // BlockLocation
       this.probeToBlock.put(CodeCoverageStore.encode(classId, i),
-          new BlockLocation(loc, i - first));
+          new BlockLocation(loc, i - first, is.readInt(), is.readInt()));
     }
   }
 

--- a/pitest-entry/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/export/DefaultCoverageExporter.java
@@ -49,7 +49,10 @@ public class DefaultCoverageExporter implements CoverageExporter {
         "<block classname='" + l.getClassName().asJavaName() + "'"
             + " method='"
             + StringUtil.escapeBasicHtmlChars(l.getMethodName().name()) + StringUtil.escapeBasicHtmlChars(l.getMethodDesc())
-            + "' number='" + each.getBlock().getBlock() + "'>");
+            + "' number='" + each.getBlock().getBlock()
+            + "' firstInstruction='" + each.getBlock().getFirstInsnInBlock()
+            + "' lastInstruction='" + each.getBlock().getLastInsnInBlock()
+            + "'>");
     write(out, "<tests>\n");
     final List<String> ts = new ArrayList<>(each.getTests());
     Collections.sort(ts);

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/DefaultTestPrioritiser.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/DefaultTestPrioritiser.java
@@ -2,12 +2,14 @@ package org.pitest.mutationtest.build;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Logger;
 
 import org.pitest.classinfo.ClassName;
 import org.pitest.coverage.BlockLocation;
 import org.pitest.coverage.CoverageDatabase;
+import org.pitest.coverage.InstructionLocation;
 import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import org.pitest.functional.prelude.Prelude;
@@ -42,7 +44,23 @@ public class DefaultTestPrioritiser implements TestPrioritiser {
 
   private Collection<TestInfo> pickTests(MutationDetails mutation) {
     if (!mutation.isInStaticInitializer()) {
-      return this.coverage.getTestsForBlockLocation(new BlockLocation(mutation.getId().getLocation(), mutation.getBlock()));
+      if (mutation.getId().getIndexes().size() > 1) {
+        HashSet<TestInfo> ret = new HashSet<>();
+        for (int each : mutation.getId().getIndexes()) {
+          Collection<TestInfo> r = this.coverage.getTestsForInstructionLocation(
+              new InstructionLocation(
+                  new BlockLocation(mutation.getId().getLocation(),
+                      mutation.getBlock(), -1, -1), each - 1));
+          if (r != null) {
+            ret.addAll(r);
+          }
+        }
+        return ret;
+      } else {
+        return this.coverage
+            .getTestsForInstructionLocation(new InstructionLocation(new BlockLocation(mutation.getId().getLocation(), mutation.getBlock(), -1, -1),
+                mutation.getId().getFirstIndex() - 1));
+      }
     } else {
       LOG.warning("Using untargetted tests");
       return this.coverage.getTestsForClass(mutation.getClassName());

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/DefaultTestPrioritiser.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/DefaultTestPrioritiser.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.pitest.classinfo.ClassName;
+import org.pitest.coverage.BlockLocation;
 import org.pitest.coverage.CoverageDatabase;
 import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
@@ -41,7 +42,7 @@ public class DefaultTestPrioritiser implements TestPrioritiser {
 
   private Collection<TestInfo> pickTests(MutationDetails mutation) {
     if (!mutation.isInStaticInitializer()) {
-      return this.coverage.getTestsForClassLine(mutation.getClassLine());
+      return this.coverage.getTestsForBlockLocation(new BlockLocation(mutation.getId().getLocation(), mutation.getBlock()));
     } else {
       LOG.warning("Using untargetted tests");
       return this.coverage.getTestsForClass(mutation.getClassName());

--- a/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
@@ -286,7 +286,7 @@ public class CoverageDataTest {
   private Collection<BlockLocation> makeCoverage(final String clazz,
       final int block) {
     final BlockLocation cs = new BlockLocation(Location.location(
-        ClassName.fromString(clazz), MethodName.fromString("foo"), "V"), block);
+        ClassName.fromString(clazz), MethodName.fromString("foo"), "V"), block, -1, -1);
 
     return Collections.singleton(cs);
   }

--- a/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
@@ -93,11 +93,14 @@ public class CoverageProcessSystemTest {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TesteeWithComplexConstructorsTest.class);
     assertTrue(coversBlock(coveredClasses, "testHigh", 0));
     assertTrue(coversBlock(coveredClasses, "testHigh", 1));
-    assertFalse(coversBlock(coveredClasses, "testHigh", 2));
+    assertTrue(coversBlock(coveredClasses, "testHigh", 2));
+    assertTrue(coversBlock(coveredClasses, "testHigh", 3));
+    assertFalse(coversBlock(coveredClasses, "testHigh", 4));
 
     assertTrue(coversBlock(coveredClasses, "testLow", 0));
-    assertTrue(coversBlock(coveredClasses, "testLow", 2));
-    assertFalse(coversBlock(coveredClasses, "testLow", 1));
+    assertTrue(coversBlock(coveredClasses, "testLow", 1));
+    assertTrue(coversBlock(coveredClasses, "testLow", 4));
+    assertFalse(coversBlock(coveredClasses, "testLow", 2));
   }
 
   @Test
@@ -232,7 +235,7 @@ public class CoverageProcessSystemTest {
         Location.location(clazz, this.foo, "()V"), 0)));
 
         assertThat(coveredClasses).anyMatch(coverageFor(BlockLocation.blockLocation(
-        Location.location(clazz, this.foo, "()V"), 1)));
+        Location.location(clazz, this.foo, "()V"), 4)));
   }
 
   @Test

--- a/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/export/DefaultCoverageExporterTest.java
@@ -57,9 +57,9 @@ public class DefaultCoverageExporterTest {
 
     final String actual = this.out.toString();
     assertThat(actual).contains(
-        "<block classname='Foo' method='method()I' number='42'>");
+        "<block classname='Foo' method='method()I' number='42'");
     assertThat(actual).contains(
-        "<block classname='Bar' method='method()I' number='42'>");
+        "<block classname='Bar' method='method()I' number='42'");
     assertThat(actual).contains(
         "<tests>\n<test name='Test1'/>\n<test name='Test2'/>\n</tests>");
     assertThat(actual).contains(

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/DefaultTestPrioritiserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/DefaultTestPrioritiserTest.java
@@ -16,9 +16,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.pitest.classinfo.ClassByteArraySource;
 import org.pitest.classinfo.ClassName;
-import org.pitest.coverage.BlockLocation;
-import org.pitest.coverage.ClassLine;
 import org.pitest.coverage.CoverageDatabase;
+import org.pitest.coverage.InstructionLocation;
 import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import java.util.Optional;
@@ -47,7 +46,7 @@ public class DefaultTestPrioritiserTest {
   @Test
   public void shouldAssignTestsForRelevantLineToGeneratedMutations() {
     final List<TestInfo> expected = makeTestInfos(0);
-    when(this.coverage.getTestsForBlockLocation(any(BlockLocation.class))).thenReturn(
+    when(this.coverage.getTestsForInstructionLocation(any(InstructionLocation.class))).thenReturn(
         expected);
     final List<TestInfo> actual = this.testee.assignTests(makeMutation("foo"));
     assertEquals(expected, actual);
@@ -66,7 +65,7 @@ public class DefaultTestPrioritiserTest {
   @Test
   public void shouldPrioritiseTestsByExecutionTime() {
     final List<TestInfo> unorderedTests = makeTestInfos(10000, 100, 1000, 1);
-    when(this.coverage.getTestsForBlockLocation(any(BlockLocation.class))).thenReturn(
+    when(this.coverage.getTestsForInstructionLocation(any(InstructionLocation.class))).thenReturn(
         unorderedTests);
     final List<TestInfo> actual = this.testee.assignTests(makeMutation("foo"));
 

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/DefaultTestPrioritiserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/DefaultTestPrioritiserTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.pitest.classinfo.ClassByteArraySource;
 import org.pitest.classinfo.ClassName;
+import org.pitest.coverage.BlockLocation;
 import org.pitest.coverage.ClassLine;
 import org.pitest.coverage.CoverageDatabase;
 import org.pitest.coverage.TestInfo;
@@ -46,7 +47,7 @@ public class DefaultTestPrioritiserTest {
   @Test
   public void shouldAssignTestsForRelevantLineToGeneratedMutations() {
     final List<TestInfo> expected = makeTestInfos(0);
-    when(this.coverage.getTestsForClassLine(any(ClassLine.class))).thenReturn(
+    when(this.coverage.getTestsForBlockLocation(any(BlockLocation.class))).thenReturn(
         expected);
     final List<TestInfo> actual = this.testee.assignTests(makeMutation("foo"));
     assertEquals(expected, actual);
@@ -65,7 +66,7 @@ public class DefaultTestPrioritiserTest {
   @Test
   public void shouldPrioritiseTestsByExecutionTime() {
     final List<TestInfo> unorderedTests = makeTestInfos(10000, 100, 1000, 1);
-    when(this.coverage.getTestsForClassLine(any(ClassLine.class))).thenReturn(
+    when(this.coverage.getTestsForBlockLocation(any(BlockLocation.class))).thenReturn(
         unorderedTests);
     final List<TestInfo> actual = this.testee.assignTests(makeMutation("foo"));
 

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasExceptionsTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasExceptionsTest.java
@@ -1,0 +1,14 @@
+package com.example.blockcoverage;
+
+import org.junit.Test;
+
+public class HasExceptionsTest {
+  @Test
+  public void testCallsMethodThrowsException() {
+    try {
+      HasExceptionsTestee.foo();
+    } catch (NullPointerException ex) {
+      //nop
+    }
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasExceptionsTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasExceptionsTestee.java
@@ -1,0 +1,9 @@
+package com.example.blockcoverage;
+
+public class HasExceptionsTestee {
+  public static void foo(){
+    String x = null;
+    int y  =x.length();
+    y++;
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasFinallyTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasFinallyTest.java
@@ -1,0 +1,16 @@
+package com.example.blockcoverage;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasFinallyTest {
+  @Test
+  public void testHasInlinedFinallyBlock(){
+    Assert.assertTrue(HasFinallyTestee.methodWithFinally(true));
+  }
+
+  @Test
+  public void testHasInlinedFinallyBlockOtherBranch(){
+    Assert.assertFalse(HasFinallyTestee.methodWithFinally(false));
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasFinallyTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasFinallyTestee.java
@@ -1,0 +1,17 @@
+package com.example.blockcoverage;
+
+public class HasFinallyTestee {
+
+  public static boolean methodWithFinally(boolean bailEarly) {
+    int x = 0;
+    int y = 0;
+    try {
+      if (bailEarly)
+        return true;
+    } finally {
+      x++;
+      x--;
+    }
+    return false;
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasTernaryTest.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasTernaryTest.java
@@ -1,0 +1,12 @@
+package com.example.blockcoverage;
+
+import org.junit.Test;
+
+public class HasTernaryTest {
+
+  @Test
+  public void testTernary(){
+    int ret = HasTernaryTestee.mutable(10);
+
+  }
+}

--- a/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasTernaryTestee.java
+++ b/pitest-java8-verification/src/test/java/com/example/blockcoverage/HasTernaryTestee.java
@@ -1,0 +1,7 @@
+package com.example.blockcoverage;
+
+public class HasTernaryTestee {
+  public static int mutable(int in) {
+    return (in > 0 ? in++ : in--);
+  }
+}

--- a/pitest-java8-verification/src/test/java/org/pitest/blockcoverage/verification/VerifyBlockCoverageIT.java
+++ b/pitest-java8-verification/src/test/java/org/pitest/blockcoverage/verification/VerifyBlockCoverageIT.java
@@ -1,0 +1,33 @@
+package org.pitest.blockcoverage.verification;
+
+import static java.util.Arrays.asList;
+import static org.pitest.mutationtest.DetectionStatus.KILLED;
+import static org.pitest.mutationtest.DetectionStatus.NO_COVERAGE;
+import static org.pitest.mutationtest.DetectionStatus.SURVIVED;
+
+import com.example.blockcoverage.HasExceptionsTest;
+import com.example.blockcoverage.HasTernaryTest;
+import com.example.java8.Java8ClassTest;
+import org.junit.Test;
+import org.pitest.mutationtest.ReportTestBase;
+
+public class VerifyBlockCoverageIT extends ReportTestBase {
+
+  @Test
+  public void shouldNotRunMutantsOnCoveredLineButNotCovered() {
+    this.data.setTargetTests(predicateFor(HasTernaryTest.class));
+    this.data.setTargetClasses(asList("com.example.blockcoverage.HasTernaryTestee"));
+    setMutators("INCREMENTS");
+    createAndRun();
+    verifyResults(SURVIVED, NO_COVERAGE);
+  }
+
+  @Test
+  public void shouldNotRunMutantsOnLinesUncoveredByExceptions(){
+    this.data.setTargetTests(predicateFor(HasExceptionsTest.class));
+    this.data.setTargetClasses(asList("com.example.blockcoverage.HasExceptionsTestee"));
+    setMutators("INCREMENTS");
+    createAndRun();
+    verifyResults(NO_COVERAGE);
+  }
+}

--- a/pitest-java8-verification/src/test/java/org/pitest/blockcoverage/verification/VerifyBlockCoverageIT.java
+++ b/pitest-java8-verification/src/test/java/org/pitest/blockcoverage/verification/VerifyBlockCoverageIT.java
@@ -1,13 +1,13 @@
 package org.pitest.blockcoverage.verification;
 
 import static java.util.Arrays.asList;
-import static org.pitest.mutationtest.DetectionStatus.KILLED;
 import static org.pitest.mutationtest.DetectionStatus.NO_COVERAGE;
 import static org.pitest.mutationtest.DetectionStatus.SURVIVED;
 
 import com.example.blockcoverage.HasExceptionsTest;
+import com.example.blockcoverage.HasFinallyTest;
 import com.example.blockcoverage.HasTernaryTest;
-import com.example.java8.Java8ClassTest;
+import org.junit.Assert;
 import org.junit.Test;
 import org.pitest.mutationtest.ReportTestBase;
 
@@ -29,5 +29,19 @@ public class VerifyBlockCoverageIT extends ReportTestBase {
     setMutators("INCREMENTS");
     createAndRun();
     verifyResults(NO_COVERAGE);
+  }
+
+  @Test
+  public void shouldDetectInlinedFinallyCodeAndOnlyMakeOneMutant(){
+    this.data.setTargetTests(predicateFor(HasFinallyTest.class));
+    this.data.setTargetClasses(asList("com.example.blockcoverage.HasFinallyTestee"));
+    this.data.setDetectInlinedCode(true);
+    setMutators("INCREMENTS");
+    createAndRun();
+
+    //Check that exactly 2 mutants were created and that BOTH tests were run on both
+    //(even though the tests hit on different instructions)
+    Assert.assertEquals(4, this.metaDataExtractor.getNumberOfTestsRun());
+    verifyResults(SURVIVED, SURVIVED);
   }
 }

--- a/pitest/src/main/java/org/pitest/coverage/BlockLocation.java
+++ b/pitest/src/main/java/org/pitest/coverage/BlockLocation.java
@@ -7,15 +7,20 @@ public final class BlockLocation {
 
   private final Location location;
   private final int      block;
+  private final int      firstInsnInBlock;
+  private final int      lastInsnInBlock;
 
-  public BlockLocation(final Location location, final int block) {
+  public BlockLocation(final Location location, final int block,
+      final int firstInsnInBlock, final int lastInsnInBlock) {
     this.location = location;
     this.block = block;
+    this.firstInsnInBlock = firstInsnInBlock;
+    this.lastInsnInBlock = lastInsnInBlock;
   }
 
   public static BlockLocation blockLocation(final Location location,
-      final int block) {
-    return new BlockLocation(location, block);
+      final int block ) {
+    return new BlockLocation(location, block, -1, -1);
   }
 
   public boolean isFor(final ClassName clazz) {
@@ -28,6 +33,14 @@ public final class BlockLocation {
 
   public Location getLocation() {
     return this.location;
+  }
+
+  public int getFirstInsnInBlock() {
+    return firstInsnInBlock;
+  }
+
+  public int getLastInsnInBlock() {
+    return lastInsnInBlock;
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/coverage/InstructionLocation.java
+++ b/pitest/src/main/java/org/pitest/coverage/InstructionLocation.java
@@ -1,0 +1,47 @@
+package org.pitest.coverage;
+
+import org.pitest.classinfo.ClassName;
+
+public final class InstructionLocation {
+  private final BlockLocation blockLocation;
+  private final int           instructionIndex;
+
+  public InstructionLocation(BlockLocation blockLocation,
+      int instructionIndex) {
+    this.blockLocation = blockLocation;
+    this.instructionIndex = instructionIndex;
+  }
+
+  public BlockLocation getBlockLocation() {
+    return blockLocation;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    InstructionLocation that = (InstructionLocation) o;
+
+    if (instructionIndex != that.instructionIndex) {
+      return false;
+    }
+    return blockLocation.getLocation().equals(that.blockLocation.getLocation());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = blockLocation.getLocation().hashCode();
+    result = 31 * result + instructionIndex;
+    return result;
+  }
+
+  public boolean isFor(final ClassName clazz) {
+    return this.blockLocation.getLocation().getClassName().equals(clazz);
+  }
+
+}

--- a/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
@@ -43,7 +43,7 @@ public class CoverageAnalyser extends MethodNode {
     this.parent.registerProbes(blocks.size());
     final int blockCount = blocks.size();
     CodeCoverageStore.registerMethod(this.classId, this.name, this.desc,
-        this.probeOffset, (this.probeOffset + blocks.size()) - 1);
+        this.probeOffset, (this.probeOffset + blocks.size()) - 1, blocks);
 
     // according to the jvm spec
     // "There must never be an uninitialized class instance in a local variable in code protected by an exception handler"

--- a/pitest/src/main/java/org/pitest/coverage/analysis/LineMapper.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/LineMapper.java
@@ -43,8 +43,10 @@ public class LineMapper implements LineMap {
             MethodName.fromString(mn.name), mn.desc);
         final List<Block> blocks = ControlFlowAnalyser.analyze(mn);
         for (int i = 0; i != blocks.size(); i++) {
-          final BlockLocation bl = new BlockLocation(l, i);
-          map.put(bl, blocks.get(i).getLines());
+          final Block each = blocks.get(i);
+          final BlockLocation bl = new BlockLocation(l, i,
+              each.getFirstInstruction(), each.getLastInstruction());
+          map.put(bl, each.getLines());
         }
 
       }

--- a/pitest/src/main/java/org/pitest/coverage/execute/CoveragePipe.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoveragePipe.java
@@ -4,6 +4,7 @@ import java.io.OutputStream;
 import java.util.Collection;
 
 import org.pitest.coverage.CoverageReceiver;
+import org.pitest.coverage.analysis.Block;
 import org.pitest.testapi.Description;
 import org.pitest.util.ExitCode;
 import org.pitest.util.Id;
@@ -57,13 +58,17 @@ public class CoveragePipe implements CoverageReceiver {
 
   @Override
   public synchronized void registerProbes(int classId, String methodName,
-      String methodDesc, int firstProbe, int lastProbe) {
+      String methodDesc, int firstProbe, int lastProbe, Iterable<Block> blocks) {
     this.dos.writeByte(Id.PROBES);
     this.dos.writeInt(classId);
     this.dos.writeString(methodName);
     this.dos.writeString(methodDesc);
     this.dos.writeInt(firstProbe);
     this.dos.writeInt(lastProbe);
+    for (Block b : blocks) {
+      this.dos.writeInt(b.getFirstInstruction());
+      this.dos.writeInt(b.getLastInstruction());
+    }
   }
 
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/MutationIdentifier.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/MutationIdentifier.java
@@ -79,6 +79,15 @@ public final class MutationIdentifier implements Comparable<MutationIdentifier>,
   }
 
   /**
+   * Returns the list of instruction indexes to which this mutation applies
+   *
+   * @return the instruction indexes of the mutation
+   */
+  public List<Integer> getIndexes() {
+    return indexes;
+  }
+
+  /**
    * Returns the index to the first instruction on which this mutation occurs.
    * This index is specific to how ASM represents the bytecode.
    *

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/ClassContext.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/ClassContext.java
@@ -107,7 +107,12 @@ class ClassContext implements BlockCounter {
   }
 
   public int getCurrentBlock() {
-    return this.blockCounter.getCurrentBlock();
+    return this.blockCounter.getCurrentBlockThisMethod();
+  }
+
+  @Override
+  public void registerNewMethodStart() {
+    this.blockCounter.registerNewMethodStart();
   }
 
   public boolean isWithinFinallyBlock() {

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodInfo.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodInfo.java
@@ -40,6 +40,10 @@ public class MethodInfo {
     return this.owningClass.getName() + "::" + getName();
   }
 
+  public int getAccess() {
+    return access;
+  }
+
   public String getName() {
     return this.methodName;
   }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutationContext.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutationContext.java
@@ -65,6 +65,11 @@ class MethodMutationContext implements MutationContext, InstructionCounter {
   }
 
   @Override
+  public void registerNewMethodStart() {
+    this.classContext.registerNewMethodStart();
+  }
+
+  @Override
   public void registerFinallyBlockStart() {
     this.classContext.registerFinallyBlockStart();
   }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
@@ -96,7 +96,7 @@ class MutatingClassVisitor extends ClassVisitor {
 
   private static MethodVisitor wrapWithBlockTracker(
       MethodMutationContext methodContext, final MethodVisitor mv, final MethodInfo methodInfo) {
-    return new BlockTrackingMethodDecorator(methodContext, mv, methodInfo.getAccess(), methodInfo.getName(), methodInfo.getDescription(), null, null);
+    return new BlockTrackingMethodDecorator(methodContext, mv, methodInfo.getAccess(), methodInfo.getName(), methodInfo.getMethodDescriptor(), null, null);
   }
 
   private MethodVisitor visitMethodForMutation(

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
@@ -82,6 +82,23 @@ class MutatingClassVisitor extends ClassVisitor {
 
   }
 
+  private static MethodVisitor wrapWithDecorators(
+      MethodMutationContext methodContext, final MethodVisitor mv, final MethodInfo methodInfo) {
+    return wrapWithBlockTracker(methodContext,
+        wrapWithInstructionTracker(methodContext,
+            wrapWithLineTracker(methodContext, mv)), methodInfo);
+  }
+
+  private static MethodVisitor wrapWithInstructionTracker(
+      MethodMutationContext methodContext, final MethodVisitor mv) {
+    return new InstructionTrackingMethodVisitor(mv, methodContext);
+  }
+
+  private static MethodVisitor wrapWithBlockTracker(
+      MethodMutationContext methodContext, final MethodVisitor mv, final MethodInfo methodInfo) {
+    return new BlockTrackingMethodDecorator(methodContext, mv, methodInfo.getAccess(), methodInfo.getName(), methodInfo.getDescription(), null, null);
+  }
+
   private MethodVisitor visitMethodForMutation(
       MethodMutationContext methodContext, final MethodInfo methodInfo,
       final MethodVisitor methodVisitor) {
@@ -91,19 +108,7 @@ class MutatingClassVisitor extends ClassVisitor {
       next = each.create(methodContext, methodInfo, next);
     }
 
-    return new InstructionTrackingMethodVisitor(wrapWithDecorators(
-        methodContext, wrapWithFilters(methodContext, next)), methodContext);
-  }
-
-  private static MethodVisitor wrapWithDecorators(MethodMutationContext methodContext,
-      final MethodVisitor mv) {
-    return wrapWithBlockTracker(methodContext,
-        wrapWithLineTracker(methodContext, mv));
-  }
-
-  private static MethodVisitor wrapWithBlockTracker(
-      MethodMutationContext methodContext, final MethodVisitor mv) {
-    return new BlockTrackingMethodDecorator(methodContext, mv);
+    return wrapWithDecorators(methodContext, wrapWithFilters(methodContext, next), methodInfo);
   }
 
   private static MethodVisitor wrapWithLineTracker(

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/BlockCounter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/BlockCounter.java
@@ -8,4 +8,6 @@ public interface BlockCounter {
 
   void registerFinallyBlockEnd();
 
+  void registerNewMethodStart();
+
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/BlockTrackingMethodDecorator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/BlockTrackingMethodDecorator.java
@@ -23,68 +23,195 @@ import static org.objectweb.asm.Opcodes.LRETURN;
 import static org.objectweb.asm.Opcodes.RETURN;
 
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Set;
 
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.MethodNode;
 import org.pitest.bytecode.ASMVersion;
+import org.pitest.coverage.analysis.Block;
+import org.pitest.coverage.analysis.ControlFlowAnalyser;
 
-public class BlockTrackingMethodDecorator extends MethodVisitor {
+public class BlockTrackingMethodDecorator extends MethodNode {
 
-  private final BlockCounter blockCounter;
-  private final Set<Label>   handlers = new HashSet<>();
+  private final BlockCounter  blockCounter;
+  private final Set<Label>    handlers = new HashSet<>();
+  private final MethodVisitor cmv;
 
   public BlockTrackingMethodDecorator(final BlockCounter blockCounter,
-      final MethodVisitor mv) {
-    super(ASMVersion.ASM_VERSION, mv);
+      final MethodVisitor mv, int acc, String name, String desc,
+      String signature, String[] exceptions) {
+    super(ASMVersion.ASM_VERSION, acc, name, desc, signature, exceptions);
+    this.cmv = mv;
     this.blockCounter = blockCounter;
   }
 
   @Override
-  public void visitInsn(final int opcode) {
-    this.mv.visitInsn(opcode);
-    if (endsBlock(opcode)) {
-      this.blockCounter.registerFinallyBlockEnd();
-      this.blockCounter.registerNewBlock();
-    }
-  }
+  public void visitEnd() {
+    super.visitEnd();
 
-  @Override
-  public void visitJumpInsn(final int arg0, final Label arg1) {
-    this.mv.visitJumpInsn(arg0, arg1);
-    this.blockCounter.registerNewBlock();
-  }
+    final LinkedList<Block> blocks = new LinkedList<>(
+        ControlFlowAnalyser.analyze(this));
 
-  @Override
-  public void visitTryCatchBlock(final Label start, final Label end,
-      final Label handler, final String type) {
-    super.visitTryCatchBlock(start, end, handler, type);
-    if (type == null) {
-      this.handlers.add(handler);
-    }
-  }
+    blockCounter.registerNewMethodStart();
+    this.accept(new MethodVisitor(ASMVersion.ASM_VERSION, cmv) {
+      Block curBlock = blocks.pop();
+      int i;
+      private HashSet<Label> handlers = new HashSet<>();
 
-  @Override
-  public void visitLabel(final Label label) {
-    super.visitLabel(label);
-    if (this.handlers.contains(label)) {
-      this.blockCounter.registerFinallyBlockStart();
-    }
-  }
+      @Override
+      public void visitTryCatchBlock(Label start, Label end, Label handler,
+          String type) {
+        super.visitTryCatchBlock(start, end, handler, type);
+        if (type == null) {
+          handlers.add(handler);
+        }
+      }
 
-  private boolean endsBlock(final int opcode) {
-    switch (opcode) {
-    case RETURN:
-    case ARETURN:
-    case DRETURN:
-    case FRETURN:
-    case IRETURN:
-    case LRETURN:
-    case ATHROW: // dubious if this is needed
-      return true;
-    default:
-      return false;
-    }
-  }
+      private boolean endsBlock(final int opcode) {
+        switch (opcode) {
+        case RETURN:
+        case ARETURN:
+        case DRETURN:
+        case FRETURN:
+        case IRETURN:
+        case LRETURN:
+        case ATHROW: // dubious if this is needed
+          return true;
+        default:
+          return false;
+        }
+      }
 
+      private void visitAnything() {
+        if ((i == curBlock.getFirstInstruction())) {
+          if (i == 0) {
+            //ignore the very first block since we are 0 based
+            if (!blocks.isEmpty()) {
+              curBlock = blocks.pop();
+            }
+          } else {
+            blockCounter.registerNewBlock();
+            if (!blocks.isEmpty()) {
+              curBlock = blocks.pop();
+            }
+          }
+        }
+        i++;
+      }
+
+      @Override
+      public void visitFrame(int type, int numLocal, Object[] local,
+          int numStack, Object[] stack) {
+        visitAnything();
+        super.visitFrame(type, numLocal, local, numStack, stack);
+      }
+
+      @Override
+      public void visitInsn(int opcode) {
+        visitAnything();
+        super.visitInsn(opcode);
+        if (endsBlock(opcode)) {
+          blockCounter.registerFinallyBlockEnd();
+          //          blockCounter.registerNewBlock();
+        }
+      }
+
+      @Override
+      public void visitIntInsn(int opcode, int operand) {
+        visitAnything();
+        super.visitIntInsn(opcode, operand);
+      }
+
+      @Override
+      public void visitVarInsn(int opcode, int var) {
+        visitAnything();
+        super.visitVarInsn(opcode, var);
+      }
+
+      @Override
+      public void visitTypeInsn(int opcode, String type) {
+        visitAnything();
+        super.visitTypeInsn(opcode, type);
+      }
+
+      @Override
+      public void visitFieldInsn(int opcode, String owner, String name,
+          String descriptor) {
+        visitAnything();
+        super.visitFieldInsn(opcode, owner, name, descriptor);
+      }
+
+      @Override
+      public void visitMethodInsn(int opcode, String owner, String name,
+          String descriptor, boolean isInterface) {
+        visitAnything();
+        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+      }
+
+      @Override
+      public void visitInvokeDynamicInsn(String name, String descriptor,
+          Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+        visitAnything();
+        super.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle,
+            bootstrapMethodArguments);
+      }
+
+      @Override
+      public void visitJumpInsn(int opcode, Label label) {
+        visitAnything();
+        super.visitJumpInsn(opcode, label);
+      }
+
+      @Override
+      public void visitLabel(Label label) {
+        visitAnything();
+        if (handlers.contains(label)) {
+          blockCounter.registerFinallyBlockStart();
+        }
+        super.visitLabel(label);
+      }
+
+      @Override
+      public void visitLdcInsn(Object value) {
+        visitAnything();
+        super.visitLdcInsn(value);
+      }
+
+      @Override
+      public void visitIincInsn(int var, int increment) {
+        visitAnything();
+        super.visitIincInsn(var, increment);
+      }
+
+      @Override
+      public void visitTableSwitchInsn(int min, int max, Label dflt,
+          Label... labels) {
+        visitAnything();
+        super.visitTableSwitchInsn(min, max, dflt, labels);
+      }
+
+      @Override
+      public void visitLookupSwitchInsn(Label dflt, int[] keys,
+          Label[] labels) {
+        visitAnything();
+        super.visitLookupSwitchInsn(dflt, keys, labels);
+      }
+
+      @Override
+      public void visitMultiANewArrayInsn(String descriptor,
+          int numDimensions) {
+        visitAnything();
+        super.visitMultiANewArrayInsn(descriptor, numDimensions);
+      }
+
+      @Override
+      public void visitLineNumber(int line, Label start) {
+        visitAnything();
+        super.visitLineNumber(line, start);
+      }
+    });
+  }
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/ConcreteBlockCounter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/blocks/ConcreteBlockCounter.java
@@ -3,11 +3,13 @@ package org.pitest.mutationtest.engine.gregor.blocks;
 public class ConcreteBlockCounter implements BlockCounter {
 
   private int     currentBlock = 0;
+  private int     currentBlockThisMethod = 0;
   private boolean isWithinExceptionHandler;
 
   @Override
   public void registerNewBlock() {
     this.currentBlock++;
+    this.currentBlockThisMethod++;
   }
 
   @Override
@@ -20,8 +22,17 @@ public class ConcreteBlockCounter implements BlockCounter {
     this.isWithinExceptionHandler = false;
   }
 
+  @Override
+  public void registerNewMethodStart() {
+    currentBlockThisMethod = 0;
+  }
+
   public int getCurrentBlock() {
     return this.currentBlock;
+  }
+
+  public int getCurrentBlockThisMethod() {
+    return this.currentBlockThisMethod;
   }
 
   public boolean isWithinFinallyBlock() {

--- a/pitest/src/main/java/sun/pitest/CodeCoverageStore.java
+++ b/pitest/src/main/java/sun/pitest/CodeCoverageStore.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.pitest.coverage.analysis.Block;
+
 /**
  * Store for line visit information.
  */
@@ -585,9 +587,10 @@ public final class CodeCoverageStore {
   }
 
   public static void registerMethod(final int clazz, final String methodName,
-      final String methodDesc, final int firstProbe, final int lastProbe) {
+      final String methodDesc, final int firstProbe, final int lastProbe,
+      Iterable<Block> blocks) {
     invokeQueue.registerProbes(clazz, methodName, methodDesc, firstProbe,
-        lastProbe);
+        lastProbe, blocks);
   }
 
   private static synchronized int nextId() {

--- a/pitest/src/main/java/sun/pitest/InvokeReceiver.java
+++ b/pitest/src/main/java/sun/pitest/InvokeReceiver.java
@@ -1,10 +1,12 @@
 package sun.pitest;
 
+import org.pitest.coverage.analysis.Block;
+
 public interface InvokeReceiver {
 
   void registerClass(int id, String className);
 
   void registerProbes(int classId, String methodName, String methodDesc,
-      int firstProbe, int lastProbe);
+      int firstProbe, int lastProbe, Iterable<Block> blocks);
 
 }

--- a/pitest/src/test/java/com/example/coverage/execute/samples/simple/ThreeMultiLineBlocks.java
+++ b/pitest/src/test/java/com/example/coverage/execute/samples/simple/ThreeMultiLineBlocks.java
@@ -2,11 +2,14 @@ package com.example.coverage.execute.samples.simple;
 
 public class ThreeMultiLineBlocks {
   int foo(int i) {
+    i++;
     System.out.println("foo");
     if (i > 30) {
+      i++;
       System.out.println("foo");
       return 1;
     }
+    i++;
     System.out.println("foo");
     return 2;
   }

--- a/pitest/src/test/java/org/pitest/bytecode/MethodDecoratorTest.java
+++ b/pitest/src/test/java/org/pitest/bytecode/MethodDecoratorTest.java
@@ -14,21 +14,26 @@
  */
 package org.pitest.bytecode;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.objectweb.asm.Opcodes.NOP;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 public abstract class MethodDecoratorTest {
 
-  protected abstract MethodVisitor getTesteeVisitor();
-
   @Mock
   protected MethodVisitor mv;
+
+  protected abstract MethodVisitor getTesteeVisitor();
 
   @Before
   public void setUp() {
@@ -37,12 +42,16 @@ public abstract class MethodDecoratorTest {
 
   @Test
   public void shouldForwardVisitCodeCallsToChild() {
-    getTesteeVisitor().visitCode();
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitCode();
   }
 
   @Test
   public void shouldForwardVisitEndCallsToChild() {
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
     getTesteeVisitor().visitEnd();
     verify(this.mv).visitEnd();
   }
@@ -50,50 +59,67 @@ public abstract class MethodDecoratorTest {
   @Test
   public void shouldForwardVisitAnnotationCallsToChild() {
     getTesteeVisitor().visitAnnotation("foo", true);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitAnnotation("foo", true);
   }
 
   @Test
   public void shouldForwardVisitAnnotationDefaultCallsToChild() {
-    getTesteeVisitor().visitAnnotationDefault();
+    AnnotationVisitor av = getTesteeVisitor().visitAnnotationDefault();
+    if (av != null)
+      av.visit("foo", "bar");
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitAnnotationDefault();
   }
 
   @Test
   public void shouldForwardVisitAttributeCallsToChild() {
     getTesteeVisitor().visitAttribute(null);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitAttribute(null);
   }
 
   @Test
   public void shouldForwardVisitFieldInsnCallsToChild() {
     getTesteeVisitor().visitFieldInsn(1, "2", "3", "4");
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitFieldInsn(1, "2", "3", "4");
   }
 
   @Test
   public void shouldForwardVisitFrameCallsToChild() {
-    final Object[] f1 = { 1, 2, 3 };
+    final Object[] f1 = { 1, 2 };
     final Object[] f2 = { 2, 4, 6 };
-    getTesteeVisitor().visitFrame(1, 2, f1, 3, f2);
-    verify(this.mv).visitFrame(1, 2, f1, 3, f2);
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitFrame(Opcodes.F_FULL, 2, f1, 3, f2);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv).visitFrame(Opcodes.F_FULL, 2, f1, 3, f2);
   }
 
   @Test
   public void shouldForwardVisitIincInsnToChild() {
     getTesteeVisitor().visitIincInsn(1, 2);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitIincInsn(1, 2);
   }
 
   @Test
   public void shouldForwardVisitInsnToChild() {
     getTesteeVisitor().visitInsn(1);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitInsn(1);
   }
 
   @Test
   public void shouldForwardVisitIntInsnToChild() {
     getTesteeVisitor().visitIntInsn(1, 2);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitIntInsn(1, 2);
   }
 
@@ -101,19 +127,25 @@ public abstract class MethodDecoratorTest {
   public void shouldForwardVisitJumpInsnToChild() {
     final Label l = new Label();
     getTesteeVisitor().visitJumpInsn(1, l);
-    verify(this.mv).visitJumpInsn(1, l);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv).visitJumpInsn(eq(1), any(Label.class));
   }
 
   @Test
   public void shouldForwardVisitLabelToChild() {
     final Label l = new Label();
     getTesteeVisitor().visitLabel(l);
-    verify(this.mv).visitLabel(l);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv).visitLabel(any(Label.class));
   }
 
   @Test
   public void shouldForwardVisitLdcInsnToChild() {
     getTesteeVisitor().visitLdcInsn(1);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitLdcInsn(1);
   }
 
@@ -121,15 +153,23 @@ public abstract class MethodDecoratorTest {
   public void shouldForwardVisitLineNumberToChild() {
     final Label l = new Label();
     getTesteeVisitor().visitLineNumber(1, l);
-    verify(this.mv).visitLineNumber(1, l);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv).visitLineNumber(eq(1), any(Label.class));
   }
 
   @Test
   public void shouldForwardVisitLocalVariableToChild() {
     final Label l = new Label();
     final Label l2 = new Label();
+    getTesteeVisitor().visitCode();
+    getTesteeVisitor().visitInsn(NOP);
     getTesteeVisitor().visitLocalVariable("foo", "bar", "one", l, l2, 2);
-    verify(this.mv).visitLocalVariable("foo", "bar", "one", l, l2, 2);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv)
+        .visitLocalVariable(eq("foo"), eq("bar"), eq("one"), any(Label.class),
+            any(Label.class), eq(2));
   }
 
   @Test
@@ -138,30 +178,41 @@ public abstract class MethodDecoratorTest {
     final Label[] l2 = { new Label() };
     final int[] i = { 1, 2, 3 };
     getTesteeVisitor().visitLookupSwitchInsn(l, i, l2);
-    verify(this.mv).visitLookupSwitchInsn(l, i, l2);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv)
+        .visitLookupSwitchInsn(any(Label.class), eq(i), any(Label[].class));
   }
 
   @Test
   public void shouldForwardVisitMaxsToChild() {
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
     getTesteeVisitor().visitMaxs(1, 2);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitMaxs(1, 2);
   }
 
   @Test
   public void shouldForwardVisitMethodInsnToChild() {
     getTesteeVisitor().visitMethodInsn(1, "a", "b", "c", false);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitMethodInsn(1, "a", "b", "c", false);
   }
 
   @Test
   public void shouldForwardVisitMultiANewArrayInsnToChild() {
     getTesteeVisitor().visitMultiANewArrayInsn("foo", 1);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitMultiANewArrayInsn("foo", 1);
   }
 
   @Test
   public void shouldForwardVisitParameterAnnotationToChild() {
     getTesteeVisitor().visitParameterAnnotation(1, "foo", false);
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
     verify(this.mv).visitParameterAnnotation(1, "foo", false);
   }
 
@@ -170,7 +221,10 @@ public abstract class MethodDecoratorTest {
     final Label l = new Label();
     final Label[] l2 = { new Label() };
     getTesteeVisitor().visitTableSwitchInsn(1, 2, l, l2);
-    verify(this.mv).visitTableSwitchInsn(1, 2, l, l2);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv)
+        .visitTableSwitchInsn(eq(1), eq(2), any(Label.class), any(Label.class));
   }
 
   @Test
@@ -178,8 +232,13 @@ public abstract class MethodDecoratorTest {
     final Label l = new Label();
     final Label l2 = new Label();
     final Label l3 = new Label();
+
     getTesteeVisitor().visitTryCatchBlock(l, l2, l3, "foo");
-    verify(this.mv).visitTryCatchBlock(l, l2, l3, "foo");
+    getTesteeVisitor().visitInsn(NOP);
+    getTesteeVisitor().visitInsn(Opcodes.ATHROW);
+    getTesteeVisitor().visitEnd();
+    verify(this.mv).visitTryCatchBlock(any(Label.class), any(Label.class),
+        any(Label.class), eq("foo"));
   }
 
 }

--- a/pitest/src/test/java/org/pitest/coverage/CoverageResultTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/CoverageResultTest.java
@@ -38,7 +38,7 @@ public class CoverageResultTest {
   private BlockLocation makeCoverage(final String name, final int block) {
     final Location l = Location.location(ClassName.fromString(name),
         MethodName.fromString("amethod"), "methodDesc");
-    final BlockLocation bl = new BlockLocation(l, block);
+    final BlockLocation bl = new BlockLocation(l, block, 0, 1);
     return bl;
   }
 

--- a/pitest/src/test/java/org/pitest/coverage/codeassist/LineMapperTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/codeassist/LineMapperTest.java
@@ -65,8 +65,14 @@ public class LineMapperTest {
         MethodName.fromString("foo"), "(I)I");
 
     assertThat(actual.get(BlockLocation.blockLocation(l, 0))).contains(5, 6);
-    assertThat(actual.get(BlockLocation.blockLocation(l, 1))).contains(7, 8);
-    assertThat(actual.get(BlockLocation.blockLocation(l, 2))).contains(10, 11);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 1))).contains(6);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 2))).contains(7);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 3))).contains(8, 9);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 4))).contains(9);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 5))).contains(10);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 6))).contains(12, 13);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 7))).contains(13);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 8))).contains(14);
   }
 
   @Test
@@ -87,7 +93,7 @@ public class LineMapperTest {
         ClassName.fromClass(LastLineOfContructorCheck.class),
         MethodName.fromString("<init>"), "()V");
 
-    assertThat(actual.get(BlockLocation.blockLocation(l, 0))).contains(6);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 1))).contains(6);
   }
 
   @Test
@@ -95,9 +101,9 @@ public class LineMapperTest {
     final Map<BlockLocation, Set<Integer>> actual = analyse(ThreeBlocks2.class);
     final Location l = Location.location(ClassName.fromClass(ThreeBlocks2.class),
         MethodName.fromString("foo"), "(I)I");
-    assertThat(actual.get(BlockLocation.blockLocation(l, 0))).containsOnly(105);
-    assertThat(actual.get(BlockLocation.blockLocation(l, 1))).containsOnly(106);
-    assertThat(actual.get(BlockLocation.blockLocation(l, 2))).containsOnly(108);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 0))).containsOnly(111);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 1))).containsOnly(112);
+    assertThat(actual.get(BlockLocation.blockLocation(l, 2))).containsOnly(114);
   }
 
   static class ThreeBlocks2 {

--- a/pitest/src/test/java/org/pitest/coverage/codeassist/LineMapperTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/codeassist/LineMapperTest.java
@@ -37,7 +37,7 @@ public class LineMapperTest {
 
     final Location l = Location.location(ClassName.fromClass(OneBlock.class),
         MethodName.fromString("foo"), "()I");
-    final BlockLocation bl = new BlockLocation(l, 0);
+    final BlockLocation bl = new BlockLocation(l, 0, -1, -1);
 
     assertThat(actual.get(bl)).containsOnly(5);
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapterTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidAssertsMethodAdapterTest.java
@@ -28,6 +28,7 @@ public class AvoidAssertsMethodAdapterTest extends MethodDecoratorTest {
   public void setUp() {
     super.setUp();
     this.testee = new AvoidAssertsMethodAdapter(this.context, this.mv);
+    this.testee.visitCode();
   }
 
   @Test

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidStringSwitchedMethodAdapterTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/AvoidStringSwitchedMethodAdapterTest.java
@@ -28,6 +28,7 @@ public class AvoidStringSwitchedMethodAdapterTest extends MethodDecoratorTest {
   public void setUp() {
     super.setUp();
     this.testee = new AvoidStringSwitchedMethodAdapter(this.context, this.mv);
+    this.testee.visitCode();
   }
 
   @Test

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/TestGregorMutater.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/TestGregorMutater.java
@@ -207,13 +207,6 @@ public class TestGregorMutater extends MutatorTestBase {
     }
   }
 
-  @Test
-  public void shouldRecordMutationsAsInDifferentBlocksWhenInDifferentMethods() {
-    createTesteeWith(Mutator.byName("INCREMENTS"));
-    final List<MutationDetails> actualDetails = findMutationsFor(TwoMethods.class);
-    assertTwoMutationsInDifferentBlocks(actualDetails);
-  }
-
   public static class SwitchStatement {
     public void a(int i, final int b) {
       switch (b) {
@@ -252,12 +245,12 @@ public class TestGregorMutater extends MutatorTestBase {
   }
 
   @Test
-  public void shouldRecordMutationsAsInSameBlockWhenSwitchStatementFallsThrough() {
+  public void shouldNotRecordMutationsAsInSameBlockWhenSwitchStatementFallsThrough() {
     createTesteeWith(Mutator.byName("INCREMENTS"));
     final List<MutationDetails> actualDetails = findMutationsFor(FallThroughSwitch.class);
     assertEquals(2, actualDetails.size());
     final int firstMutationBlock = actualDetails.get(0).getBlock();
-    assertEquals(firstMutationBlock, actualDetails.get(1).getBlock());
+    assertEquals(firstMutationBlock+1, actualDetails.get(1).getBlock());
   }
 
   public static class HasExceptionBlock {

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/blocks/BlockTrackingMethodDecoratorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/blocks/BlockTrackingMethodDecoratorTest.java
@@ -8,6 +8,7 @@ import static org.objectweb.asm.Opcodes.FRETURN;
 import static org.objectweb.asm.Opcodes.ICONST_0;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.LRETURN;
+import static org.objectweb.asm.Opcodes.NOP;
 import static org.objectweb.asm.Opcodes.RETURN;
 
 import org.junit.Before;
@@ -15,6 +16,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.pitest.bytecode.MethodDecoratorTest;
 
 public class BlockTrackingMethodDecoratorTest extends MethodDecoratorTest {
@@ -28,7 +30,8 @@ public class BlockTrackingMethodDecoratorTest extends MethodDecoratorTest {
   @Before
   public void setUp() {
     super.setUp();
-    this.testee = new BlockTrackingMethodDecorator(this.tracker, this.mv);
+    this.testee = new BlockTrackingMethodDecorator(this.tracker, this.mv, 0,
+        "foo", "(II)V", null, null);
   }
 
   @Test
@@ -37,7 +40,9 @@ public class BlockTrackingMethodDecoratorTest extends MethodDecoratorTest {
     final Label start = new Label();
     final Label handler = new Label();
     this.testee.visitTryCatchBlock(start, end, handler, null);
+    this.testee.visitInsn(Opcodes.NOP);
     this.testee.visitLabel(handler);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockStart();
   }
 
@@ -60,79 +65,106 @@ public class BlockTrackingMethodDecoratorTest extends MethodDecoratorTest {
 
   @Test
   public void shouldRegisiterNewBlockForJumpInstructions() {
-    this.testee.visitJumpInsn(0, null);
+    this.testee.visitJumpInsn(0, new Label());
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(ARETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterNewBlockForReturnInstructions() {
     this.testee.visitInsn(RETURN);
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(RETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForReturnInstructions() {
     this.testee.visitInsn(RETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 
   @Test
   public void shouldRegisterNewBlockForAReturnInstructions() {
     this.testee.visitInsn(ARETURN);
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(ARETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForAReturnInstructions() {
     this.testee.visitInsn(ARETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 
   @Test
   public void shouldRegisterNewBlockForFReturnInstructions() {
     this.testee.visitInsn(FRETURN);
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(FRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForFReturnInstructions() {
     this.testee.visitInsn(FRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 
   @Test
   public void shouldRegisterNewBlockForIReturnInstructions() {
     this.testee.visitInsn(IRETURN);
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(IRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForIReturnInstructions() {
     this.testee.visitInsn(IRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 
   @Test
   public void shouldRegisterNewBlockForLReturnInstructions() {
     this.testee.visitInsn(LRETURN);
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(LRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForLReturnInstructions() {
     this.testee.visitInsn(LRETURN);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 
   @Test
   public void shouldRegisterNewBlockForAThrowInstructions() {
     this.testee.visitInsn(ATHROW); // possible without also getting a jump??
+    this.testee.visitInsn(NOP);
+    this.testee.visitInsn(ATHROW);
+    this.testee.visitEnd();
     verify(this.tracker).registerNewBlock();
   }
 
   @Test
   public void shouldRegisterFinallyBlockEndForAThrowInstructions() {
     this.testee.visitInsn(ATHROW);
+    this.testee.visitEnd();
     verify(this.tracker).registerFinallyBlockEnd();
   }
 


### PR DESCRIPTION
We found that PIT can erroneously report mutants as "survived" when they should actually be NO_COVERAGE (and should never even be executed). This is because the initial block-based coverage collection assumes that no instructions throw exceptions, and hence, PIT will attempt to mutate instructions that are never actually covered, but are assumed to be covered (based on the block definition). I've created a test that shows this (VerifyBlockCoverageIT. shouldNotRunMutantsOnLinesUncoveredByExceptions).

We also noticed that PIT was deciding on which test-mutant pairs to run based on _line_ coverage, rather than _block_ coverage (even though block coverage is what is collected). I've created a test that shows this too (VerifyBlockCoverageIT. shouldNotRunMutantsOnCoveredLineButNotCovered).

This PR resolves both of these issues by:
1. Modifying the ControlFlowAnalyser to consider instructions that might throw an exception as ending a basic block (for coverage purposes).
2. Refactor the block counter that is used in mutation running to use the same exact notion of block (the implementation previously did not match up exactly, and hence, the block index for the same instruction would differ in the coverage minion and the mutation minion)
3. Modify the test prioritiser to use block index to determine where to insert a mutant rather than line number.

I've also modified many of the unit/integration tests that had a tight coupling on line number/block number to match with this new approach. 

Anecdotally this does not seem to have a significant performance impact - but if you have performance concerns and a preferred way to measure coverage/mutation performance I'm happy to do optimization as necessary. 