### PR TITLE
Fix for issue 537

### DIFF
--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -195,31 +195,31 @@ public class JUnitCustomRunnerTestUnitFinderTest {
 
   @RunWith(CustomDescriptionSuiteRunner.class)
   @SuiteClasses({ })
-  public static class EmptySuite {
+  public static class EmptyCustomDescriptionSuite {
   }
 
 
   @RunWith(CustomDescriptionSuiteRunner.class)
   @SuiteClasses({ One.class })
-  public static class CustomTest {
+  public static class CustomDescriptionSuite {
   }
 
   @Test
   public void shouldHandleEmptySuite() {
-    final Collection<TestUnit> actual = findWithTestee(EmptySuite.class);
+    final Collection<TestUnit> actual = findWithTestee(EmptyCustomDescriptionSuite.class);
     assertTrue(actual.isEmpty());
+  }
+
+  @Test
+  public void shouldNotFindTestsInCustomDescriptionSuite() {
+    final Collection<TestUnit> actual = findWithTestee(CustomDescriptionSuite.class);
+    assertEquals(2, actual.size());
   }
 
   @Test
   public void shouldNotFindTestsInCustomSuite() {
     final Collection<TestUnit> actual = findWithTestee(CustomSuite.class);
     assertTrue(actual.isEmpty());
-  }
-
-  @Test
-  public void shouldNotFindTestsInCustomSuite2() {
-    final Collection<TestUnit> actual = findWithTestee(CustomTest.class);
-    assertEquals(2, actual.size());
   }
 
   public static class Three {

--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -123,13 +123,11 @@ public class JUnitCustomRunnerTestUnitFinderTest {
    *
    * This appears to be happening in org.apache.maven.plugins:maven-pmd-plugin:3.13.0.
    *
-   * This needs to be addressed in two ways:
-   * 1) if the Suite has no SuiteClasses, isTest() is
-   * true. Pitest must not fail if the the name in the
-   * Description throws a ClassNotFoundException
-   * 2) if the Suite has SuiteClasses, isTest() is false,
-   * Pitest must then use the child descriptions of the Suite
-   * to continue testing with.
+   * This needs to be addressed as follows:
+   * if a ClassNotFoundException is thrown
+   * when creating a TestUnit because of non-class name,
+   * find its direct children to create test units
+   * from.
    */
   public static class CustomDescriptionSuiteRunner extends Suite {
 

--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -202,10 +202,6 @@ public class JUnitCustomRunnerTestUnitFinderTest {
   @RunWith(CustomDescriptionSuiteRunner.class)
   @SuiteClasses({ One.class })
   public static class CustomTest {
-    @Test
-    public void six() {
-
-    }
   }
 
   @Test

--- a/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
+++ b/pitest/src/test/java/org/pitest/junit/JUnitCustomRunnerTestUnitFinderTest.java
@@ -123,15 +123,13 @@ public class JUnitCustomRunnerTestUnitFinderTest {
    *
    * This appears to be happening in org.apache.maven.plugins:maven-pmd-plugin:3.13.0.
    *
-   * This fails in two ways:
-   * 1) if the Suite has no SuiteClasses, it is determined to be a
-   * test, after which its description is used to create a TestUnit
-   * but as the classname of the description is not an actual class
-   * a ClassNotFoundException is thrown and the entiry test results
-   * in "PitError: Coverage generation minion exited abnormall
-   * y!" errors.
-   * 2) if the Suite does have SuiteClasss, it is determined to NOT be a
-   * test, after which it is ignored entirely.
+   * This needs to be addressed in two ways:
+   * 1) if the Suite has no SuiteClasses, isTest() is
+   * true. Pitest must not fail if the the name in the
+   * Description throws a ClassNotFoundException
+   * 2) if the Suite has SuiteClasses, isTest() is false,
+   * Pitest must then use the child descriptions of the Suite
+   * to continue testing with.
    */
   public static class CustomDescriptionSuiteRunner extends Suite {
 


### PR DESCRIPTION
Hi all,

This is my fix for https://github.com/hcoles/pitest/issues/537.

Appearently, it is possible to get a Description from a org.junit.runner.Runner with a non-existent classname (or any name actually). This resulted in a ClassNotFoundException when there were no child descriptions, or it resulted in no TestUnits if there were child Descriptions.

I think I fixed those issues. At least the other unit tests still work and my issue is solved :)

Thanks and regards,
Michiel


