### PR TITLE
GregorMutater line 98 Minor Bug Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 .checkstyle
 dependency-reduced-pom.xml
 */bin
+DS_Store
+*~

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/GregorMutater.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/GregorMutater.java
@@ -95,7 +95,7 @@ public class GregorMutater implements Mutater {
     context.setTargetMutation(Optional.ofNullable(id));
 
     final Optional<byte[]> bytes = this.byteSource.getBytes(id.getClassName()
-        .asJavaName());
+        .asInternalName()); // getBytes expects internal name of the class!
 
     final ClassReader reader = new ClassReader(bytes.get());
     final ClassWriter w = new ComputeClassWriter(this.byteSource,


### PR DESCRIPTION
GregorMutater line 98 changed from asJavaName to asInternalName so that we can take advantage of caching of ByteArraySource.