### PR TITLE
#723 Upgraded versions of vulnerable transitive dependencies in pitest-maven

### DIFF
--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -102,6 +102,8 @@
 			<artifactId>maven-reporting-api</artifactId>
 			<version>${maven.version}</version>
 		</dependency>
+		<!-- commons-collections, commons-beanutils, and plexus-utils specified
+		 due to vulnerable versions used by maven-reporting-impl:2.0.4.3-->
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
@@ -137,6 +139,8 @@
 			<artifactId>maven-scm-manager-plexus</artifactId>
 			<version>${scm.version}</version>
 		</dependency>
+		<!-- Specifying groovy-all because maven-scm-providers-standard:1.9.4
+		 relies on a vulnerable version of groovy-all-->
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>

--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -103,6 +103,21 @@
 			<version>${maven.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>1.9.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.3.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-impl</artifactId>
 			<version>2.0.4.3</version>
@@ -121,6 +136,12 @@
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-manager-plexus</artifactId>
 			<version>${scm.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.groovy</groupId>
+			<artifactId>groovy-all</artifactId>
+			<version>2.4.18</version>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,25 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>owasp-dependency-check</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.owasp</groupId>
+						<artifactId>dependency-check-maven</artifactId>
+						<version>5.3.0</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<!-- common dependencies used in all subprojects -->
@@ -270,26 +289,8 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.0.1</version>
 				</plugin>
-				<plugin>
-					<groupId>org.owasp</groupId>
-					<artifactId>dependency-check-maven</artifactId>
-					<version>5.3.0</version>
-					<executions>
-						<execution>
-							<goals>
-								<goal>check</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
 			</plugins>
 		</pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.owasp</groupId>
-				<artifactId>dependency-check-maven</artifactId>
-			</plugin>
-		</plugins>
 	</build>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -270,8 +270,26 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.0.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.owasp</groupId>
+					<artifactId>dependency-check-maven</artifactId>
+					<version>5.3.0</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>check</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+			</plugin>
+		</plugins>
 	</build>
 
 	<distributionManagement>


### PR DESCRIPTION
Upgraded versions of vulnerable transitive dependencies in pitest-maven and adding the OWASP Dependency Check plugin to the pitest-parent POM

Upgraded versions of vulnerable transitive dependencies, placing them immediately before the dependencies where they are used to ensure that Maven excludes the transitive dependencies:
- commons-collections, commons-beanutils, and plexus-utils are all used by maven-reporting-impl
- groovy-all is a transitive dependency of maven-scm-providers-standard.  It is used by maven-scm-provider-integrity

Added the OWASP Dependency Check plugin to the pitest-parent POM to allow it to be run in any module.