### PR TITLE
Add skipFailingTests flag to command line PIT

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -44,6 +44,7 @@ import static org.pitest.mutationtest.config.ConfigOption.MUTATION_UNIT_SIZE;
 import static org.pitest.mutationtest.config.ConfigOption.OUTPUT_FORMATS;
 import static org.pitest.mutationtest.config.ConfigOption.PLUGIN_CONFIGURATION;
 import static org.pitest.mutationtest.config.ConfigOption.REPORT_DIR;
+import static org.pitest.mutationtest.config.ConfigOption.SKIP_FAILING_TESTS;
 import static org.pitest.mutationtest.config.ConfigOption.SOURCE_DIR;
 import static org.pitest.mutationtest.config.ConfigOption.TARGET_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_FILTER;
@@ -113,6 +114,7 @@ public class OptionsParser {
   private final OptionSpec<String>                   additionalClassPathSpec;
   private final OptionSpec<File>                     classPathFile;
   private final ArgumentAcceptingOptionSpec<Boolean> failWhenNoMutations;
+  private final ArgumentAcceptingOptionSpec<Boolean> skipFailingTests;
   private final ArgumentAcceptingOptionSpec<String>  codePaths;
   private final OptionSpec<String>                   excludedGroupsSpec;
   private final OptionSpec<String>                   includedGroupsSpec;
@@ -280,6 +282,10 @@ public class OptionsParser {
         .withOptionalArg().ofType(Boolean.class).defaultsTo(true)
         .describedAs("whether to throw error if no mutations found");
 
+    this.skipFailingTests = parserAccepts(SKIP_FAILING_TESTS)
+            .withOptionalArg().ofType(Boolean.class).defaultsTo(false)
+            .describedAs("whether to ignore failing tests when computing coverage");
+
     this.codePaths = parserAccepts(CODE_PATHS)
         .withRequiredArg()
         .ofType(String.class)
@@ -412,6 +418,7 @@ public class OptionsParser {
 
     data.addOutputFormats(this.outputFormatSpec.values(userArgs));
     data.setFailWhenNoMutations(this.failWhenNoMutations.value(userArgs));
+    data.setSkipFailingTests(this.skipFailingTests.value(userArgs));
     data.setCodePaths(this.codePaths.values(userArgs));
     data.setMutationUnitSize(this.mutationUnitSizeSpec.value(userArgs));
 

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -312,6 +312,19 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldDetermineIfSkipFailingTestsFlagIsSet() {
+    assertTrue(parseAddingRequiredArgs("--skipFailingTests", "true")
+        .skipFailingTests());
+    assertFalse(parseAddingRequiredArgs("--skipFailingTests", "false")
+        .skipFailingTests());
+  }
+
+  @Test
+  public void shouldSkipFailingTestsNotSetByDefault() {
+    assertFalse(parseAddingRequiredArgs("").skipFailingTests());
+  }
+  
+  @Test
   public void shouldParseCommaSeparatedListOfMutableCodePaths() {
     final ReportOptions actual = parseAddingRequiredArgs("--mutableCodePaths",
         "foo,bar");

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -104,7 +104,7 @@ public enum ConfigOption {
   EXCLUDED_CLASSES("excludedClasses"),
 
   /**
-   * Filter defining test classes to excludd
+   * Filter defining test classes to excluded
    */
   EXCLUDED_TEST_CLASSES("excludedTestClasses"),
   /**
@@ -128,6 +128,10 @@ public enum ConfigOption {
    * Flag to indicate if an error should be thrown if no mutations found
    */
   FAIL_WHEN_NOT_MUTATIONS("failWhenNoMutations", true),
+  /**
+   * Ignore failing tests when computing coverage. Otherwise, the execution will fail.
+   */
+  SKIP_FAILING_TESTS("skipFailingTests", false),
   /**
    * Filter defining paths that should be treated as containing mutable code
    */


### PR DESCRIPTION
To make it possible to use from the Gradle plugin.

Fixes: https://github.com/szpak/gradle-pitest-plugin/issues/175.