### PR TITLE
Allowed more tests to be considered killing a mutant when using historic data (fixes #763)

### DIFF
--- a/pitest-entry/pom.xml
+++ b/pitest-entry/pom.xml
@@ -175,6 +175,19 @@
 			<version>${testng.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>${hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>${hamcrest.version}</version>
+			<scope>test</scope>
+		</dependency>
 		
 	</dependencies>
 

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
@@ -15,6 +15,8 @@
 
 package org.pitest.coverage;
 
+import static java.util.stream.Collectors.toCollection;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +33,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.pitest.classinfo.ClassInfo;
@@ -61,7 +62,7 @@ public class CoverageData implements CoverageDatabase {
   private final List<Description>                             failingTestDescriptions = new ArrayList<>();
 
   public CoverageData(final CodeSource code, final LineMap lm) {
-    this(code, lm, new LinkedHashMap<InstructionLocation, Set<TestInfo>>());
+    this(code, lm, new LinkedHashMap<>());
   }
 
 
@@ -116,13 +117,10 @@ public class CoverageData implements CoverageDatabase {
 
   @Override
   public Collection<TestInfo> getTestsForClass(final ClassName clazz) {
-    final Set<TestInfo> tis = new TreeSet<>(
-        new TestInfoNameComparator());
-    tis.addAll(this.instructionCoverage.entrySet().stream().filter(isFor(clazz))
-        .flatMap(toTests())
-        .collect(Collectors.toList())
-        );
-    return tis;
+    return this.instructionCoverage.entrySet().stream()
+            .filter(isFor(clazz))
+            .flatMap(toTests())
+            .collect(toCollection(() -> new TreeSet<>(new TestInfoNameComparator())));
   }
 
   public void calculateClassCoverage(final CoverageResult cr) {
@@ -172,7 +170,7 @@ public class CoverageData implements CoverageDatabase {
     final Collection<ClassInfo> value = this.getClassesForFileCache().get(
         keyFromSourceAndPackage(sourceFile, packageName));
     if (value == null) {
-      return Collections.<ClassInfo> emptyList();
+      return Collections.emptyList();
     } else {
       return value;
     }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/IncrementalAnalyserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/IncrementalAnalyserTest.java
@@ -1,15 +1,35 @@
 package org.pitest.mutationtest.incremental;
 
-import static org.junit.Assert.assertEquals;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static org.pitest.mutationtest.DetectionStatus.KILLED;
+import static org.pitest.mutationtest.DetectionStatus.NOT_STARTED;
+import static org.pitest.mutationtest.DetectionStatus.SURVIVED;
+import static org.pitest.mutationtest.DetectionStatus.TIMED_OUT;
 import static org.pitest.mutationtest.LocationMother.aLocation;
 import static org.pitest.mutationtest.LocationMother.aMutationId;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -17,12 +37,12 @@ import org.mockito.MockitoAnnotations;
 import org.pitest.classinfo.ClassName;
 import org.pitest.coverage.CoverageDatabase;
 import org.pitest.coverage.TestInfo;
-import java.util.Optional;
 import org.pitest.mutationtest.DetectionStatus;
 import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.MutationStatusTestPair;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.util.Log;
 
 public class IncrementalAnalyserTest {
 
@@ -34,23 +54,41 @@ public class IncrementalAnalyserTest {
   @Mock
   private CoverageDatabase    coverage;
 
+  private LogCatcher logCatcher;
+
   @Before
   public void setUp() {
+    configureLogCatcher();
+
     MockitoAnnotations.initMocks(this);
     this.testee = new IncrementalAnalyser(this.history, this.coverage);
+  }
+
+  private void configureLogCatcher() {
+    logCatcher = new LogCatcher();
+    final Logger logger = Log.getLogger();
+
+    for (Handler handler : logger.getHandlers()) {
+      logger.removeHandler(handler);
+    }
+    logger.addHandler(logCatcher);
+    logger.setLevel(Level.ALL);
   }
 
   @Test
   public void shouldStartNewMutationsAtAStatusOfNotStarted() {
     final MutationDetails md = makeMutation("foo");
     when(this.history.getPreviousResult(any(MutationIdentifier.class)))
-    .thenReturn(Optional.<MutationStatusTestPair> empty());
+    .thenReturn(Optional.empty());
 
-    final Collection<MutationResult> actual = this.testee.analyse(Collections
-        .singletonList(md));
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
 
-    assertEquals(DetectionStatus.NOT_STARTED, actual.iterator().next()
-        .getStatus());
+    assertThat(actual, hasItem(withStatus(NOT_STARTED)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of NOT_STARTED",
+                    "Incremental analysis reduced number of mutations by 0"
+            ));
   }
 
   @Test
@@ -60,10 +98,14 @@ public class IncrementalAnalyserTest {
     when(
         this.history.hasCoverageChanged(any(ClassName.class),
             any(BigInteger.class))).thenReturn(true);
-    final Collection<MutationResult> actual = this.testee.analyse(Collections
-        .singletonList(md));
-    assertEquals(DetectionStatus.NOT_STARTED, actual.iterator().next()
-        .getStatus());
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
+
+    assertThat(actual, hasItem(withStatus(NOT_STARTED)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of NOT_STARTED",
+                    "Incremental analysis reduced number of mutations by 0"
+            ));
   }
 
   @Test
@@ -73,9 +115,14 @@ public class IncrementalAnalyserTest {
     when(
         this.history.hasCoverageChanged(any(ClassName.class),
             any(BigInteger.class))).thenReturn(false);
-    final Collection<MutationResult> actual = this.testee.analyse(Collections
-        .singletonList(md));
-    assertEquals(DetectionStatus.SURVIVED, actual.iterator().next().getStatus());
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
+
+    assertThat(actual, hasItem(withStatus(SURVIVED)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of SURVIVED",
+                    "Incremental analysis reduced number of mutations by 1"
+            ));
   }
 
   @Test
@@ -83,11 +130,14 @@ public class IncrementalAnalyserTest {
     final MutationDetails md = makeMutation("foo");
     setHistoryForAllMutationsTo(DetectionStatus.TIMED_OUT);
     when(this.history.hasClassChanged(any(ClassName.class))).thenReturn(true);
-    final Collection<MutationResult> actual = this.testee.analyse(Collections
-        .singletonList(md));
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
 
-    assertEquals(DetectionStatus.NOT_STARTED, actual.iterator().next()
-        .getStatus());
+    assertThat(actual, hasItem(withStatus(NOT_STARTED)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of NOT_STARTED",
+                    "Incremental analysis reduced number of mutations by 0"
+            ));
   }
 
   @Test
@@ -95,29 +145,14 @@ public class IncrementalAnalyserTest {
     final MutationDetails md = makeMutation("foo");
     setHistoryForAllMutationsTo(DetectionStatus.TIMED_OUT);
     when(this.history.hasClassChanged(any(ClassName.class))).thenReturn(false);
-    final Collection<MutationResult> actual = this.testee.analyse(Collections
-        .singletonList(md));
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
 
-    assertEquals(DetectionStatus.TIMED_OUT, actual.iterator().next()
-        .getStatus());
-  }
-
-  @Test
-  public void shouldStartPreviousKilledMutationsAtAStatusOfNotStartedWhenNeitherClassOrTestHasChanged() {
-    final MutationDetails md = makeMutation("foo");
-    final String killingTest = "fooTest";
-    setHistoryForAllMutationsTo(DetectionStatus.KILLED, killingTest);
-
-    final Collection<TestInfo> tests = Collections.singleton(new TestInfo(
-        "TEST_CLASS", killingTest, 0, Optional.<ClassName> empty(), 0));
-    when(this.coverage.getTestsForClass(any(ClassName.class)))
-    .thenReturn(tests);
-    when(this.history.hasClassChanged(any(ClassName.class))).thenReturn(false);
-    final MutationResult actual = this.testee
-        .analyse(Collections.singletonList(md)).iterator().next();
-
-    assertEquals(DetectionStatus.KILLED, actual.getStatus());
-    assertEquals(Optional.ofNullable(killingTest), actual.getKillingTest());
+    assertThat(actual, hasItem(withStatus(TIMED_OUT)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of TIMED_OUT",
+                    "Incremental analysis reduced number of mutations by 1"
+            ));
   }
 
   @Test
@@ -127,17 +162,185 @@ public class IncrementalAnalyserTest {
     setHistoryForAllMutationsTo(DetectionStatus.KILLED, killingTest);
 
     final Collection<TestInfo> tests = Collections.singleton(new TestInfo(
-        "TEST_CLASS", killingTest, 0, Optional.<ClassName> empty(), 0));
+        "TEST_CLASS", killingTest, 0, Optional.empty(), 0));
     when(this.coverage.getTestsForClass(any(ClassName.class)))
     .thenReturn(tests);
-    when(this.history.hasClassChanged(ClassName.fromString("foo"))).thenReturn(
-        false);
-    when(this.history.hasClassChanged(ClassName.fromString("TEST_CLASS")))
-    .thenReturn(true);
-    final MutationResult actual = this.testee
-        .analyse(Collections.singletonList(md)).iterator().next();
+    when(this.history.hasClassChanged(any(ClassName.class))).thenReturn(false);
+    final Collection<MutationResult> actual = this.testee
+        .analyse(singletonList(md));
 
-    assertEquals(DetectionStatus.NOT_STARTED, actual.getStatus());
+    assertThat(actual, hasItem(allOf(withStatus(KILLED), withKillingTest(killingTest))));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of KILLED",
+                    "Incremental analysis reduced number of mutations by 1"
+            ));
+
+  }
+
+  @Test
+  public void shouldStartPreviousKilledMutationsAtAStatusOfKilledWhenNeitherClassHasChangedNorTestHasChangedForAtLeastOneKillingTest() {
+    final MutationDetails md = makeMutation("foo");
+    final String killingTestChanged = "fooTest";
+    final String killingTestUnchanged = "killerTest";
+
+    setHistoryForAllMutationsTo(DetectionStatus.KILLED, killingTestChanged, killingTestUnchanged );
+
+    final TestInfo testChanged = new TestInfo("TEST_CLASS_CHANGED", killingTestChanged, 0, Optional.empty(), 0);
+    final TestInfo testUnchanged = new TestInfo("TEST_CLASS_UNCHANGED", killingTestUnchanged, 0, Optional.empty(), 0);
+
+    when(this.coverage.getTestsForClass(ClassName.fromString("clazz")))
+            .thenReturn(asList(testChanged,testUnchanged));
+
+    when(this.history.hasClassChanged(ClassName.fromString("clazz")))
+            .thenReturn(false);
+
+    when(this.history.hasClassChanged(ClassName.fromString("TEST_CLASS_CHANGED")))
+            .thenReturn(true);
+    when(this.history.hasClassChanged(ClassName.fromString("TEST_CLASS_UNCHANGED")))
+            .thenReturn(false);
+
+
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
+
+    assertThat(actual, hasItem(allOf(withStatus(KILLED), withKillingTest(killingTestUnchanged))));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of KILLED",
+                    "Incremental analysis reduced number of mutations by 1"
+            ));
+  }
+
+  @Test
+  public void shouldStartPreviousKilledMutationsAtAStatusOfNotStartedWhenTestHasChanged() {
+    final MutationDetails md = makeMutation("foo");
+    final String killingTest = "fooTest";
+    setHistoryForAllMutationsTo(DetectionStatus.KILLED, killingTest);
+
+    final Collection<TestInfo> tests = Collections.singleton(new TestInfo(
+            "TEST_CLASS", killingTest, 0, Optional.empty(), 0));
+    when(this.coverage.getTestsForClass(any(ClassName.class)))
+            .thenReturn(tests);
+    when(this.history.hasClassChanged(ClassName.fromString("clazz"))).thenReturn(
+            false);
+    when(this.history.hasClassChanged(ClassName.fromString("TEST_CLASS")))
+            .thenReturn(true);
+
+    final Collection<MutationResult> actual = this.testee.analyse(singletonList(md));
+
+    assertThat(actual, hasItem(withStatus(NOT_STARTED)));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of NOT_STARTED",
+                    "Incremental analysis reduced number of mutations by 0"
+            ));
+  }
+
+  @Test
+  public void assessMultipleMutationsAtATime() {
+    final MutationDetails md1 = makeMutation("foo");
+    final MutationDetails md2 = makeMutation("bar");
+    final MutationDetails md3 = makeMutation("baz");
+    final MutationDetails md4 = makeMutation("bumm");
+
+    final String killingTest = "killerTest";
+    final TestInfo test = new TestInfo("TEST_CLASS", killingTest, 0, Optional.empty(), 0);
+
+    when(this.history.getPreviousResult(md1.getId()))
+            .thenReturn(Optional.of(
+                    new MutationStatusTestPair(
+                            0,
+                            KILLED,
+                            singletonList(killingTest),
+                            emptyList())));
+
+    when(this.history.getPreviousResult(md2.getId()))
+            .thenReturn(Optional.of(
+                    new MutationStatusTestPair(
+                            0,
+                            KILLED,
+                            singletonList(killingTest),
+                            emptyList())));
+
+    when(this.history.getPreviousResult(md3.getId()))
+            .thenReturn(Optional.of(
+                    new MutationStatusTestPair(0, SURVIVED, emptyList(), emptyList())));
+
+    when(this.history.getPreviousResult(md4.getId()))
+            .thenReturn(Optional.empty());
+
+    when(this.coverage.getTestsForClass(ClassName.fromString("clazz")))
+            .thenReturn(singletonList(test));
+
+    when(this.history.hasClassChanged(ClassName.fromString("clazz")))
+            .thenReturn(false);
+    when(this.history.hasClassChanged(ClassName.fromString("TEST_CLASS")))
+            .thenReturn(false);
+
+    final Collection<MutationResult> actual = this.testee.analyse(asList(md1, md2, md3, md4));
+
+    assertThat(actual, contains(
+            withStatus(KILLED),
+            withStatus(KILLED),
+            withStatus(SURVIVED),
+            withStatus(NOT_STARTED)
+    ));
+    assertThat(logCatcher.logEntries,
+            hasItems(
+                    "Incremental analysis set 1 mutations to a status of NOT_STARTED",
+                    "Incremental analysis set 2 mutations to a status of KILLED",
+                    "Incremental analysis set 1 mutations to a status of SURVIVED",
+                    "Incremental analysis reduced number of mutations by 3"
+            ));
+  }
+
+  private Matcher<MutationResult> withStatus(final DetectionStatus status) {
+    return new TypeSafeDiagnosingMatcher<MutationResult>() {
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText("a mutation result with status ").appendValue(status);
+      }
+
+      @Override
+      protected boolean matchesSafely(final MutationResult item,
+                                      final Description mismatchDescription) {
+        mismatchDescription
+                .appendText("a mutation result with status ")
+                .appendValue(item.getStatus());
+
+        return status.equals(item.getStatus());
+      }
+    };
+  }
+
+  private Matcher<MutationResult> withKillingTest(final String expectedKillingTest) {
+    return new TypeSafeDiagnosingMatcher<MutationResult>() {
+      @Override
+      public void describeTo(final Description description) {
+        description
+                .appendText("a mutation result with killing test named ")
+                .appendValue(expectedKillingTest);
+      }
+
+      @Override
+      protected boolean matchesSafely(final MutationResult item,
+                                      final Description mismatchDescription) {
+        Optional<String> itemKillingTest = item.getKillingTest();
+        if (!itemKillingTest.isPresent()) {
+          mismatchDescription
+                  .appendText("a mutation result with no killing test");
+          return false;
+        }
+
+        final String killingTestName = itemKillingTest.get();
+        mismatchDescription
+                .appendText("a mutation result with killing test named ")
+                .appendValue(killingTestName);
+
+        return expectedKillingTest.equals(killingTestName);
+      }
+    };
   }
 
   private MutationDetails makeMutation(final String method) {
@@ -151,9 +354,25 @@ public class IncrementalAnalyserTest {
   }
 
   private void setHistoryForAllMutationsTo(final DetectionStatus status,
-      final String test) {
+      final String... test) {
     when(this.history.getPreviousResult(any(MutationIdentifier.class)))
-    .thenReturn(Optional.ofNullable(new MutationStatusTestPair(0, status, test)));
+    .thenReturn(Optional.of(
+            new MutationStatusTestPair(0, status, asList(test), emptyList())));
   }
 
+  private static class LogCatcher extends Handler {
+
+    final ArrayList<String> logEntries = new ArrayList<>();
+
+    @Override
+    public void publish(final LogRecord record) {
+      logEntries.add(record.getMessage());
+    }
+
+    @Override
+    public void flush() { }
+
+    @Override
+    public void close() throws SecurityException { }
+  }
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/IncrementalAnalyserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/incremental/IncrementalAnalyserTest.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -56,23 +57,25 @@ public class IncrementalAnalyserTest {
 
   private LogCatcher logCatcher;
 
+
+  @Before
+  public void configureLogCatcher() {
+    logCatcher = new LogCatcher();
+    final Logger logger = Log.getLogger();
+
+    logger.addHandler(logCatcher);
+    logger.setLevel(Level.ALL);
+  }
+
   @Before
   public void setUp() {
-    configureLogCatcher();
-
     MockitoAnnotations.initMocks(this);
     this.testee = new IncrementalAnalyser(this.history, this.coverage);
   }
 
-  private void configureLogCatcher() {
-    logCatcher = new LogCatcher();
-    final Logger logger = Log.getLogger();
-
-    for (Handler handler : logger.getHandlers()) {
-      logger.removeHandler(handler);
-    }
-    logger.addHandler(logCatcher);
-    logger.setLevel(Level.ALL);
+  @After
+  public void removeLogCatcher() {
+    Log.getLogger().removeHandler(logCatcher);
   }
 
   @Test


### PR DESCRIPTION
fixes #763

Incremental analysis honors all killing tests now instead of limiting the scope of analysis to the first killing test.
This is often identical if there is no matrix mutation in place but TestNG plugin calculates test units in terms of test classes thus executes all test methods of a test class and records historic data
with method level granularity and class level granularity. We need to take all killing tests into account to match history data and executable test units in the analyzer. This will also help if different test classes cover a certain production class and one of those test classes is deleted or renamed.

Improved logging to help spotting analyzer misbehaviour. Although pitest is already verbose I added another info-level statement.

I've also refactored the test and added more test cases to prove the correctness of my changes.