### PR TITLE
Make child JVM headless by default

### DIFF
--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static org.pitest.mutationtest.config.ReportOptions.DEFAULT_CHILD_JVM_ARGS;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -101,7 +102,12 @@ public class OptionsParserTest {
   @Test
   public void shouldParseCommaSeparatedListOfJVMArgs() {
     final ReportOptions actual = parseAddingRequiredArgs("--jvmArgs", "foo,bar");
-    assertEquals(Arrays.asList("foo", "bar"), actual.getJvmArgs());
+
+    List<String> expected = new ArrayList<>();
+    expected.addAll(DEFAULT_CHILD_JVM_ARGS);
+    expected.add("foo");
+    expected.add("bar");
+    assertEquals(expected, actual.getJvmArgs());
   }
 
   @Test

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -61,6 +61,8 @@ import org.pitest.util.Unchecked;
  */
 public class ReportOptions {
 
+  public static final List<String> DEFAULT_CHILD_JVM_ARGS = Collections.singletonList("-Djava.awt.headless=true");
+
   public static final Collection<String> LOGGING_CLASSES                = Arrays
       .asList(
           "java.util.logging",
@@ -93,7 +95,7 @@ public class ReportOptions {
 
   private int                            dependencyAnalysisMaxDistance;
 
-  private final List<String>             jvmArgs                        = new ArrayList<>();
+  private final List<String>             jvmArgs                        = new ArrayList<>(DEFAULT_CHILD_JVM_ARGS);
   private int                            numberOfThreads                = 0;
   private float                          timeoutFactor                  = PercentAndConstantTimeoutStrategy.DEFAULT_FACTOR;
   private long                           timeoutConstant                = PercentAndConstantTimeoutStrategy.DEFAULT_CONSTANT;

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.Repository;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.mockito.Mockito;
 import java.util.function.Predicate;
@@ -104,7 +106,13 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
         "                      <param>bar</param>" + //
         "                  </jvmArgs>";
     final ReportOptions actual = parseConfig(xml);
-    assertEquals(Arrays.asList("foo", "bar"), actual.getJvmArgs());
+
+    List<String> expectedArgs = new ArrayList<>();
+    expectedArgs.addAll(ReportOptions.DEFAULT_CHILD_JVM_ARGS);
+    expectedArgs.add("foo");
+    expectedArgs.add("bar");
+
+    assertEquals(expectedArgs, actual.getJvmArgs());
   }
 
   public void testParsesListOfMutationOperators() {


### PR DESCRIPTION
This will avoid the constant keyboard focus loss on mac that is mentionned un #581.