### PR TITLE
OpenJ9 11 Travis build + some other Travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,35 +15,27 @@ env:
 
 matrix:
   include:
-    # Open jdk 8 mvn 3.2.5
     - jdk: openjdk8
       env: MAVEN=3.2.5
 
-    # Java 8 mvn 3.3.9
     - jdk: oraclejdk8
       env: MAVEN=3.3.9
     
-    # Java 9 mvn 3.5.4
-    - jdk: oraclejdk9
+    - jdk: openjdk9
+      env: MAVEN=3.5.4
+    
+    - jdk: openjdk10
+      env: MAVEN=3.5.4
+    
+    - jdk: openjdk11
       env: MAVEN=3.5.4
 
-    # Java 9 mvn 3.2.5
-    - env: JDK='JDK9' MAVEN=3.2.5
-      install: . ./install-jdk.sh -F 9 -L GPL
-    
-    # Java 10 mvn 3.5.4
-    - env: JDK='JDK 10' MAVEN=3.5.4
-      install: . ./install-jdk.sh -F 10 -L GPL
-    
-    # Java 11 mvn 3.5.4
-    - env: JDK='JDK 11' MAVEN=3.5.4
-      install: . ./install-jdk.sh -F 11 -L BCL 
+    - jdk: openjdk12
+      env: MAVEN=3.5.4
 
-    # OpenJ9 8 mvn 3.5.4
     - env: JDK='OpenJ9 8' MAVEN=3.5.4
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
 
-    # OpenJ9 11 mvn 3.5.4
     - env: JDK='OpenJ9 11' MAVEN=3.5.4
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,14 @@ matrix:
     - env: JDK='JDK 11' MAVEN=3.5.4
       install: . ./install-jdk.sh -F 11 -L BCL 
 
+    # OpenJ9 8 mvn 3.5.4
+    - env: JDK='OpenJ9 8' MAVEN=3.5.4
+      install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
+
+    # OpenJ9 11 mvn 3.5.4
+    - env: JDK='OpenJ9 11' MAVEN=3.5.4
+      install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
+
 script:
   - wget $(echo -n $BASEURL | sed -e 's#VERSION#'$MAVEN'#g')
   - tar -xvzf $(echo -n $FILE | sed -e 's#VERSION#'$MAVEN'#')

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ matrix:
     - env: JDK='OpenJ9 11' MAVEN=3.5.4
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
 
+  # Java 12 build fails
+  allow_failures:
+    - jdk: openjdk12
+      env: MAVEN=3.5.4
+
 script:
   - wget $(echo -n $BASEURL | sed -e 's#VERSION#'$MAVEN'#g')
   - tar -xvzf $(echo -n $FILE | sed -e 's#VERSION#'$MAVEN'#')

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
     - jdk: openjdk12
       env: MAVEN=3.5.4
 
-    - env: JDK='OpenJ9 8' MAVEN=3.5.4
-      install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
-
     - env: JDK='OpenJ9 11' MAVEN=3.5.4
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
 


### PR DESCRIPTION
I initially wanted to just add OpenJ9 11 build on Travis, but along the way I also added builds for newer Java versions and simplified a build matrix (newer Java versions are available out-of-box).

The Java 12 build [fails](https://travis-ci.org/szpak/pitest/jobs/530166058) - among other as 1.6 as a class level is no longer supported. I left it as "allow_failures" to have it fixed by you on your own way (a basic smoke test in my Gradle plugin works [fine](https://travis-ci.org/szpak/gradle-pitest-plugin/jobs/530015469) with Java 12 in general)

In addition there is a [problem](https://travis-ci.org/szpak/pitest/jobs/530162313#L7842) with PowerMock and OpenJ9 8. It's a [known limitation](https://github.com/powermock/powermock/issues/970) and I don't know if you want to bother with that (so I removed that build completely).

I divided PR into a few commits to make it easier to remove some of them if needed.