### PR TITLE
Fix Mutator map key for AOD2

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -247,7 +247,7 @@ public final class Mutator {
      * mutators that replace a binary arithmetic operations with one of its members.
      */
     add("AOD1", AOD1Mutator.AOD_1_MUTATOR);
-    add("AOD1", AOD2Mutator.AOD_2_MUTATOR);
+    add("AOD2", AOD2Mutator.AOD_2_MUTATOR);
 
 
     /**


### PR DESCRIPTION
Without this change, you can only configure AOD2 (but called AOD1) manually,
and if you configure ALL, you get AOD2.
Only if add the complete AOD group, you get both.