### PR TITLE
Rounding can give false 100% in html report

### DIFF
--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -49,13 +49,13 @@ public class MutationTotals {
   }
 
   public int getLineCoverage() {
-    return this.numberOfLines == 0 ? 100 : Math
+    return this.numberOfLines == 0 ? 100 : (int) Math
         .floor((100f * this.numberOfLinesCovered) / this.numberOfLines);
   }
 
   public int getMutationCoverage() {
     return this.numberOfMutations == 0 ? 100
-        : Math.floor((100f * this.numberOfMutationsDetected)
+        : (int) Math.floor((100f * this.numberOfMutationsDetected)
             / this.numberOfMutations);
   }
 

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -50,12 +50,12 @@ public class MutationTotals {
 
   public int getLineCoverage() {
     return this.numberOfLines == 0 ? 100 : Math
-        .round((100f * this.numberOfLinesCovered) / this.numberOfLines);
+        .floor((100f * this.numberOfLinesCovered) / this.numberOfLines);
   }
 
   public int getMutationCoverage() {
     return this.numberOfMutations == 0 ? 100
-        : Math.round((100f * this.numberOfMutationsDetected)
+        : Math.floor((100f * this.numberOfMutationsDetected)
             / this.numberOfMutations);
   }
 

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
@@ -36,7 +36,7 @@ public class MutationTotalsTest {
   public void shouldCorrectlyCalculateLineCoverageWhenPartiallyCovered() {
     this.testee.addLines(63);
     this.testee.addLinesCovered(20);
-    assertEquals(32, this.testee.getLineCoverage());
+    assertEquals(31, this.testee.getLineCoverage());
   }
 
   @Test
@@ -61,7 +61,7 @@ public class MutationTotalsTest {
   public void shouldCorrectlyCalculateMutationCoverageWhenSomeMutationUndetected() {
     this.testee.addMutations(63);
     this.testee.addMutationsDetetcted(20);
-    assertEquals(32, this.testee.getMutationCoverage());
+    assertEquals(31, this.testee.getMutationCoverage());
   }
 
   @Test


### PR DESCRIPTION
To avoid false 100% coverage in html report i suggest using floor instead of round