### PR TITLE
Ignore empty element from plugin configuration

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.apache.maven.artifact.Artifact;
@@ -17,6 +18,8 @@ import org.apache.maven.project.MavenProject;
 import org.pitest.coverage.CoverageSummary;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import org.pitest.mutationtest.config.PluginServices;
 import org.pitest.mutationtest.config.ReportOptions;
 import org.pitest.mutationtest.statistics.MutationStatistics;
@@ -487,7 +490,7 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getTargetClasses() {
-    return this.targetClasses;
+    return withoutNulls(this.targetClasses);
   }
 
   public void setTargetClasses(ArrayList<String> targetClasses) {
@@ -495,7 +498,7 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getTargetTests() {
-    return this.targetTests;
+    return withoutNulls(this.targetTests);
   }
 
   public void setTargetTests(ArrayList<String> targetTests) {
@@ -503,15 +506,15 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getExcludedMethods() {
-    return this.excludedMethods;
+    return withoutNulls(this.excludedMethods);
   }
 
   public List<String> getExcludedClasses() {
-    return this.excludedClasses;
+    return withoutNulls(this.excludedClasses);
   }
 
   public List<String> getAvoidCallsTo() {
-    return this.avoidCallsTo;
+    return withoutNulls(this.avoidCallsTo);
   }
 
   public File getReportsDirectory() {
@@ -531,7 +534,7 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getMutators() {
-    return this.mutators;
+    return withoutNulls(this.mutators);
   }
 
   public float getTimeoutFactor() {
@@ -543,7 +546,7 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public ArrayList<String> getExcludedTestClasses() {
-    return excludedTestClasses;
+    return withoutNulls(excludedTestClasses);
   }
 
   public int getMaxMutationsPerClass() {
@@ -551,11 +554,11 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getJvmArgs() {
-    return this.jvmArgs;
+    return withoutNulls(this.jvmArgs);
   }
 
   public List<String> getOutputFormats() {
-    return this.outputFormats;
+    return withoutNulls(this.outputFormats);
   }
 
   public boolean isVerbose() {
@@ -575,15 +578,15 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getExcludedGroups() {
-    return this.excludedGroups;
+    return withoutNulls(this.excludedGroups);
   }
 
   public List<String> getIncludedGroups() {
-    return this.includedGroups;
+    return withoutNulls(this.includedGroups);
   }
 
   public List<String> getIncludedTestMethods() {
-    return this.includedTestMethods;
+    return withoutNulls(this.includedTestMethods);
   }
 
   public boolean isFullMutationMatrix() {
@@ -657,11 +660,11 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public List<String> getAdditionalClasspathElements() {
-    return this.additionalClasspathElements;
+    return withoutNulls(this.additionalClasspathElements);
   }
 
   public List<String> getClasspathDependencyExcludes() {
-    return this.classpathDependencyExcludes;
+    return withoutNulls(this.classpathDependencyExcludes);
   }
 
   public boolean isParseSurefireConfig() {
@@ -685,11 +688,11 @@ public class AbstractPitMojo extends AbstractMojo {
   }
 
   public ArrayList<String> getExcludedRunners() {
-    return excludedRunners;
+    return withoutNulls(excludedRunners);
   }
   
   public ArrayList<String> getFeatures() {
-    return features;
+    return withoutNulls(features);
   }
 
   public String getTestPlugin() {
@@ -714,6 +717,16 @@ public class AbstractPitMojo extends AbstractMojo {
     public List<String> getReasons() {
       return Collections.unmodifiableList(reasons);
     }
+  }
+
+  private <X> ArrayList<X> withoutNulls(List<X> originalList) {
+    if (originalList == null) {
+      return null;
+    }
+
+    return originalList.stream()
+        .filter(Objects::nonNull)
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -31,9 +31,9 @@ public class AbstractPitMojo extends AbstractMojo {
 
   private final Predicate<MavenProject> notEmptyProject;
   
-  protected final Predicate<Artifact> filter;
+  private final Predicate<Artifact>   filter;
 
-  protected final PluginServices      plugins;
+  private final PluginServices        plugins;
 
   // Concrete List types declared for all fields to work around maven 2 bug
   
@@ -47,13 +47,13 @@ public class AbstractPitMojo extends AbstractMojo {
    * Classes to include in mutation test
    */
   @Parameter(property = "targetClasses")
-  protected ArrayList<String>         targetClasses;
+  private ArrayList<String>           targetClasses;
 
   /**
    * Tests to run
    */
   @Parameter(property = "targetTests")
-  protected ArrayList<String>         targetTests;
+  private ArrayList<String>           targetTests;
 
   /**
    * Methods not to mutate
@@ -349,7 +349,7 @@ public class AbstractPitMojo extends AbstractMojo {
    *
    */
   @Parameter(property = "project", readonly = true, required = true)
-  protected MavenProject              project;
+  private MavenProject                project;
 
   /**
    * <i>Internal</i>: Map of plugin artifacts.
@@ -366,7 +366,7 @@ public class AbstractPitMojo extends AbstractMojo {
   @Parameter(property = "useClasspathJar", defaultValue = "false")
   private boolean                     useClasspathJar;
 
-  protected final GoalStrategy        goalStrategy;
+  private final GoalStrategy          goalStrategy;
 
   public AbstractPitMojo() {
     this(new RunPitStrategy(), new DependencyFilter(new PluginServices(
@@ -474,12 +474,32 @@ public class AbstractPitMojo extends AbstractMojo {
     return executionProject.getBasedir();
   }
 
+  protected Predicate<Artifact> getFilter() {
+    return filter;
+  }
+
+  protected GoalStrategy getGoalStrategy() {
+    return goalStrategy;
+  }
+
+  protected PluginServices getPlugins() {
+    return plugins;
+  }
+
   public List<String> getTargetClasses() {
     return this.targetClasses;
   }
 
+  public void setTargetClasses(ArrayList<String> targetClasses) {
+    this.targetClasses = targetClasses;
+  }
+
   public List<String> getTargetTests() {
     return this.targetTests;
+  }
+
+  public void setTargetTests(ArrayList<String> targetTests) {
+    this.targetTests = targetTests;
   }
 
   public List<String> getExcludedMethods() {

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -165,7 +165,7 @@ public class MojoToReportOptionsConverter {
 
   private void useHistoryFileInTempDir(final ReportOptions data) {
     String tempDir = System.getProperty("java.io.tmpdir");
-    MavenProject project = this.mojo.project;
+    MavenProject project = this.mojo.getProject();
     String name = project.getGroupId() + "."
         + project.getArtifactId() + "."
         + project.getVersion() + "_pitest_history.bin";

--- a/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
@@ -115,9 +115,9 @@ public class ScmMojo extends AbstractPitMojo {
       this.scmRootDir = findScmRootDir();
     }
 
-    this.targetClasses = makeConcreteList(findModifiedClassNames());
+    setTargetClasses(makeConcreteList(findModifiedClassNames()));
 
-    if (this.targetClasses.isEmpty()) {
+    if (this.getTargetClasses().isEmpty()) {
       this.getLog().info(
           "No modified files found - nothing to mutation test, analyseLastCommit=" + this.analyseLastCommit);
       return Optional.empty();
@@ -126,11 +126,11 @@ public class ScmMojo extends AbstractPitMojo {
     logClassNames();
     defaultTargetTestsIfNoValueSet();
     final ReportOptions data = new MojoToReportOptionsConverter(this,
-        new SurefireConfigConverter(), filter).convert();
+        new SurefireConfigConverter(), getFilter()).convert();
     data.setFailWhenNoMutations(false);
 
-    return Optional.ofNullable(this.goalStrategy.execute(detectBaseDir(), data,
-        plugins, new HashMap<String, String>()));
+    return Optional.ofNullable(this.getGoalStrategy().execute(detectBaseDir(), data,
+        getPlugins(), new HashMap<String, String>()));
 
   }
 
@@ -138,20 +138,20 @@ public class ScmMojo extends AbstractPitMojo {
     if (this.getTargetTests() == null || this.getTargetTests().isEmpty()) {
       File tests = new File(this.getProject().getBuild()
       .getTestOutputDirectory());
-      this.targetTests = new ArrayList<>(MojoToReportOptionsConverter
-          .findOccupiedPackagesIn(tests));
+      setTargetTests(new ArrayList<>(MojoToReportOptionsConverter
+          .findOccupiedPackagesIn(tests)));
     }
   }
 
   private void logClassNames() {
-    for (final String each : this.targetClasses) {
+    for (final String each : this.getTargetClasses()) {
       this.getLog().info("Will mutate changed class " + each);
     }
   }
 
   private List<String> findModifiedClassNames() throws MojoExecutionException {
 
-    final File sourceRoot = new File(this.project.getBuild()
+    final File sourceRoot = new File(this.getProject().getBuild()
         .getSourceDirectory());
 
     final List<String> modifiedPaths = FCollection.map(findModifiedPaths(), pathByScmDir());
@@ -165,7 +165,7 @@ public class ScmMojo extends AbstractPitMojo {
   }
 
   private File findScmRootDir() {
-    MavenProject rootProject = this.project;
+    MavenProject rootProject = this.getProject();
     while (rootProject.hasParent() && rootProject.getParent().getBasedir() != null) {
       rootProject = rootProject.getParent();
     }
@@ -268,17 +268,17 @@ public class ScmMojo extends AbstractPitMojo {
 
   private String getSCMConnection() throws MojoExecutionException {
 
-    if (this.project.getScm() == null) {
+    if (this.getProject().getScm() == null) {
       throw new MojoExecutionException("No SCM Connection configured.");
     }
 
-    final String scmConnection = this.project.getScm().getConnection();
+    final String scmConnection = this.getProject().getScm().getConnection();
     if ("connection".equalsIgnoreCase(this.connectionType)
         && StringUtils.isNotEmpty(scmConnection)) {
       return scmConnection;
     }
 
-    final String scmDeveloper = this.project.getScm().getDeveloperConnection();
+    final String scmDeveloper = this.getProject().getScm().getDeveloperConnection();
     if ("developerconnection".equalsIgnoreCase(this.connectionType)
         && StringUtils.isNotEmpty(scmDeveloper)) {
       return scmDeveloper;

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -126,8 +126,10 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
     setVariableValueToObject(pitMojo, "project", this.project);
 
-    ArrayList<String> elements = new ArrayList<>();
-    setVariableValueToObject(pitMojo, "additionalClasspathElements", elements);
+    if (pitMojo.getAdditionalClasspathElements() == null) {
+      ArrayList<String> elements = new ArrayList<>();
+      setVariableValueToObject(pitMojo, "additionalClasspathElements", elements);
+    }
 
   }
 

--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -1,5 +1,6 @@
 package org.pitest.maven;
 
+import static java.util.Arrays.asList;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -146,6 +147,231 @@ public class PitMojoTest extends BasePitMojoTest {
         + "                    </environmentVariables>"));
 
     assertEquals(mojo.getEnvironmentVariables().get("DISPLAY"), ":20");
+  }
+
+  public void testEmptyTargetClassIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <targetClasses>\n"
+        + "    <targetClass>net.example.ClassName</targetClass>\n"
+        + "    <targetClass>net.example.Other</targetClass>\n"
+        + "    <targetClass></targetClass>\n"
+        + "  </targetClasses>"));
+
+    assertEquals(
+        asList("net.example.ClassName", "net.example.Other"),
+        mojo.getTargetClasses());
+  }
+
+  public void testEmptyTargetTestIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <targetTests>\n"
+        + "    <targetTest>net.example.ClassNameTest</targetTest>\n"
+        + "    <targetTest>net.example.OtherTest</targetTest>\n"
+        + "    <targetTest></targetTest>\n"
+        + "  </targetTests>"));
+
+    assertEquals(
+        asList("net.example.ClassNameTest", "net.example.OtherTest"),
+        mojo.getTargetTests());
+  }
+
+
+  public void testEmptyExcludedMethodIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <excludedMethods>\n"
+        + "    <excludedMethod>*method1</excludedMethod>\n"
+        + "    <excludedMethod>*method2</excludedMethod>\n"
+        + "    <excludedMethod></excludedMethod>\n"
+        + "  </excludedMethods>"));
+
+    assertEquals(
+        asList("*method1", "*method2"),
+        mojo.getExcludedMethods());
+  }
+
+  public void testEmptyExcludedClassIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <excludedClasses>\n"
+        + "    <excludedClass>net.example.BadClass</excludedClass>\n"
+        + "    <excludedClass>net.example.WorstClass</excludedClass>\n"
+        + "    <excludedClass></excludedClass>\n"
+        + "  </excludedClasses>"));
+
+    assertEquals(
+        asList("net.example.BadClass", "net.example.WorstClass"),
+        mojo.getExcludedClasses());
+  }
+
+  public void testEmptyAvoidCallsToValueIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <avoidCallsTo>\n"
+        + "    <avoidCallsTo>net.example.methodA</avoidCallsTo>\n"
+        + "    <avoidCallsTo>net.example.methodB</avoidCallsTo>\n"
+        + "    <avoidCallsTo></avoidCallsTo>\n"
+        + "  </avoidCallsTo>"));
+
+    assertEquals(
+        asList("net.example.methodA", "net.example.methodB"),
+        mojo.getAvoidCallsTo());
+  }
+
+  public void testEmptyMutatorIsIgnored() throws Exception{
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <mutators>\n"
+        + "    <mutator>MUTATOR_1</mutator>\n"
+        + "    <mutator>MUTATOR_2</mutator>\n"
+        + "    <mutator></mutator>\n"
+        + "  </mutators>"));
+
+    assertEquals(
+        asList("MUTATOR_1", "MUTATOR_2"),
+        mojo.getMutators());
+  }
+
+  public void testEmptyExcludedTestClassIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <excludedTestClasses>\n"
+        + "    <excludedTestClass>TestClass1</excludedTestClass>\n"
+        + "    <excludedTestClass>TestClass2</excludedTestClass>\n"
+        + "    <excludedTestClass></excludedTestClass>\n"
+        + "  </excludedTestClasses>"));
+
+    assertEquals(
+        asList("TestClass1", "TestClass2"),
+        mojo.getExcludedTestClasses());
+  }
+
+  public void testEmptyJvmArgIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <jvmArgs>\n"
+        + "    <jvmArg>-Dnet.sample.param=42</jvmArg>\n"
+        + "    <jvmArg>-Dnet.sample.fun=true</jvmArg>\n"
+        + "    <jvmArg></jvmArg>\n"
+        + "  </jvmArgs>"));
+
+    assertEquals(
+        asList("-Dnet.sample.param=42", "-Dnet.sample.fun=true"),
+        mojo.getJvmArgs());
+  }
+
+  public void testEmptyOutputFormatIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <outputFormats>\n"
+        + "    <outputFormat>XML</outputFormat>\n"
+        + "    <outputFormat>HTML</outputFormat>\n"
+        + "    <outputFormat></outputFormat>\n"
+        + "  </outputFormats>"));
+
+    assertEquals(
+        asList("XML", "HTML"),
+        mojo.getOutputFormats());
+  }
+
+  public void testEmptyExcludedGroupIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <excludedGroups>\n"
+        + "    <excludedGroup>REDS</excludedGroup>\n"
+        + "    <excludedGroup>GREENS</excludedGroup>\n"
+        + "    <excludedGroup></excludedGroup>\n"
+        + "  </excludedGroups>"));
+
+    assertEquals(
+        asList("REDS", "GREENS"),
+        mojo.getExcludedGroups());
+  }
+
+  public void testEmptyIncludedGroupIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <includedGroups>\n"
+        + "    <includedGroup>YELLOWS</includedGroup>\n"
+        + "    <includedGroup>PURPLES</includedGroup>\n"
+        + "    <includedGroup></includedGroup>\n"
+        + "  </includedGroups>"));
+
+    assertEquals(
+        asList("YELLOWS", "PURPLES"),
+        mojo.getIncludedGroups());
+  }
+
+  public void testEmptyIncludedTestMethodIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <includedTestMethods>\n"
+        + "    <includedTestMethod>testA</includedTestMethod>\n"
+        + "    <includedTestMethod>testB</includedTestMethod>\n"
+        + "    <includedTestMethod></includedTestMethod>\n"
+        + "  </includedTestMethods>"));
+
+    assertEquals(
+        asList("testA", "testB"),
+        mojo.getIncludedTestMethods());
+  }
+
+  public void testEmptyAdditionalClasspathElementIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <additionalClasspathElements>\n"
+        + "    <additionalClasspathElement>stuff.jar</additionalClasspathElement>\n"
+        + "    <additionalClasspathElement>thing.jar</additionalClasspathElement>\n"
+        + "    <additionalClasspathElement></additionalClasspathElement>\n"
+        + "  </additionalClasspathElements>"));
+
+    assertEquals(
+        asList("stuff.jar", "thing.jar"),
+        mojo.getAdditionalClasspathElements());
+  }
+
+  public void testEmptyClasspathDependencyExcludeIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <classpathDependencyExcludes>\n"
+        + "    <classpathDependencyExclude>bad.jar</classpathDependencyExclude>\n"
+        + "    <classpathDependencyExclude>unwanted.jar</classpathDependencyExclude>\n"
+        + "    <classpathDependencyExclude></classpathDependencyExclude>\n"
+        + "  </classpathDependencyExcludes>"));
+
+    assertEquals(
+        asList("bad.jar", "unwanted.jar"),
+        mojo.getClasspathDependencyExcludes());
+  }
+
+  public void testEmptyExcludedRunnerIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <excludedRunners>\n"
+        + "    <excludedRunner>SimpleRunner</excludedRunner>\n"
+        + "    <excludedRunner>FastRunner</excludedRunner>\n"
+        + "    <excludedRunner></excludedRunner>\n"
+        + "  </excludedRunners>"));
+
+    assertEquals(
+        asList("SimpleRunner", "FastRunner"),
+        mojo.getExcludedRunners());
+  }
+
+  public void testEmptyFeatureIsIgnored() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+        + "  <features>\n"
+        + "    <feature>DO_THAT_THING</feature>\n"
+        + "    <feature>BE_AWESOME</feature>\n"
+        + "    <feature></feature>\n"
+        + "  </features>"));
+
+    assertEquals(
+        asList("DO_THAT_THING", "BE_AWESOME"),
+        mojo.getFeatures());
   }
 
   private void setupCoverage(long mutationScore, int lines, int linesCovered)


### PR DESCRIPTION
As highlighted by https://github.com/hcoles/pitest/issues/539, throwing a `NullPointerException` when the plugin configuration contains an empty element is not the most user friendly behavior.

This pull request change `AbstractPitMojo` getters to filter out nulls from lists. This way, empty elements in configuration will be ignored.

Before the actual bug fix, fields were made private and getters and setters were created as needed.

*PR history:*
A first version of this PR replaced `ArrayList` fields and return types by `List`. This was removed to keep compatible with maven 2.