### PR TITLE
bump maven-checkstyle-plugin to 3.1.0

### DIFF
--- a/pitest-build-config/src/main/resources/pitest/checkstyle.xml
+++ b/pitest-build-config/src/main/resources/pitest/checkstyle.xml
@@ -7,6 +7,8 @@
 
 <module name="Checker">
 
+	<property name="cacheFile" value="${checkstyle.cache.file}" />
+
 	<!-- Checks that each Java package has a Javadoc file used for commenting. -->
 	<!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
 	<!-- <module name="JavadocPackage"> <property name="allowLegacy" value="true"/> 
@@ -33,8 +35,6 @@
 		<property name="message" value="Line has trailing spaces."/> </module> -->
 
 	<module name="TreeWalker">
-
-		<property name="cacheFile" value="${checkstyle.cache.file}" />
 
 		<!-- Checks for Javadoc comments. -->
 		<!-- See http://checkstyle.sf.net/config_javadoc.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.15</version>
+					<version>3.1.0</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.pitest</groupId>
@@ -181,7 +181,9 @@
 							<configuration>
 								<failOnViolation>true</failOnViolation>
 								<configLocation>pitest/checkstyle.xml</configLocation>
-                                <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>	
+								<sourceDirectories>
+									<sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+								</sourceDirectories>
 							</configuration>
 						</execution>
 					</executions>


### PR DESCRIPTION
old version of 2.15 was using checkstyle 6.1.1 by default.
new version of 3.1.0 is using checkstyle 8.19 by default.
This is still not the latest version of checkstyle.