### PR TITLE
fixed compile issues with CRCR tests on windows

### DIFF
--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR1Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR1Test.java
@@ -183,7 +183,7 @@ public class CRCR1Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -194,8 +194,8 @@ public class CRCR1Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWith1() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant,
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant,
         1);
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR2Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR2Test.java
@@ -183,7 +183,7 @@ public class CRCR2Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -194,8 +194,8 @@ public class CRCR2Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWith0() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant,
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant,
         0);
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR3Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR3Test.java
@@ -183,7 +183,7 @@ public class CRCR3Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -194,8 +194,8 @@ public class CRCR3Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWithMinus1() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant,
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant,
         -1);
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR4Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR4Test.java
@@ -183,7 +183,7 @@ public class CRCR4Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -194,8 +194,8 @@ public class CRCR4Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWithMinusConstant() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant,
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant,
         -2144567);
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR5Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR5Test.java
@@ -184,7 +184,7 @@ public class CRCR5Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -195,8 +195,8 @@ public class CRCR5Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWithConstantPlus1() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant,
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant,
         2144568);
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR6Test.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/rv/CRCR6Test.java
@@ -184,7 +184,7 @@ public class CRCR6Test extends MutatorTestBase {
   }
 
 
-  private static class HasIntegerLdc implements Callable<Integer> {
+  private static class HasIntegerLDC2 implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
@@ -195,8 +195,8 @@ public class CRCR6Test extends MutatorTestBase {
 
   @Test
   public void shouldReplaceIntegerLdcWithConstantMinus1() throws Exception {
-    final Mutant mutant = getFirstMutant(HasIntegerLdc.class);
-    assertMutantCallableReturns(new HasIntegerLdc(), mutant, 2144566);
+    final Mutant mutant = getFirstMutant(HasIntegerLDC2.class);
+    assertMutantCallableReturns(new HasIntegerLDC2(), mutant, 2144566);
   }
 
   private static class HasLongLCONST0 implements Callable<Long> {


### PR DESCRIPTION
This fixes the first compile issue I ran into when compiling the project on windows. ( See https://github.com/hcoles/pitest/issues/311#issuecomment-462561250 )

Inner classes are stored as separate class files under the target directory. In these tests, it has 2 inner classes named `HasIntegerLDC` and `HasIntegerLdc`. Unfortunately, windows doesn't allow the 2 files with the same name in different cases. The fix is to just rename the inner classes that conflict.

In checkstyle project, we ensure our project can compile on windows by using appveyor CI. Pitest could consider using it too.