### PR TITLE
Check that PROBE_FIELD_NAME is not null when using it.

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
@@ -19,6 +19,7 @@ package org.pitest.coverage;
 
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.pitest.classinfo.BridgeMethodFilter;
@@ -39,6 +40,8 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
   private int       probeCount = 1;
 
   private String    className;
+  private boolean   foundClinit;
+  private int       access;
 
   public CoverageClassVisitor(final int classId, final ClassWriter writer) {
     super(writer, BridgeMethodFilter.INSTANCE);
@@ -51,32 +54,37 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
 
   @Override
   public void visit(int version, int access, String name, String signature,
-      String superName, String[] interfaces) {
+                    String superName, String[] interfaces) {
     super.visit(version, access, name, signature, superName, interfaces);
     this.className = name;
+    this.access = access;
   }
 
 
   @Override
   public MethodVisitor visitMethodIfRequired(final int access,
-      final String name, final String desc, final String signature,
-      final String[] exceptions, final MethodVisitor methodVisitor) {
+                                             final String name, final String desc, final String signature,
+                                             final String[] exceptions, final MethodVisitor methodVisitor) {
+
+    if (name.equals("<clinit>")) {
+      foundClinit = true;
+    }
 
     return new CoverageAnalyser(this, this.classId, this.probeCount,
-        methodVisitor, access, name, desc, signature, exceptions);
+            methodVisitor, access, name, desc, signature, exceptions);
 
   }
 
   @Override
   public FieldVisitor visitField(int access, String name, String descriptor,
-      String signature, Object value) {
+                                 String signature, Object value) {
 
     /*
     If this class was already instrumented, then do not do it again!
      */
     if (name.equals(CodeCoverageStore.PROBE_FIELD_NAME)) {
       throw new AlreadyInstrumentedException("Class " + getClassName()
-          + " already has coverage instrumentation, but asked to do it again!");
+              + " already has coverage instrumentation, but asked to do it again!");
     }
     return super.visitField(access, name, descriptor, signature, value);
   }
@@ -88,16 +96,108 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
 
   private void addCoverageProbeField() {
 
-    super.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_PUBLIC
-            | Opcodes.ACC_SYNTHETIC, CodeCoverageStore.PROBE_FIELD_NAME, "[Z", null,
-        null);
+    if ((this.access & Opcodes.ACC_INTERFACE) != 0) { // If we are instrumenting an interface, use final field + static initialisation
+      super.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_PUBLIC
+                      | Opcodes.ACC_SYNTHETIC, CodeCoverageStore.PROBE_FIELD_NAME, "[Z", null,
+              null);
+
+      //If there is no <clinit>, then generate one that sets the probe field directly
+      if (!foundClinit) {
+        MethodVisitor clinitMv = this.cv
+                .visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
+        clinitMv.visitCode();
+
+        pushConstant(clinitMv, this.classId);
+        pushConstant(clinitMv, this.probeCount);
+        clinitMv
+                .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,
+                        "getOrRegisterClassProbes", "(II)[Z", false);
+
+        clinitMv.visitFieldInsn(Opcodes.PUTSTATIC, className,
+                CodeCoverageStore.PROBE_FIELD_NAME, "[Z");
+        clinitMv.visitInsn(Opcodes.RETURN);
+        clinitMv.visitMaxs(0, 0);
+        clinitMv.visitEnd();
+      }
+    } else { //for classes and enums use volatile field and synchronised method for double checked locking pattern
+      super.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_VOLATILE | Opcodes.ACC_PUBLIC
+                      | Opcodes.ACC_SYNTHETIC, CodeCoverageStore.PROBE_FIELD_NAME, "[Z", null,
+              null);
+
+      MethodVisitor probesInitMv = this.cv
+              .visitMethod(Opcodes.ACC_STATIC | Opcodes.ACC_SYNCHRONIZED,
+                      CodeCoverageStore.PROBE_FIELD_NAME + "Init", "()[Z",null, null);
+      probesInitMv.visitCode();
+      probesInitMv.visitFieldInsn(Opcodes.GETSTATIC, className,
+              CodeCoverageStore.PROBE_FIELD_NAME, "[Z");
+      probesInitMv.visitInsn(Opcodes.DUP); //duplicate array reference, one for null check and one to use
+
+      //Check if PROBE_FIELD_NAME has been initialised
+      Label notNull = new Label();
+      probesInitMv.visitJumpInsn(Opcodes.IFNONNULL,notNull);
+
+      //if not initialised then initialise it
+      probesInitMv.visitInsn(Opcodes.POP); //get rid of null on top of stack
+      pushConstant(probesInitMv, this.classId);
+      pushConstant(probesInitMv, this.probeCount);
+      probesInitMv
+              .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,
+                      "getOrRegisterClassProbes", "(II)[Z", false);
+
+      probesInitMv.visitInsn(Opcodes.DUP); //duplicate array reference, one to store in field, one to return
+
+      probesInitMv.visitFieldInsn(Opcodes.PUTSTATIC, className,
+              CodeCoverageStore.PROBE_FIELD_NAME, "[Z"); //store value in field
+
+      // if it has already been initialised then just return it
+      probesInitMv.visitLabel(notNull);
+
+      probesInitMv.visitInsn(Opcodes.ARETURN);
+      probesInitMv.visitMaxs(0, 0);
+      probesInitMv.visitEnd();
+    }
 
     super.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_PUBLIC
-            | Opcodes.ACC_SYNTHETIC, CodeCoverageStore.PROBE_LENGTH_FIELD_NAME, "I",
-        null, this.probeCount + 1);
+                    | Opcodes.ACC_SYNTHETIC, CodeCoverageStore.PROBE_LENGTH_FIELD_NAME, "I",
+            null, this.probeCount + 1);
+  }
+
+  private void pushConstant(MethodVisitor mv, int value) {
+    switch (value) {
+      case 0:
+        mv.visitInsn(Opcodes.ICONST_0);
+        break;
+      case 1:
+        mv.visitInsn(Opcodes.ICONST_1);
+        break;
+      case 2:
+        mv.visitInsn(Opcodes.ICONST_2);
+        break;
+      case 3:
+        mv.visitInsn(Opcodes.ICONST_3);
+        break;
+      case 4:
+        mv.visitInsn(Opcodes.ICONST_4);
+        break;
+      case 5:
+        mv.visitInsn(Opcodes.ICONST_5);
+        break;
+      default:
+        if (value <= Byte.MAX_VALUE) {
+          mv.visitIntInsn(Opcodes.BIPUSH, value);
+        } else if (value <= Short.MAX_VALUE) {
+          mv.visitIntInsn(Opcodes.SIPUSH, value);
+        } else {
+          mv.visitLdcInsn(value);
+        }
+    }
   }
 
   public String getClassName() {
     return className;
+  }
+
+  public int getClassAccess() {
+    return access;
   }
 }

--- a/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
@@ -45,7 +45,7 @@ public class CoverageAnalyser extends MethodNode {
     final DefaultInstructionCounter counter = new DefaultInstructionCounter();
     accept(new InstructionTrackingMethodVisitor(
         new ArrayProbeCoverageMethodVisitor(blocks, counter, this.classId,
-            this.mv, this.access, parent.getClassName(), this.name, this.desc,
+            this.mv, parent.getClassAccess(), this.access, parent.getClassName(), this.name, this.desc,
             this.probeOffset), counter));
   }
 


### PR DESCRIPTION
Hello,

This is a fix for https://github.com/hcoles/pitest/issues/770, which also seems to solve https://github.com/hcoles/pitest/issues/746.

It looks like in some configurations, it is possible that we try to access the coverage probes field ($$pitCoverageProbes) before it is initialised in the static initialiser (<clinit>). This leads to a NullPointerException.

Here, instead of initialising the field in the static initialiser, we check if it is null every time we access it and initialise it if needed. All the tests are passing.