### PR TITLE
Fixes for issue 597

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
@@ -107,12 +107,9 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
           .visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
       clinitMv.visitCode();
 
-      clinitMv.visitIntInsn(
-          (this.classId <= Byte.MAX_VALUE ? Opcodes.BIPUSH : Opcodes.SIPUSH),
-          this.classId);
-      clinitMv.visitIntInsn(
-          (1 + this.probeCount <= Byte.MAX_VALUE ? Opcodes.BIPUSH : Opcodes.SIPUSH),
-          1 + this.probeCount);
+
+      pushConstant(clinitMv, this.classId);
+      pushConstant(clinitMv, this.probeCount);
       clinitMv
           .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,
               "getOrRegisterClassProbes", "(II)[Z", false);
@@ -122,6 +119,37 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
       clinitMv.visitInsn(Opcodes.RETURN);
       clinitMv.visitMaxs(0, 0);
       clinitMv.visitEnd();
+    }
+  }
+
+  private void pushConstant(MethodVisitor mv, int value) {
+    switch (value) {
+      case 0:
+        mv.visitInsn(Opcodes.ICONST_0);
+        break;
+      case 1:
+        mv.visitInsn(Opcodes.ICONST_1);
+        break;
+      case 2:
+        mv.visitInsn(Opcodes.ICONST_2);
+        break;
+      case 3:
+        mv.visitInsn(Opcodes.ICONST_3);
+        break;
+      case 4:
+        mv.visitInsn(Opcodes.ICONST_4);
+        break;
+      case 5:
+        mv.visitInsn(Opcodes.ICONST_5);
+        break;
+      default:
+        if (value <= Byte.MAX_VALUE) {
+          mv.visitIntInsn(Opcodes.BIPUSH, value);
+        } else if (value <= Short.MAX_VALUE) {
+          mv.visitIntInsn(Opcodes.SIPUSH, value);
+        } else {
+          mv.visitLdcInsn(value);
+        }
     }
   }
 

--- a/pitest/src/main/java/org/pitest/coverage/analysis/ArrayProbeCoverageMethodVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/ArrayProbeCoverageMethodVisitor.java
@@ -87,7 +87,7 @@ public class ArrayProbeCoverageMethodVisitor extends AbstractCoverageStrategy {
   @Override
   void prepare() {
     if (getName().equals("<clinit>")) {
-        this.mv.visitIntInsn(Opcodes.SIPUSH, this.classId);
+        pushConstant(this.classId);
         this.mv.visitFieldInsn(Opcodes.GETSTATIC, this.className, CodeCoverageStore.PROBE_LENGTH_FIELD_NAME,"I");
         this.mv
             .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,

--- a/pitest/src/main/java/org/pitest/util/StreamUtil.java
+++ b/pitest/src/main/java/org/pitest/util/StreamUtil.java
@@ -27,6 +27,10 @@ public abstract class StreamUtil {
 
   private static void copy(final InputStream input, final OutputStream output)
       throws IOException {
+    //Ensure that this thread does not have the "interrupted" flag set, otherwise
+    //the NIO calls will throw an java.nio.channels.ClosedByInterruptException
+    Thread.interrupted();
+
     final ReadableByteChannel src = Channels.newChannel(input);
     final WritableByteChannel dest = Channels.newChannel(output);
     final ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);


### PR DESCRIPTION
The coverage changes I introduced in 1.4.7 will break if more that `Short.MAX_VALUE` classes are loaded - this patch resolves that limitation.

This patch also adds a defensive `Thread.interrupted()` check before copying class data in the `JavassistCoverageInterceptor`. The NIO utilities will throw a `ClosedByInterruptException` if the thread was interrupted (and didn't have its flag cleared) before these methods are called. Poorly-behaved tests might interrupt a thread, not clear the interrupt flag, then trigger class loading, which would then result in this exception.