### PR TITLE
Allow custom locations for Test Classes. 

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -47,6 +47,7 @@ import static org.pitest.mutationtest.config.ConfigOption.REPORT_DIR;
 import static org.pitest.mutationtest.config.ConfigOption.SOURCE_DIR;
 import static org.pitest.mutationtest.config.ConfigOption.TARGET_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_FILTER;
+import static org.pitest.mutationtest.config.ConfigOption.TEST_PATHS;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_PLUGIN;
 import static org.pitest.mutationtest.config.ConfigOption.THREADS;
 import static org.pitest.mutationtest.config.ConfigOption.TIMEOUT_CONST;
@@ -114,6 +115,7 @@ public class OptionsParser {
   private final OptionSpec<File>                     classPathFile;
   private final ArgumentAcceptingOptionSpec<Boolean> failWhenNoMutations;
   private final ArgumentAcceptingOptionSpec<String>  codePaths;
+  private final ArgumentAcceptingOptionSpec<String>  testPaths;
   private final OptionSpec<String>                   excludedGroupsSpec;
   private final OptionSpec<String>                   includedGroupsSpec;
   private final OptionSpec<String>                   includedTestMethodsSpec;
@@ -287,6 +289,14 @@ public class OptionsParser {
         .describedAs(
             "Globs identifying classpath roots containing mutable code");
 
+    this.testPaths = parserAccepts(TEST_PATHS)
+        .withRequiredArg()
+        .ofType(String.class)
+        .withValuesSeparatedBy(',')
+        .describedAs(
+            "Globs identifying classpath roots containing code with test classes");
+
+
     this.includedGroupsSpec = parserAccepts(INCLUDED_GROUPS).withRequiredArg()
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("TestNG groups/JUnit categories to include");
@@ -413,6 +423,7 @@ public class OptionsParser {
     data.addOutputFormats(this.outputFormatSpec.values(userArgs));
     data.setFailWhenNoMutations(this.failWhenNoMutations.value(userArgs));
     data.setCodePaths(this.codePaths.values(userArgs));
+    data.setTestPaths(this.testPaths.values(userArgs));
     data.setMutationUnitSize(this.mutationUnitSizeSpec.value(userArgs));
 
     data.setHistoryInputLocation(this.historyInputSpec.value(userArgs));

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -319,6 +319,13 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldParseCommaSeparatedListOfTestPaths() {
+    final ReportOptions actual = parseAddingRequiredArgs("--testCodePaths",
+        "foo,bar");
+    assertEquals(Arrays.asList("foo", "bar"), actual.getTestPaths());
+  }
+
+  @Test
   public void shouldParseCommaSeparatedListOfExcludedTestGroups() {
     final ReportOptions actual = parseAddingRequiredArgs("--excludedGroups",
         "foo,bar");

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -133,6 +133,10 @@ public enum ConfigOption {
    */
   CODE_PATHS("mutableCodePaths"),
   /**
+   * Filter defining paths that should be treated as containing test code
+   */
+  TEST_PATHS("testCodePaths"),
+  /**
    * TestNG groups/JUnit categories to include
    */
   INCLUDED_GROUPS("includedGroups"),

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -83,6 +83,8 @@ public class ReportOptions {
 
   private Collection<String>             codePaths;
 
+  private Collection<String>             testPaths;
+
   private String                         reportDir;
 
   private File                           historyInputLocation;
@@ -399,8 +401,16 @@ public class ReportOptions {
   }
 
   private PathFilter createPathFilter() {
-    return new PathFilter(createCodePathFilter(),
-        not(new DefaultDependencyPathPredicate()));
+    return new PathFilter(createCodePathFilter(), createTestPathFilter());
+  }
+
+  private Predicate<ClassPathRoot> createTestPathFilter() {
+    if ((this.testPaths != null) && !this.testPaths.isEmpty()) {
+      return new PathNamePredicate(Prelude.or(Glob
+          .toGlobPredicates(this.testPaths)));
+    } else {
+      return not(new DefaultDependencyPathPredicate());
+    }
   }
 
   private Predicate<ClassPathRoot> createCodePathFilter() {
@@ -418,6 +428,14 @@ public class ReportOptions {
 
   public void setCodePaths(final Collection<String> codePaths) {
     this.codePaths = codePaths;
+  }
+
+  public Collection<String> getTestPaths() {
+    return testPaths;
+  }
+
+  public void setTestPaths(Collection<String> testPaths) {
+    this.testPaths = testPaths;
   }
 
   public void setGroupConfig(final TestGroupConfig groupConfig) {


### PR DESCRIPTION
Default behavior (i.e. `not(DefaultDependencyPathPredicate())`) assumes that compiled test classes are ALWAYS flatten and are not in JAR/ZIP archives. 

However, BUCK [java_test](https://buck.build/rule/java_test.html) target puts test classes into JARs. 

I guess BAZEL does the same.