### PR TITLE
Do not print the class name twice for unsplittable test units

### DIFF
--- a/pitest/src/main/java/org/pitest/testapi/Description.java
+++ b/pitest/src/main/java/org/pitest/testapi/Description.java
@@ -49,7 +49,7 @@ public final class Description implements Serializable {
   }
 
   public String getQualifiedName() {
-    if (this.testClass != null) {
+    if ((this.testClass != null) && !this.testClass.equals(this.getName())) {
       return this.getFirstTestClass() + "." + this.getName();
     } else {
       return this.getName();


### PR DESCRIPTION
Fixes #657