### PR TITLE
TestNG 7.0.0 compatibility

### DIFF
--- a/pitest-maven-verification/src/test/resources/pit-testng-jmockit/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-testng-jmockit/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.8.8</version>
+			<version>6.9.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pitest-maven-verification/src/test/resources/pit-testng/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-testng/pom.xml
@@ -10,7 +10,7 @@
 		<dependency>
 			<groupId>org.testng</groupId>
 			<artifactId>testng</artifactId>
-			<version>6.1.1</version>
+			<version>6.9.10</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pitest/src/main/java/org/pitest/testng/TestNGTestUnit.java
+++ b/pitest/src/main/java/org/pitest/testng/TestNGTestUnit.java
@@ -26,6 +26,7 @@ import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
+import org.testng.ITestNGListener;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.TestNG;
@@ -47,8 +48,9 @@ public class TestNGTestUnit extends AbstractTestUnit {
   private static final MutableTestListenerWrapper LISTENER = new MutableTestListenerWrapper();
 
   static {
-    TESTNG.addListener(LISTENER);
-    TESTNG.addInvokedMethodListener(new FailFast(LISTENER));
+    // force using TestNG.addListener(ITestNGListener) to be compatible with TestNG 7.x
+    TESTNG.addListener((ITestNGListener)LISTENER);
+    TESTNG.addListener((ITestNGListener)new FailFast(LISTENER));
   }
 
   private final Class<?>                     clazz;

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
 		<maven.version>2.2.1</maven.version>
 		<powermock.version>1.7.3</powermock.version>
 		<surefire.version>2.17</surefire.version>
-		<testng.version>6.8.21</testng.version>
+		<testng.version>6.9.10</testng.version>
 		<slf4j.version>1.7.12</slf4j.version>
 
 		<maven.failsafe-plugin.version>${surefire.version}</maven.failsafe-plugin.version>


### PR DESCRIPTION
Bump the TestNG version to 6.9.10 and force the use of TestNG.addListener(ITestNGListener).

TestNG 7.0.0 removed various deprecated specialized TestNG.addListener methods.
Using TestNG.addListener(ITestNGListener) explicitly keeps PITest binary-compatible with the new TestNG 7.x releases.

This fixes #634