### PR TITLE
Enhance error message on not enabled test plugin

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
@@ -138,9 +138,9 @@ public class DefaultCoverageGenerator implements CoverageGenerator {
     final ExitCode exitCode = process.waitToDie();
 
     if (exitCode == ExitCode.JUNIT_ISSUE) {
-      LOG.severe("Error generating coverage. Please check that your classpath contains JUnit 4.6 or above.");
+      LOG.severe("Error generating coverage. Please check that your classpath contains JUnit 4.6+ or PIT test plugin for other test tool is enabled.");
       throw new PitError(
-          "Coverage generation minion exited abnormally. Please check the classpath.");
+          "Coverage generation minion exited abnormally. Please check the classpath and/or enable test plguin for used test tool.");
     } else if (!exitCode.isOk()) {
       LOG.severe("Coverage generator Minion exited abnormally due to "
           + exitCode);


### PR DESCRIPTION
I ran into that in https://github.com/szpak/gradle-pitest-plugin/issues/129 - when the testng plugin was not enabled.
If I understand correctly that error message means that no JUnit 4.6+ is on a classpath and no test plugin is enabled for other test tools (assuming they are on a classpath).

Feel free to adjust the message to your preferences.