### PR TITLE
solved issue #705: '+' in path name is now allowed

### DIFF
--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -26,12 +26,14 @@ public class Glob implements Predicate<String> {
   private final Pattern regex;
 
   public Glob(final String glob) {
+    String rectifiedGlob;
     if (glob.startsWith("~")) {
-      this.regex = Pattern.compile(glob.substring(1));
+      rectifiedGlob = glob.substring(1);
     } else {
-      this.regex = Pattern.compile(convertGlobToRegex(glob)
-      );
+      rectifiedGlob = convertGlobToRegex(glob);
     }
+    rectifiedGlob = rectifiedGlob.replace("+", "\\+");
+    this.regex = Pattern.compile(rectifiedGlob);
   }
 
   public boolean matches(final CharSequence seq) {


### PR DESCRIPTION
I think we can work around issue #705 by replacing every "+" with "\\+" in the regular expressions used in the class org.pitest.util.Glob.