### PR TITLE
ANT support for the fullMutationMatrix option

### DIFF
--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -28,241 +28,241 @@ import org.pitest.mutationtest.config.ConfigOption;
 
 public class PitestTask extends Task { // NO_UCD (test only)
 
-    private static final String[] REQUIRED_OPTIONS = {
-            ConfigOption.TARGET_CLASSES.getParamName(),
-            ConfigOption.REPORT_DIR.getParamName(),
-            ConfigOption.SOURCE_DIR.getParamName()};
+  private static final String[]     REQUIRED_OPTIONS = {
+      ConfigOption.TARGET_CLASSES.getParamName(),
+      ConfigOption.REPORT_DIR.getParamName(),
+      ConfigOption.SOURCE_DIR.getParamName()        };
 
-    private final Map<String, String> options = new HashMap<>();
+  private final Map<String, String> options          = new HashMap<>();
 
-    /**
-     * Classpath to analyse
-     */
-    private String classpath;
+  /**
+   * Classpath to analyse
+   */
+  private String                    classpath;
 
-    /**
-     * Classpath to pitest and plugins
-     */
-    private String pitClasspath;
+  /**
+   * Classpath to pitest and plugins
+   */
+  private String pitClasspath;
 
-    @Override
-    public void execute() throws BuildException {
-        try {
-            execute(new Java(this));
-        } catch (final Throwable t) {
-            throw new BuildException(t);
-        }
+  @Override
+  public void execute() throws BuildException {
+    try {
+      execute(new Java(this));
+    } catch (final Throwable t) {
+      throw new BuildException(t);
+    }
+  }
+
+  void execute(final Java java) {
+
+    this.setOption(ConfigOption.INCLUDE_LAUNCH_CLASSPATH, "false");
+    this.setOption(ConfigOption.CLASSPATH, generateAnalysisClasspath());
+
+    java.setClasspath(generateLaunchClasspath());
+    java.setClassname(MutationCoverageReport.class.getCanonicalName());
+    java.setFailonerror(true);
+    java.setFork(true);
+
+    checkRequiredOptions();
+    for (final Map.Entry<String, String> option : this.options.entrySet()) {
+      java.createArg().setValue(
+          "--" + option.getKey() + "=" + option.getValue());
     }
 
-    void execute(final Java java) {
+    java.execute();
+  }
 
-        this.setOption(ConfigOption.INCLUDE_LAUNCH_CLASSPATH, "false");
-        this.setOption(ConfigOption.CLASSPATH, generateAnalysisClasspath());
-
-        java.setClasspath(generateLaunchClasspath());
-        java.setClassname(MutationCoverageReport.class.getCanonicalName());
-        java.setFailonerror(true);
-        java.setFork(true);
-
-        checkRequiredOptions();
-        for (final Map.Entry<String, String> option : this.options.entrySet()) {
-            java.createArg().setValue(
-                    "--" + option.getKey() + "=" + option.getValue());
-        }
-
-        java.execute();
+  private Path generateLaunchClasspath() {
+    if (this.pitClasspath == null) {
+      throw new BuildException("You must specify the classpath for pitest and its plugins.");
     }
 
-    private Path generateLaunchClasspath() {
-        if (this.pitClasspath == null) {
-            throw new BuildException("You must specify the classpath for pitest and its plugins.");
-        }
-
-        final Object reference = getProject().getReference(this.pitClasspath);
-        if (reference != null) {
-            this.pitClasspath = reference.toString();
-        }
-
-        return new Path(getProject(), this.pitClasspath);
+    final Object reference = getProject().getReference(this.pitClasspath);
+    if (reference != null) {
+      this.pitClasspath = reference.toString();
     }
 
-    private void checkRequiredOptions() {
-        for (final String requiredOption : REQUIRED_OPTIONS) {
-            if (optionMissing(requiredOption)) {
-                throw new BuildException("You must specify the " + requiredOption + ".");
-            }
-        }
+    return new Path(getProject(), this.pitClasspath);
+  }
+
+  private void checkRequiredOptions() {
+    for (final String requiredOption : REQUIRED_OPTIONS) {
+      if (optionMissing(requiredOption)) {
+        throw new BuildException("You must specify the " + requiredOption + ".");
+      }
+    }
+  }
+
+  private boolean optionMissing(final String option) {
+    return !this.options.keySet().contains(option);
+  }
+
+  private String generateAnalysisClasspath() {
+    if (this.classpath == null) {
+      throw new BuildException("You must specify the classpath.");
     }
 
-    private boolean optionMissing(final String option) {
-        return !this.options.keySet().contains(option);
+    final Object reference = getProject().getReference(this.classpath);
+    if (reference != null) {
+      this.classpath = reference.toString();
     }
 
-    private String generateAnalysisClasspath() {
-        if (this.classpath == null) {
-            throw new BuildException("You must specify the classpath.");
-        }
+    return this.classpath.replaceAll(File.pathSeparator, ",");
 
-        final Object reference = getProject().getReference(this.classpath);
-        if (reference != null) {
-            this.classpath = reference.toString();
-        }
+  }
 
-        return this.classpath.replaceAll(File.pathSeparator, ",");
+  public void setReportDir(final String value) {
+    this.setOption(ConfigOption.REPORT_DIR, value);
+  }
 
+  public void setTargetClasses(final String value) {
+    this.setOption(ConfigOption.TARGET_CLASSES, value);
+  }
+
+  public void setTargetTests(final String value) {
+    this.setOption(ConfigOption.TEST_FILTER, value);
+  }
+
+  public void setDependencyDistance(final String value) {
+    this.setOption(ConfigOption.DEPENDENCY_DISTANCE, value);
+  }
+
+  public void setThreads(final String value) {
+    this.setOption(ConfigOption.THREADS, value);
+  }
+
+  public void setDetectInlinedCode(final String value) {
+    this.setOption(ConfigOption.USE_INLINED_CODE_DETECTION, value);
+  }
+
+  public void setTimestampedReports(final String value) {
+    this.setOption(ConfigOption.TIME_STAMPED_REPORTS, value);
+  }
+
+  public void setMutators(final String value) {
+    this.setOption(ConfigOption.MUTATIONS, value);
+  }
+
+  public void setFeatures(final String value) {
+    this.setOption(ConfigOption.FEATURES, value);
+  }
+
+  public void setExcludedMethods(final String value) {
+    this.setOption(ConfigOption.EXCLUDED_METHOD, value);
+  }
+
+  public void setExcludedClasses(final String value) {
+    this.setOption(ConfigOption.EXCLUDED_CLASSES, value);
+  }
+
+  public void setExcludedTestClasses(final String value) {
+    this.setOption(ConfigOption.EXCLUDED_TEST_CLASSES, value);
+  }
+
+  public void setAvoidCallsTo(final String value) {
+    this.setOption(ConfigOption.AVOID_CALLS, value);
+  }
+
+  public void setVerbose(final String value) {
+    this.setOption(ConfigOption.VERBOSE, value);
+  }
+
+  public void setTimeoutFactor(final String value) {
+    this.setOption(ConfigOption.TIMEOUT_FACTOR, value);
+  }
+
+  public void setTimeoutConst(final String value) {
+    this.setOption(ConfigOption.TIMEOUT_CONST, value);
+  }
+
+  public void setMaxMutationsPerClass(final String value) {
+    this.setOption(ConfigOption.MAX_MUTATIONS_PER_CLASS, value);
+  }
+
+  public void setJvmArgs(final String value) {
+    this.setOption(ConfigOption.CHILD_JVM, value);
+  }
+
+  public void setOutputFormats(final String value) {
+    this.setOption(ConfigOption.OUTPUT_FORMATS, value);
+  }
+
+  public void setFailWhenNoMutations(final String value) {
+    this.setOption(ConfigOption.FAIL_WHEN_NOT_MUTATIONS, value);
+  }
+
+  public void setSourceDir(final String value) {
+    this.setOption(ConfigOption.SOURCE_DIR, value);
+  }
+
+  public void setClasspath(final String classpath) {
+    this.classpath = classpath;
+  }
+
+  public void setPitClasspath(final String classpath) {
+    this.pitClasspath = classpath;
+  }
+
+  public void setMutableCodePaths(final String glob) {
+    setOption(ConfigOption.CODE_PATHS, glob);
+  }
+
+  public void setTestPlugin(final String value) {
+    this.setOption(ConfigOption.TEST_PLUGIN, value);
+  }
+
+  public void setIncludedGroups(final String value) {
+    this.setOption(ConfigOption.INCLUDED_GROUPS, value);
+  }
+
+  public void setExcludedGroups(final String value) {
+    this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
+  }
+
+  public void setIncludedTestMethods(final String value) {
+    this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
+  }
+
+  public void setHistoryInputLocation(final String value) {
+    this.setOption(ConfigOption.HISTORY_INPUT_LOCATION, value);
+  }
+
+  public void setHistoryOutputLocation(final String value) {
+    this.setOption(ConfigOption.HISTORY_OUTPUT_LOCATION, value);
+  }
+
+  public void setMutationThreshold(final String value) {
+    this.setOption(ConfigOption.MUTATION_THRESHOLD, value);
+  }
+
+  public void setMaxSurviving(final String value) {
+    this.setOption(ConfigOption.MAX_SURVIVING, value);
+  }
+
+  public void setCoverageThreshold(final String value) {
+    this.setOption(ConfigOption.COVERAGE_THRESHOLD, value);
+  }
+
+  public void setMutationEngine(String value) {
+    this.setOption(ConfigOption.MUTATION_ENGINE, value);
+  }
+
+  public void setFullMutationMatrix(final String value) {
+    this.setOption(ConfigOption.FULL_MUTATION_MATRIX, value);
+  }
+
+  public void setJVM(String value) {
+    this.setOption(ConfigOption.JVM_PATH, value);
+  }
+
+  private void setOption(final ConfigOption option, final String value) {
+    if (!"".equals(value)) {
+      this.options.put(option.getParamName(), value);
     }
+  }
 
-    public void setReportDir(final String value) {
-        this.setOption(ConfigOption.REPORT_DIR, value);
-    }
-
-    public void setTargetClasses(final String value) {
-        this.setOption(ConfigOption.TARGET_CLASSES, value);
-    }
-
-    public void setTargetTests(final String value) {
-        this.setOption(ConfigOption.TEST_FILTER, value);
-    }
-
-    public void setDependencyDistance(final String value) {
-        this.setOption(ConfigOption.DEPENDENCY_DISTANCE, value);
-    }
-
-    public void setThreads(final String value) {
-        this.setOption(ConfigOption.THREADS, value);
-    }
-
-    public void setDetectInlinedCode(final String value) {
-        this.setOption(ConfigOption.USE_INLINED_CODE_DETECTION, value);
-    }
-
-    public void setTimestampedReports(final String value) {
-        this.setOption(ConfigOption.TIME_STAMPED_REPORTS, value);
-    }
-
-    public void setMutators(final String value) {
-        this.setOption(ConfigOption.MUTATIONS, value);
-    }
-
-    public void setFeatures(final String value) {
-        this.setOption(ConfigOption.FEATURES, value);
-    }
-
-    public void setExcludedMethods(final String value) {
-        this.setOption(ConfigOption.EXCLUDED_METHOD, value);
-    }
-
-    public void setExcludedClasses(final String value) {
-        this.setOption(ConfigOption.EXCLUDED_CLASSES, value);
-    }
-
-    public void setExcludedTestClasses(final String value) {
-        this.setOption(ConfigOption.EXCLUDED_TEST_CLASSES, value);
-    }
-
-    public void setAvoidCallsTo(final String value) {
-        this.setOption(ConfigOption.AVOID_CALLS, value);
-    }
-
-    public void setVerbose(final String value) {
-        this.setOption(ConfigOption.VERBOSE, value);
-    }
-
-    public void setTimeoutFactor(final String value) {
-        this.setOption(ConfigOption.TIMEOUT_FACTOR, value);
-    }
-
-    public void setTimeoutConst(final String value) {
-        this.setOption(ConfigOption.TIMEOUT_CONST, value);
-    }
-
-    public void setMaxMutationsPerClass(final String value) {
-        this.setOption(ConfigOption.MAX_MUTATIONS_PER_CLASS, value);
-    }
-
-    public void setJvmArgs(final String value) {
-        this.setOption(ConfigOption.CHILD_JVM, value);
-    }
-
-    public void setOutputFormats(final String value) {
-        this.setOption(ConfigOption.OUTPUT_FORMATS, value);
-    }
-
-    public void setFailWhenNoMutations(final String value) {
-        this.setOption(ConfigOption.FAIL_WHEN_NOT_MUTATIONS, value);
-    }
-
-    public void setSourceDir(final String value) {
-        this.setOption(ConfigOption.SOURCE_DIR, value);
-    }
-
-    public void setClasspath(final String classpath) {
-        this.classpath = classpath;
-    }
-
-    public void setPitClasspath(final String classpath) {
-        this.pitClasspath = classpath;
-    }
-
-    public void setMutableCodePaths(final String glob) {
-        setOption(ConfigOption.CODE_PATHS, glob);
-    }
-
-    public void setTestPlugin(final String value) {
-        this.setOption(ConfigOption.TEST_PLUGIN, value);
-    }
-
-    public void setIncludedGroups(final String value) {
-        this.setOption(ConfigOption.INCLUDED_GROUPS, value);
-    }
-
-    public void setExcludedGroups(final String value) {
-        this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
-    }
-
-    public void setIncludedTestMethods(final String value) {
-        this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
-    }
-
-    public void setHistoryInputLocation(final String value) {
-        this.setOption(ConfigOption.HISTORY_INPUT_LOCATION, value);
-    }
-
-    public void setHistoryOutputLocation(final String value) {
-        this.setOption(ConfigOption.HISTORY_OUTPUT_LOCATION, value);
-    }
-
-    public void setMutationThreshold(final String value) {
-        this.setOption(ConfigOption.MUTATION_THRESHOLD, value);
-    }
-
-    public void setMaxSurviving(final String value) {
-        this.setOption(ConfigOption.MAX_SURVIVING, value);
-    }
-
-    public void setCoverageThreshold(final String value) {
-        this.setOption(ConfigOption.COVERAGE_THRESHOLD, value);
-    }
-
-    public void setMutationEngine(String value) {
-        this.setOption(ConfigOption.MUTATION_ENGINE, value);
-    }
-
-    public void setFullMutationMatrix(final String value) {
-        this.setOption(ConfigOption.FULL_MUTATION_MATRIX, value);
-    }
-
-    public void setJVM(String value) {
-        this.setOption(ConfigOption.JVM_PATH, value);
-    }
-
-    private void setOption(final ConfigOption option, final String value) {
-        if (!"".equals(value)) {
-            this.options.put(option.getParamName(), value);
-        }
-    }
-
-    public void setUseClasspathJar(String value) {
-        this.setOption(ConfigOption.USE_CLASSPATH_JAR, value);
-    }
+  public void setUseClasspathJar(String value) {
+    this.setOption(ConfigOption.USE_CLASSPATH_JAR, value);
+  }
 }

--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -28,237 +28,241 @@ import org.pitest.mutationtest.config.ConfigOption;
 
 public class PitestTask extends Task { // NO_UCD (test only)
 
-  private static final String[]     REQUIRED_OPTIONS = {
-      ConfigOption.TARGET_CLASSES.getParamName(),
-      ConfigOption.REPORT_DIR.getParamName(),
-      ConfigOption.SOURCE_DIR.getParamName()        };
+    private static final String[] REQUIRED_OPTIONS = {
+            ConfigOption.TARGET_CLASSES.getParamName(),
+            ConfigOption.REPORT_DIR.getParamName(),
+            ConfigOption.SOURCE_DIR.getParamName()};
 
-  private final Map<String, String> options          = new HashMap<>();
+    private final Map<String, String> options = new HashMap<>();
 
-  /**
-   * Classpath to analyse
-   */
-  private String                    classpath;
+    /**
+     * Classpath to analyse
+     */
+    private String classpath;
 
-  /**
-   * Classpath to pitest and plugins
-   */
-  private String pitClasspath;
+    /**
+     * Classpath to pitest and plugins
+     */
+    private String pitClasspath;
 
-  @Override
-  public void execute() throws BuildException {
-    try {
-      execute(new Java(this));
-    } catch (final Throwable t) {
-      throw new BuildException(t);
-    }
-  }
-
-  void execute(final Java java) {
-
-    this.setOption(ConfigOption.INCLUDE_LAUNCH_CLASSPATH, "false");
-    this.setOption(ConfigOption.CLASSPATH, generateAnalysisClasspath());
-
-    java.setClasspath(generateLaunchClasspath());
-    java.setClassname(MutationCoverageReport.class.getCanonicalName());
-    java.setFailonerror(true);
-    java.setFork(true);
-
-    checkRequiredOptions();
-    for (final Map.Entry<String, String> option : this.options.entrySet()) {
-      java.createArg().setValue(
-          "--" + option.getKey() + "=" + option.getValue());
+    @Override
+    public void execute() throws BuildException {
+        try {
+            execute(new Java(this));
+        } catch (final Throwable t) {
+            throw new BuildException(t);
+        }
     }
 
-    java.execute();
-  }
+    void execute(final Java java) {
 
-  private Path generateLaunchClasspath() {
-    if (this.pitClasspath == null) {
-      throw new BuildException("You must specify the classpath for pitest and its plugins.");
+        this.setOption(ConfigOption.INCLUDE_LAUNCH_CLASSPATH, "false");
+        this.setOption(ConfigOption.CLASSPATH, generateAnalysisClasspath());
+
+        java.setClasspath(generateLaunchClasspath());
+        java.setClassname(MutationCoverageReport.class.getCanonicalName());
+        java.setFailonerror(true);
+        java.setFork(true);
+
+        checkRequiredOptions();
+        for (final Map.Entry<String, String> option : this.options.entrySet()) {
+            java.createArg().setValue(
+                    "--" + option.getKey() + "=" + option.getValue());
+        }
+
+        java.execute();
     }
 
-    final Object reference = getProject().getReference(this.pitClasspath);
-    if (reference != null) {
-      this.pitClasspath = reference.toString();
+    private Path generateLaunchClasspath() {
+        if (this.pitClasspath == null) {
+            throw new BuildException("You must specify the classpath for pitest and its plugins.");
+        }
+
+        final Object reference = getProject().getReference(this.pitClasspath);
+        if (reference != null) {
+            this.pitClasspath = reference.toString();
+        }
+
+        return new Path(getProject(), this.pitClasspath);
     }
 
-    return new Path(getProject(), this.pitClasspath);
-  }
-
-  private void checkRequiredOptions() {
-    for (final String requiredOption : REQUIRED_OPTIONS) {
-      if (optionMissing(requiredOption)) {
-        throw new BuildException("You must specify the " + requiredOption + ".");
-      }
-    }
-  }
-
-  private boolean optionMissing(final String option) {
-    return !this.options.keySet().contains(option);
-  }
-
-  private String generateAnalysisClasspath() {
-    if (this.classpath == null) {
-      throw new BuildException("You must specify the classpath.");
+    private void checkRequiredOptions() {
+        for (final String requiredOption : REQUIRED_OPTIONS) {
+            if (optionMissing(requiredOption)) {
+                throw new BuildException("You must specify the " + requiredOption + ".");
+            }
+        }
     }
 
-    final Object reference = getProject().getReference(this.classpath);
-    if (reference != null) {
-      this.classpath = reference.toString();
+    private boolean optionMissing(final String option) {
+        return !this.options.keySet().contains(option);
     }
 
-    return this.classpath.replaceAll(File.pathSeparator, ",");
+    private String generateAnalysisClasspath() {
+        if (this.classpath == null) {
+            throw new BuildException("You must specify the classpath.");
+        }
 
-  }
+        final Object reference = getProject().getReference(this.classpath);
+        if (reference != null) {
+            this.classpath = reference.toString();
+        }
 
-  public void setReportDir(final String value) {
-    this.setOption(ConfigOption.REPORT_DIR, value);
-  }
+        return this.classpath.replaceAll(File.pathSeparator, ",");
 
-  public void setTargetClasses(final String value) {
-    this.setOption(ConfigOption.TARGET_CLASSES, value);
-  }
-
-  public void setTargetTests(final String value) {
-    this.setOption(ConfigOption.TEST_FILTER, value);
-  }
-
-  public void setDependencyDistance(final String value) {
-    this.setOption(ConfigOption.DEPENDENCY_DISTANCE, value);
-  }
-
-  public void setThreads(final String value) {
-    this.setOption(ConfigOption.THREADS, value);
-  }
-
-  public void setDetectInlinedCode(final String value) {
-    this.setOption(ConfigOption.USE_INLINED_CODE_DETECTION, value);
-  }
-
-  public void setTimestampedReports(final String value) {
-    this.setOption(ConfigOption.TIME_STAMPED_REPORTS, value);
-  }
-
-  public void setMutators(final String value) {
-    this.setOption(ConfigOption.MUTATIONS, value);
-  }
-
-  public void setFeatures(final String value) {
-    this.setOption(ConfigOption.FEATURES, value);
-  }
-
-  public void setExcludedMethods(final String value) {
-    this.setOption(ConfigOption.EXCLUDED_METHOD, value);
-  }
-
-  public void setExcludedClasses(final String value) {
-    this.setOption(ConfigOption.EXCLUDED_CLASSES, value);
-  }
-
-  public void setExcludedTestClasses(final String value) {
-    this.setOption(ConfigOption.EXCLUDED_TEST_CLASSES, value);
-  }
-
-  public void setAvoidCallsTo(final String value) {
-    this.setOption(ConfigOption.AVOID_CALLS, value);
-  }
-
-  public void setVerbose(final String value) {
-    this.setOption(ConfigOption.VERBOSE, value);
-  }
-
-  public void setTimeoutFactor(final String value) {
-    this.setOption(ConfigOption.TIMEOUT_FACTOR, value);
-  }
-
-  public void setTimeoutConst(final String value) {
-    this.setOption(ConfigOption.TIMEOUT_CONST, value);
-  }
-
-  public void setMaxMutationsPerClass(final String value) {
-    this.setOption(ConfigOption.MAX_MUTATIONS_PER_CLASS, value);
-  }
-
-  public void setJvmArgs(final String value) {
-    this.setOption(ConfigOption.CHILD_JVM, value);
-  }
-
-  public void setOutputFormats(final String value) {
-    this.setOption(ConfigOption.OUTPUT_FORMATS, value);
-  }
-
-  public void setFailWhenNoMutations(final String value) {
-    this.setOption(ConfigOption.FAIL_WHEN_NOT_MUTATIONS, value);
-  }
-
-  public void setSourceDir(final String value) {
-    this.setOption(ConfigOption.SOURCE_DIR, value);
-  }
-
-  public void setClasspath(final String classpath) {
-    this.classpath = classpath;
-  }
-
-  public void setPitClasspath(final String classpath) {
-    this.pitClasspath = classpath;
-  }
-
-  public void setMutableCodePaths(final String glob) {
-    setOption(ConfigOption.CODE_PATHS, glob);
-  }
-
-  public void setTestPlugin(final String value) {
-    this.setOption(ConfigOption.TEST_PLUGIN, value);
-  }
-
-  public void setIncludedGroups(final String value) {
-    this.setOption(ConfigOption.INCLUDED_GROUPS, value);
-  }
-
-  public void setExcludedGroups(final String value) {
-    this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
-  }
-
-  public void setIncludedTestMethods(final String value) {
-    this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
-  }
-
-  public void setHistoryInputLocation(final String value) {
-    this.setOption(ConfigOption.HISTORY_INPUT_LOCATION, value);
-  }
-
-  public void setHistoryOutputLocation(final String value) {
-    this.setOption(ConfigOption.HISTORY_OUTPUT_LOCATION, value);
-  }
-
-  public void setMutationThreshold(final String value) {
-    this.setOption(ConfigOption.MUTATION_THRESHOLD, value);
-  }
-
-  public void setMaxSurviving(final String value) {
-    this.setOption(ConfigOption.MAX_SURVIVING, value);
-  }
-
-  public void setCoverageThreshold(final String value) {
-    this.setOption(ConfigOption.COVERAGE_THRESHOLD, value);
-  }
-
-  public void setMutationEngine(String value) {
-    this.setOption(ConfigOption.MUTATION_ENGINE, value);
-  }
-
-  public void setJVM(String value) {
-    this.setOption(ConfigOption.JVM_PATH, value);
-  }
-
-  private void setOption(final ConfigOption option, final String value) {
-    if (!"".equals(value)) {
-      this.options.put(option.getParamName(), value);
     }
-  }
 
-  public void setUseClasspathJar(String value) {
-    this.setOption(ConfigOption.USE_CLASSPATH_JAR, value);
-  }
+    public void setReportDir(final String value) {
+        this.setOption(ConfigOption.REPORT_DIR, value);
+    }
+
+    public void setTargetClasses(final String value) {
+        this.setOption(ConfigOption.TARGET_CLASSES, value);
+    }
+
+    public void setTargetTests(final String value) {
+        this.setOption(ConfigOption.TEST_FILTER, value);
+    }
+
+    public void setDependencyDistance(final String value) {
+        this.setOption(ConfigOption.DEPENDENCY_DISTANCE, value);
+    }
+
+    public void setThreads(final String value) {
+        this.setOption(ConfigOption.THREADS, value);
+    }
+
+    public void setDetectInlinedCode(final String value) {
+        this.setOption(ConfigOption.USE_INLINED_CODE_DETECTION, value);
+    }
+
+    public void setTimestampedReports(final String value) {
+        this.setOption(ConfigOption.TIME_STAMPED_REPORTS, value);
+    }
+
+    public void setMutators(final String value) {
+        this.setOption(ConfigOption.MUTATIONS, value);
+    }
+
+    public void setFeatures(final String value) {
+        this.setOption(ConfigOption.FEATURES, value);
+    }
+
+    public void setExcludedMethods(final String value) {
+        this.setOption(ConfigOption.EXCLUDED_METHOD, value);
+    }
+
+    public void setExcludedClasses(final String value) {
+        this.setOption(ConfigOption.EXCLUDED_CLASSES, value);
+    }
+
+    public void setExcludedTestClasses(final String value) {
+        this.setOption(ConfigOption.EXCLUDED_TEST_CLASSES, value);
+    }
+
+    public void setAvoidCallsTo(final String value) {
+        this.setOption(ConfigOption.AVOID_CALLS, value);
+    }
+
+    public void setVerbose(final String value) {
+        this.setOption(ConfigOption.VERBOSE, value);
+    }
+
+    public void setTimeoutFactor(final String value) {
+        this.setOption(ConfigOption.TIMEOUT_FACTOR, value);
+    }
+
+    public void setTimeoutConst(final String value) {
+        this.setOption(ConfigOption.TIMEOUT_CONST, value);
+    }
+
+    public void setMaxMutationsPerClass(final String value) {
+        this.setOption(ConfigOption.MAX_MUTATIONS_PER_CLASS, value);
+    }
+
+    public void setJvmArgs(final String value) {
+        this.setOption(ConfigOption.CHILD_JVM, value);
+    }
+
+    public void setOutputFormats(final String value) {
+        this.setOption(ConfigOption.OUTPUT_FORMATS, value);
+    }
+
+    public void setFailWhenNoMutations(final String value) {
+        this.setOption(ConfigOption.FAIL_WHEN_NOT_MUTATIONS, value);
+    }
+
+    public void setSourceDir(final String value) {
+        this.setOption(ConfigOption.SOURCE_DIR, value);
+    }
+
+    public void setClasspath(final String classpath) {
+        this.classpath = classpath;
+    }
+
+    public void setPitClasspath(final String classpath) {
+        this.pitClasspath = classpath;
+    }
+
+    public void setMutableCodePaths(final String glob) {
+        setOption(ConfigOption.CODE_PATHS, glob);
+    }
+
+    public void setTestPlugin(final String value) {
+        this.setOption(ConfigOption.TEST_PLUGIN, value);
+    }
+
+    public void setIncludedGroups(final String value) {
+        this.setOption(ConfigOption.INCLUDED_GROUPS, value);
+    }
+
+    public void setExcludedGroups(final String value) {
+        this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
+    }
+
+    public void setIncludedTestMethods(final String value) {
+        this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
+    }
+
+    public void setHistoryInputLocation(final String value) {
+        this.setOption(ConfigOption.HISTORY_INPUT_LOCATION, value);
+    }
+
+    public void setHistoryOutputLocation(final String value) {
+        this.setOption(ConfigOption.HISTORY_OUTPUT_LOCATION, value);
+    }
+
+    public void setMutationThreshold(final String value) {
+        this.setOption(ConfigOption.MUTATION_THRESHOLD, value);
+    }
+
+    public void setMaxSurviving(final String value) {
+        this.setOption(ConfigOption.MAX_SURVIVING, value);
+    }
+
+    public void setCoverageThreshold(final String value) {
+        this.setOption(ConfigOption.COVERAGE_THRESHOLD, value);
+    }
+
+    public void setMutationEngine(String value) {
+        this.setOption(ConfigOption.MUTATION_ENGINE, value);
+    }
+
+    public void setFullMutationMatrix(final String value) {
+        this.setOption(ConfigOption.FULL_MUTATION_MATRIX, value);
+    }
+
+    public void setJVM(String value) {
+        this.setOption(ConfigOption.JVM_PATH, value);
+    }
+
+    private void setOption(final ConfigOption option, final String value) {
+        if (!"".equals(value)) {
+            this.options.put(option.getParamName(), value);
+        }
+    }
+
+    public void setUseClasspathJar(String value) {
+        this.setOption(ConfigOption.USE_CLASSPATH_JAR, value);
+    }
 }

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -474,6 +474,13 @@ public class PitestTaskTest {
     this.pitestTask.execute(this.java);
     verify(this.arg).setValue("--useClasspathJar=true");
   }
+
+  @Test
+  public void shouldPassMutationMatrixFlagToJavaTask() {
+    this.pitestTask.setFullMutationMatrix("true");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--fullMutationMatrix=true");
+  }
   
   private static class PathMatcher extends ArgumentMatcher<Path> {
 


### PR DESCRIPTION
There didn't seem to be ANT support for the `fullMutationMatrix` option described in #510 (issue) and #511 (pr), so I've added it.

I mimicked what [this PR](https://github.com/hcoles/pitest/pull/573) did to add ANT support for another feature. After doing this and producing a new set of jars, I was able to get a mutation matrix.