### PR TITLE
Turns on the new mutator set by default

### DIFF
--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/javafeatures/TryWithResourcesFilterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/javafeatures/TryWithResourcesFilterTest.java
@@ -12,7 +12,7 @@ public class TryWithResourcesFilterTest {
 
   TryWithResourcesFilter testee = new TryWithResourcesFilter();
 
-  FilterTester verifier = new FilterTester(PATH, this.testee, Mutator.defaults());
+  FilterTester verifier = new FilterTester(PATH, this.testee, Mutator.oldDefaults());
 
   @Test
   public void shouldDeclareTypeAsFilter() {

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/logging/LoggingCallsFilterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/logging/LoggingCallsFilterTest.java
@@ -30,7 +30,7 @@ public class LoggingCallsFilterTest {
   @Before
   public void setUp() {
     final ClassloaderByteArraySource source = ClassloaderByteArraySource.fromContext();
-    final Collection<MethodMutatorFactory> mutators = Mutator.defaults();
+    final Collection<MethodMutatorFactory> mutators = Mutator.oldDefaults();
     this.mutator = new GregorMutater(source, m -> true, mutators);
   }
 

--- a/pitest-entry/src/test/java/org/pitest/plugin/export/MutantExportInterceptorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/plugin/export/MutantExportInterceptorTest.java
@@ -29,7 +29,7 @@ public class MutantExportInterceptorTest {
 
   @Before
   public void setUp() {
-    final Collection<MethodMutatorFactory> mutators = Mutator.defaults();
+    final Collection<MethodMutatorFactory> mutators = Mutator.oldDefaults();
     this.mutator = new GregorMutater(this.source, m -> true, mutators);
     this.testee = new MutantExportInterceptor(this.fileSystem, this.source, "target");
   }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/GregorEngineFactory.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/GregorEngineFactory.java
@@ -49,7 +49,7 @@ public final class GregorEngineFactory implements MutationEngineFactory {
     if ((mutators != null) && !mutators.isEmpty()) {
       return Mutator.fromStrings(mutators);
     } else {
-      return Mutator.defaults();
+      return Mutator.newDefaults();
     }
 
   }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -176,10 +176,10 @@ public final class Mutator {
     researchMutators();
 
     addGroup("REMOVE_SWITCH", RemoveSwitchMutator.makeMutators());
-    addGroup("DEFAULTS", defaults());
+    addGroup("OLD_DEFAULTS", oldDefaults());
     addGroup("STRONGER", stronger());
     addGroup("ALL", all());
-    addGroup("NEW_DEFAULTS", newDefaults());
+    addGroup("DEFAULTS", newDefaults());
     addGroup("AOR", aor());
     addGroup("AOD", aod());
     addGroup("CRCR", crcr());
@@ -289,7 +289,7 @@ public final class Mutator {
 
   private static Collection<MethodMutatorFactory> stronger() {
     return combine(
-        defaults(),
+        newDefaults(),
         group(new RemoveConditionalMutator(Choice.EQUAL, false),
             new SwitchMutator()));
   }
@@ -305,7 +305,7 @@ public final class Mutator {
    * Default set of mutators - designed to provide balance between strength and
    * performance
    */
-  public static Collection<MethodMutatorFactory> defaults() {
+  public static Collection<MethodMutatorFactory> oldDefaults() {
     return group(InvertNegsMutator.INVERT_NEGS_MUTATOR,
         ReturnValsMutator.RETURN_VALS_MUTATOR, MathMutator.MATH_MUTATOR,
         VoidMethodCallMutator.VOID_METHOD_CALL_MUTATOR,


### PR DESCRIPTION
The new mutators set provides more stable return type mutators with a more easily understood behaviour. There were concerns that it may result in increased numbers of equivalent mutators, but the filters for these seem to be working well.

This PR renames the NEW_DEFAULTS mutator set to DEFAULTS and create a group called OLD_DEFAULTS to allow access to the original set.

History files will be invalidated by this change and should be deleted when upgrading.