### PR TITLE
Add missing PR from release 1.4.4 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Nothing yet, why not contribute?
 * #518 - Experimental BigInteger mutator (thanks @ripdajacker)
 * #513 - Sort mutators in html report (thanks @ThLeu)
 * #553 - Classic mutators from literature (thanls @LaurentTho3)
+* #528 - Added skipFailingTests option from maven plugin (thanks @nicerloop)
 
 <details>
     <summary>Older versions</summary>


### PR DESCRIPTION
Because of a comment on https://github.com/hcoles/pitest/pull/528, I noticed that this PR was not mentioned in the version content. This PR put it in the list.
 
The same change should be done on the github release.