### PR TITLE
Do not include the current directory to the minion class path

### DIFF
--- a/pitest/src/main/java/org/pitest/classpath/CompoundClassPathRoot.java
+++ b/pitest/src/main/java/org/pitest/classpath/CompoundClassPathRoot.java
@@ -67,7 +67,10 @@ public class CompoundClassPathRoot implements ClassPathRoot,
     for (final ClassPathRoot each : this.roots) {
       final Optional<String> additional = each.cacheLocation();
       if (additional.isPresent()) {
-        classpath = classpath.append(File.pathSeparator + additional.get());
+        if (classpath.length() != 0) {
+          classpath.append(File.pathSeparator);
+        }
+        classpath.append(additional.get());
       }
     }
 


### PR DESCRIPTION
Without this change, the calculated class path starts with `;`, which causes the current working directory to be part of the classpath.
This can greatly falsify the results.
In my case I had a dumped classfile in the current working directory, and as the current working directory was in the start of the class path, it was taken instead of the real class.
This PR fixes that behavior.