### PR TITLE
Add support for testPlugin and failWhenNoMutations to ant plugin

### DIFF
--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -188,6 +188,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
     this.setOption(ConfigOption.OUTPUT_FORMATS, value);
   }
 
+  public void setFailWhenNoMutations(final String value) {
+    this.setOption(ConfigOption.FAIL_WHEN_NOT_MUTATIONS, value);
+  }
+
   public void setSourceDir(final String value) {
     this.setOption(ConfigOption.SOURCE_DIR, value);
   }
@@ -202,6 +206,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
 
   public void setMutableCodePaths(final String glob) {
     setOption(ConfigOption.CODE_PATHS, glob);
+  }
+
+  public void setTestPlugin(final String value) {
+    this.setOption(ConfigOption.TEST_PLUGIN, value);
   }
 
   public void setIncludedGroups(final String value) {

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -163,6 +163,13 @@ public class PitestTaskTest {
   }
 
   @Test
+  public void shouldPassFailWhenNoMutationsToJavaTask() {
+    this.pitestTask.setFailWhenNoMutations("true");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--failWhenNoMutations=true");
+  }
+
+  @Test
   public void shouldPassReportDirOptionToJavaTask() {
     this.pitestTask.setReportDir("report/");
     this.pitestTask.execute(this.java);
@@ -244,6 +251,13 @@ public class PitestTaskTest {
     this.pitestTask.setMutableCodePaths("foo");
     this.pitestTask.execute(this.java);
     verify(this.arg).setValue("--mutableCodePaths=foo");
+  }
+
+  @Test
+  public void shouldPassTestPluginToJavaTask() {
+    this.pitestTask.setTestPlugin("junit");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--testPlugin=junit");
   }
 
   @Test


### PR DESCRIPTION
The ant documentation mentions test plugins should be placed with the ant plugin, but the ant plugin doesn't support the `--testPlugin` parameter to choose which one to use.  This adds support for it.

While I was at it, I noticed it also didn't support `--failWhenNoMutations` so I added that too.