### PR TITLE
Improve error message on non-enabled JUnit 5 plugin

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
@@ -138,7 +138,8 @@ public class DefaultCoverageGenerator implements CoverageGenerator {
     final ExitCode exitCode = process.waitToDie();
 
     if (exitCode == ExitCode.JUNIT_ISSUE) {
-      LOG.severe("Error generating coverage. Please check that your classpath contains JUnit 4.6+ or PIT test plugin for other test tool is enabled.");
+      LOG.severe("Error generating coverage. Please check that your classpath contains modern JUnit 4 or PIT test plugin for other test tool "
+              + "(JUnit 5, TestNG, ...) is enabled.");
       throw new PitError(
           "Coverage generation minion exited abnormally. Please check the classpath and/or enable test plugin for used test tool.");
     } else if (!exitCode.isOk()) {


### PR DESCRIPTION
Someone from the mailing list [understood](https://groups.google.com/d/msg/pitusers/ZSjeBaEDh2s/PIgisRbtAgAJ) recently that JUnit 5.x satisfies the "JUnit 4.6+" requirement.