### PR TITLE
feat(report) Add new score value for aggregation of several modules

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -99,12 +99,18 @@ public final class ReportAggregator {
     for (final BlockCoverage blockData : coverageData) {
       for (int i = blockData.getBlock().getFirstInsnInBlock();
            i <= blockData.getBlock().getLastInsnInBlock(); i++) {
-        blockCoverageMap.put(new InstructionLocation(blockData.getBlock(), i),
-            new HashSet<>(
-                FCollection.map(blockData.getTests(), toTestInfo(blockData))));
+        addBlockCoverage(blockCoverageMap, new InstructionLocation(blockData.getBlock(), i), 
+            FCollection.map(blockData.getTests(), toTestInfo(blockData)));
       }
     }
     return blockCoverageMap;
+  }
+
+  private void addBlockCoverage(Map<InstructionLocation, Set<TestInfo>> blockCoverageMap, InstructionLocation instructionLocation, List<TestInfo> tests) {
+    if (!blockCoverageMap.containsKey(instructionLocation)) {
+      blockCoverageMap.put(instructionLocation, new HashSet<>());
+    }
+    blockCoverageMap.get(instructionLocation).addAll(tests);
   }
 
   private Function<String, TestInfo> toTestInfo(final BlockCoverage blockData) {

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/AnnotatedLineFactory.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/AnnotatedLineFactory.java
@@ -34,13 +34,16 @@ public class AnnotatedLineFactory {
   private final Collection<MutationResult>         mutations;
   private final CoverageDatabase                   statistics;
   private final Collection<ClassInfo>              classesInFile;
+  private final DetectionStatusCalculator          statusCalculator;
 
   public AnnotatedLineFactory(
       final Collection<MutationResult> mutations,
-      final CoverageDatabase statistics, final Collection<ClassInfo> classes) {
+      final CoverageDatabase statistics, final Collection<ClassInfo> classes,
+      final DetectionStatusCalculator statusCalculator) {
     this.mutations = mutations;
     this.statistics = statistics;
     this.classesInFile = classes;
+    this.statusCalculator = statusCalculator;
   }
 
   public List<Line> convert(final Reader source) throws IOException {
@@ -59,9 +62,10 @@ public class AnnotatedLineFactory {
 
       @Override
       public Line apply(final String a) {
+        List<MutationResult> mutationsForLine = getMutationsForLine(this.lineNumber);
         final Line l = new Line(this.lineNumber,
             StringUtil.escapeBasicHtmlChars(a), lineCovered(this.lineNumber),
-            getMutationsForLine(this.lineNumber));
+            mutationsForLine, statusCalculator.calculate(mutationsForLine));
         this.lineNumber++;
         return l;
       }

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/DetectionStatusCalculator.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/DetectionStatusCalculator.java
@@ -1,0 +1,10 @@
+package org.pitest.mutationtest.report.html;
+
+import java.util.List;
+
+import org.pitest.mutationtest.DetectionStatus;
+import org.pitest.mutationtest.MutationResult;
+
+public interface DetectionStatusCalculator {
+  DetectionStatus calculate(List<MutationResult> mutationsForLine);
+}

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/Line.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/Line.java
@@ -14,6 +14,7 @@
  */
 package org.pitest.mutationtest.report.html;
 
+import java.util.Collections;
 import java.util.List;
 
 import java.util.Optional;
@@ -25,14 +26,17 @@ public class Line {
   private final String               text;
   private final LineStatus           lineCovered;
   private final List<MutationResult> mutations;
+  private final DetectionStatus      detectionStatus;
 
   public Line(final long number, final String text,
-      final LineStatus lineCovered, final List<MutationResult> mutations) {
+      final LineStatus lineCovered, final List<MutationResult> mutations,
+      final DetectionStatus detectionStatus) {
     this.number = number;
     this.text = text;
     this.lineCovered = lineCovered;
     this.mutations = mutations;
-    mutations.sort(new ResultComparator());
+    this.detectionStatus = detectionStatus;
+    Collections.sort(mutations, new ResultComparator());
   }
 
   public long getNumber() {
@@ -52,10 +56,7 @@ public class Line {
   }
 
   public Optional<DetectionStatus> detectionStatus() {
-    if (this.mutations.isEmpty()) {
-      return Optional.empty();
-    }
-    return Optional.ofNullable(this.mutations.get(0).getStatus());
+    return Optional.ofNullable(detectionStatus);
   }
 
   public int getNumberOfMutations() {

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MergeStatusForSameMutationAndLine.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MergeStatusForSameMutationAndLine.java
@@ -1,0 +1,102 @@
+package org.pitest.mutationtest.report.html;
+
+import static org.pitest.mutationtest.report.html.MutationScoreUtil.groupBySameMutationOnSameLines;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.pitest.mutationtest.DetectionStatus;
+import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+import org.pitest.mutationtest.report.html.ResultComparator.DetectionStatusComparator;
+
+/**
+ * Compute the {@link DetectionStatus} according to the list of mutations applied on the line.
+ * This algorithm works with multi-projects. For example:
+ * 
+ * <strong>Tested class</strong>
+ * <pre><code>
+ * 1   class Foo {
+ * 2     public int compare() {
+ * 3       if (a > b) {
+ * 4         return -1;
+ * 5       }
+ * 6       if (a < b) {
+ * 7         return 1;
+ * 8       }
+ * 9       return 0;
+ * 10    }
+ * 11  }
+ * </pre></code>
+ * 
+ * Module A contains Foo class.
+ * Module B depends on Module A.
+ * 
+ * <strong>Test results 1</strong>
+ * <table>
+ * <caption>mutations</caption>
+ * <thead><tr><th>Module</th><th>Test</th><th>Mutation results</th></tr></thead>
+ * <tbody>
+ * <tr><td>Module A</td><td>UnitTest.identical()</td><td><ul><li>line 9: return replaced by -1 -> SURVIVED</li></ul></td></tr>
+ * <tr><td>Module A</td><td>UnitTest.identical()</td><td><ul><li>line 9: return replaced by 1 -> SURVIVED</li></ul></td></tr>
+ * <tr><td>Module B</td><td>IntegrationTest.sort()</td><td><ul><li>line 9: return replaced by -1 -> KILLED</li></ul></td></tr>
+ * <tr><td>Module B</td><td>IntegrationTest.sort()</td><td><ul><li>line 9: return replaced by 1 -> SURVIVED</li></ul></td></tr>
+ * </tbody>
+ * </table>
+ * 
+ * There are several mutations applied on the same line and one mutation has survived across all tests and one mutation has been killed.
+ * So the result should be SURVIVED because for the same line, at least one mutation has survived.
+ * 
+ * <strong>Test results 2</strong>
+ * <table>
+ * <caption>mutations</caption>
+ * <thead><tr><th>Module</th><th>Test</th><th>Mutation results</th></tr></thead>
+ * <tbody>
+ * <tr><td>Module A</td><td>UnitTest.identical()</td><td><ul><li>line 9: return replaced by -1 -> SURVIVED</li></ul></td></tr>
+ * <tr><td>Module A</td><td>UnitTest.identical()</td><td><ul><li>line 9: return replaced by 1 -> KILLED</li></ul></td></tr>
+ * <tr><td>Module B</td><td>IntegrationTest.sort()</td><td><ul><li>line 9: return replaced by -1 -> KILLED</li></ul></td></tr>
+ * <tr><td>Module B</td><td>IntegrationTest.sort()</td><td><ul><li>line 9: return replaced by 1 -> SURVIVED</li></ul></td></tr>
+ * </tbody>
+ * </table>
+ * 
+ * In this case, all mutations are killed across several projects. So the result should be KILLED.
+ * 
+ * @author Aurélien Baudet
+ *
+ */
+public class MergeStatusForSameMutationAndLine implements DetectionStatusCalculator {
+  @Override
+  public DetectionStatus calculate(List<MutationResult> mutationsForLine) {
+    if (mutationsForLine.isEmpty()) {
+      return null;
+    }
+    Map<MutationIdentifier, Collection<MutationResult>> grouped = groupBySameMutationOnSameLines(mutationsForLine);
+    Map<MutationIdentifier, DetectionStatus> statusForSameMutation = new HashMap<>();
+    // compute the status for each mutation
+    for (Entry<MutationIdentifier, Collection<MutationResult>> resultsByMutation : grouped.entrySet()) {
+      statusForSameMutation.put(resultsByMutation.getKey(), computeDetectionStatusForSameLineAndMutation(resultsByMutation.getValue()));
+    }
+    // for different mutations, take the worst mutation
+    List<DetectionStatus> status = new ArrayList<>(statusForSameMutation.values());
+    Collections.sort(status, new DetectionStatusComparator());
+    if (status.isEmpty()) {
+      return null;
+    }
+    return status.get(0);
+  }
+
+  private DetectionStatus computeDetectionStatusForSameLineAndMutation(Collection<MutationResult> results) {
+    List<MutationResult> list = new ArrayList<>(results);
+    Collections.sort(list, new ResultComparator());
+    if (list.isEmpty()) {
+      return null;
+    }
+    // use best status to handle several tests across projects
+    return list.get(list.size() - 1).getStatus();
+  }
+}

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -146,7 +146,8 @@ public class MutationHtmlReportListener implements MutationResultListener {
         sourceFile);
     if (reader.isPresent()) {
       final AnnotatedLineFactory alf = new AnnotatedLineFactory(
-          mutationsForThisFile.list(), this.coverage, classes);
+          mutationsForThisFile.list(), this.coverage, classes,
+          new MergeStatusForSameMutationAndLine());
       return alf.convert(reader.get());
     }
     return Collections.emptyList();

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationScore.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationScore.java
@@ -1,0 +1,54 @@
+package org.pitest.mutationtest.report.html;
+
+public class MutationScore {
+  private long numberOfUniqueMutations;
+  private long numberOfUniqueMutationsKilled;
+  private long numberOfUniqueMutationsDetected;
+
+  public MutationScore() {
+    this(0, 0, 0);
+  }
+  
+  public MutationScore(long numberOfUniqueMutations,
+                       long numberOfUniqueMutationsKilled, 
+                       long numberOfUniqueMutationsDetected) {
+    super();
+    this.numberOfUniqueMutations = numberOfUniqueMutations;
+    this.numberOfUniqueMutationsKilled = numberOfUniqueMutationsKilled;
+    this.numberOfUniqueMutationsDetected = numberOfUniqueMutationsDetected;
+  }
+
+  public long getNumberOfUniqueMutations() {
+    return numberOfUniqueMutations;
+  }
+
+  public long getNumberOfUniqueMutationsKilled() {
+    return numberOfUniqueMutationsKilled;
+  }
+
+  public long getNumberOfUniqueMutationsDetected() {
+    return numberOfUniqueMutationsDetected;
+  }
+
+  public long getNumberOfUniqueMutationsPossiblyDetected() {
+    return numberOfUniqueMutationsDetected - numberOfUniqueMutationsKilled;
+  }
+
+  public int getKilledScore() {
+    return numberOfUniqueMutations == 0 ? 100
+            : Math.round((100f * numberOfUniqueMutationsKilled)
+                / numberOfUniqueMutations);
+  }
+
+  public int getPossiblyDetectedScore() {
+    return numberOfUniqueMutations == 0 ? 100
+            : Math.round((100f * getNumberOfUniqueMutationsDetected())
+                / numberOfUniqueMutations);
+  }
+
+  public void add(MutationScore score) {
+    numberOfUniqueMutations += score.numberOfUniqueMutations;
+    numberOfUniqueMutationsDetected += score.numberOfUniqueMutationsDetected;
+    numberOfUniqueMutationsKilled += score.numberOfUniqueMutationsKilled;
+  }
+}

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationScoreUtil.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationScoreUtil.java
@@ -1,0 +1,29 @@
+package org.pitest.mutationtest.report.html;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+
+public final class MutationScoreUtil {
+  private MutationScoreUtil() {
+    super();
+  }
+  
+  public static Map<MutationIdentifier, Collection<MutationResult>> groupBySameMutationOnSameLines(Collection<MutationResult> mutations) {
+    Map<MutationIdentifier, Collection<MutationResult>> grouped = new HashMap<>();
+    for (MutationResult each : mutations) {
+      Collection<MutationResult> results = grouped.get(each.getDetails().getId());
+      if (results == null) {
+        results = new ArrayList<>();
+        grouped.put(each.getDetails().getId(), results);
+      }
+      results.add(each);
+    }
+    return grouped;
+  }
+
+}

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
@@ -14,18 +14,21 @@
  */
 package org.pitest.mutationtest.report.html;
 
-import org.pitest.classinfo.ClassInfo;
-import org.pitest.coverage.TestInfo;
-import org.pitest.functional.FCollection;
-import org.pitest.mutationtest.MutationResult;
+import static org.pitest.mutationtest.DetectionStatus.KILLED;
+import static org.pitest.mutationtest.report.html.MutationScoreUtil.groupBySameMutationOnSameLines;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.TreeSet;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import org.pitest.classinfo.ClassInfo;
+import org.pitest.coverage.TestInfo;
+import org.pitest.functional.FCollection;
+import org.pitest.mutationtest.MutationResult;
 
 public class MutationTestSummaryData {
 
@@ -55,6 +58,7 @@ public class MutationTestSummaryData {
     mt.addLines(getNumberOfLines());
     mt.addLinesCovered(this.numberOfCoveredLines);
     mt.addMutationsWithCoverage(this.getNumberOfMutationsWithCoverage());
+    mt.addMutationScore(new MutationScore(getNumberOfUniqueMutations(), getNumberOfUniqueMutationsKilled(), getNumberOfUniqueMutationsDetected()));
     return mt;
   }
 
@@ -130,6 +134,36 @@ public class MutationTestSummaryData {
     return count;
   }
 
+  private long getNumberOfUniqueMutations() {
+    return groupBySameMutationOnSameLines(mutations).entrySet().size();
+  }
+
+  private long getNumberOfUniqueMutationsDetected() {
+    int count = 0;
+    for (final Collection<MutationResult> results : groupBySameMutationOnSameLines(mutations).values()) {
+      for (MutationResult each : results) {
+        if (each.getStatus().isDetected()) {
+          count++;
+          break;
+        }
+      }
+    }
+    return count;
+  }
+
+  private long getNumberOfUniqueMutationsKilled() {
+    int count = 0;
+    for (final Collection<MutationResult> results : groupBySameMutationOnSameLines(mutations).values()) {
+      for (MutationResult each : results) {
+        if (each.getStatus() == KILLED) {
+          count++;
+          break;
+        }
+      }
+    }
+    return count;
+  }
+  
   private Function<MutationResult, Iterable<TestInfo>> mutationToTargettedTests() {
     return a -> a.getDetails().getTestsInOrder();
   }

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -8,6 +8,7 @@ public class MutationTotals {
   private long numberOfMutations             = 0;
   private long numberOfMutationsDetected     = 0;
   private long numberOfMutationsWithCoverage = 0;
+  private MutationScore mutationScore        = new MutationScore();
 
   public long getNumberOfFiles() {
     return this.numberOfFiles;
@@ -49,6 +50,10 @@ public class MutationTotals {
     this.numberOfMutationsDetected += mutationsKilled;
   }
 
+  public void addMutationScore(final MutationScore score) {
+    mutationScore.add(score);
+  }
+
   public int getLineCoverage() {
     return this.numberOfLines == 0 ? 100 : Math
         .round((100f * this.numberOfLinesCovered) / this.numberOfLines);
@@ -74,6 +79,10 @@ public class MutationTotals {
     return this.numberOfMutationsWithCoverage;
   }
 
+  public MutationScore getMutationScore() {
+    return mutationScore;
+  }
+
   public void add(final MutationTotals data) {
     add(data.getNumberOfLines(), data.getNumberOfFiles(), data);
   }
@@ -85,5 +94,7 @@ public class MutationTotals {
     this.addMutations(data.getNumberOfMutations());
     this.addMutationsDetetcted(data.getNumberOfMutationsDetected());
     this.addMutationsWithCoverage(data.getNumberOfMutationsWithCoverage());
+    this.addMutationScore(data.getMutationScore());
   }
+
 }

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/ResultComparator.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/ResultComparator.java
@@ -41,8 +41,17 @@ class ResultComparator implements Comparator<MutationResult>, Serializable {
 
   }
 
-  private int getRanking(DetectionStatus status) {
+  private static int getRanking(DetectionStatus status) {
     return RANK.get(status);
+  }
+  
+  public static class DetectionStatusComparator implements Comparator<DetectionStatus>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public int compare(DetectionStatus o1, DetectionStatus o2) {
+      return getRanking(o1) - getRanking(o2);
+    }
   }
 
 }

--- a/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
@@ -15,6 +15,7 @@
             <th>Line Coverage</th>
             <th>Mutation Coverage</th>
             <th>Test Strength</th>
+            <th>Mutation Score</th>
         </tr>
     </thead>
     <tbody>
@@ -23,6 +24,18 @@
             <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
             <td>$totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.mutationCoverage$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
             <td>$totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$totals.testStrength$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>
+              <div class="coverage_percentage">$totals.mutationScore.killedScore$% </div>
+              <div class="coverage_bar">
+                <div class="coverage_possibly_detected width-$totals.mutationScore.possiblyDetectedScore$"></div>
+                <div class="coverage_complete width-$totals.mutationScore.killedScore$"></div>
+                <div class="coverage_legend">$totals.mutationScore.numberOfUniqueMutationsKilled$/$totals.mutationScore.numberOfUniqueMutations$</div>
+              </div>
+              <div class="legend">
+                <div class="killed">Killed: $totals.mutationScore.numberOfUniqueMutationsKilled$</div>
+                <div class="uncertain">Uncertain: $totals.mutationScore.numberOfUniqueMutationsPossiblyDetected$</div>
+              </div>
+            </td>
         </tr>
     </tbody>
 </table>
@@ -37,6 +50,7 @@
             <th>Line Coverage</th>
             <th>Mutation Coverage</th>
             <th>Test Strength</th>
+            <th>Mutation Score</th>
         </tr>
     </thead>
     <tbody>
@@ -47,6 +61,18 @@ $packageSummaries:{ summary |
             <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>
+              <div class="coverage_percentage">$summary.totals.mutationScore.killedScore$% </div>
+              <div class="coverage_bar">
+                <div class="coverage_possibly_detected width-$summary.totals.mutationScore.possiblyDetectedScore$"></div>
+                <div class="coverage_complete width-$summary.totals.mutationScore.killedScore$"></div>
+                <div class="coverage_legend">$summary.totals.mutationScore.numberOfUniqueMutationsKilled$/$summary.totals.mutationScore.numberOfUniqueMutations$</div>
+              </div>
+              <div class="legend">
+                <div class="killed">Killed: $summary.totals.mutationScore.numberOfUniqueMutationsKilled$</div>
+                <div class="uncertain">Uncertain: $summary.totals.mutationScore.numberOfUniqueMutationsPossiblyDetected$</div>
+              </div>
+            </td>
         </tr>
 }$
      </tbody>

--- a/pitest-html-report/src/main/resources/templates/mutation/package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/package_index.st
@@ -15,6 +15,7 @@
             <th>Line Coverage</th>
             <th>Mutation Coverage</th>
             <th>Test Strength</th>
+            <th>Mutation Score</th>
         </tr>
     </thead>
     <tbody>
@@ -23,6 +24,17 @@
             <td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
             <td>$packageData.totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.mutationCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
             <td>$packageData.totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.testStrength$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>$packageData.totals.mutationScore.killedScore$% 
+                <div class="coverage_bar">
+                  <div class="coverage_possibly_detected width-$packageData.totals.mutationScore.possiblyDetectedScore$"></div>
+                  <div class="coverage_complete width-$packageData.totals.mutationScore.killedScore$"></div>
+                  <div class="coverage_legend">$packageData.totals.mutationScore.numberOfUniqueMutationsKilled$/$packageData.totals.mutationScore.numberOfUniqueMutations$</div>
+                </div>
+                <div class="legend">
+                  <div class="killed">Killed: $packageData.totals.mutationScore.numberOfUniqueMutationsKilled$</div>
+                  <div class="uncertain">Uncertain: $packageData.totals.mutationScore.numberOfUniqueMutationsPossiblyDetected$</div>
+                </div>
+            </td>
         </tr>
     </tbody>
 </table>
@@ -36,6 +48,7 @@
             <th>Line Coverage</th>
             <th>Mutation Coverage</th>
             <th>Test Strength</th>
+            <th>Mutation Score</th>
         </tr>
     </thead>
     <tbody>
@@ -45,6 +58,18 @@ $packageData.summaryData:{ summary |
             <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>
+              <div class="coverage_percentage">$summary.totals.mutationScore.killedScore$% </div>
+              <div class="coverage_bar">
+                <div class="coverage_possibly_detected width-$summary.totals.mutationScore.possiblyDetectedScore$"></div>
+                <div class="coverage_complete width-$summary.totals.mutationScore.killedScore$"></div>
+                <div class="coverage_legend">$summary.totals.mutationScore.numberOfUniqueMutationsKilled$/$summary.totals.mutationScore.numberOfUniqueMutations$</div>
+              </div>
+              <div class="legend">
+                <div class="killed">Killed: $summary.totals.mutationScore.numberOfUniqueMutationsKilled$</div>
+                <div class="uncertain">Uncertain: $summary.totals.mutationScore.numberOfUniqueMutationsPossiblyDetected$</div>
+              </div>
+            </td>
         </tr>
 }$
      </tbody>

--- a/pitest-html-report/src/main/resources/templates/mutation/style.css
+++ b/pitest-html-report/src/main/resources/templates/mutation/style.css
@@ -99,11 +99,21 @@ body{
     position: relative;
 }
 
+.coverage_possibly_detected {
+    display: block;
+    height: 100%;
+    background: #dde7ef;
+    position: absolute;
+    left: 0;
+    top: 0;
+}
 .coverage_complete {
-    display: inline-block;
+    display: block;
     height: 100%;
     background: #DFD;
-    float: left;
+    position: absolute;
+    left: 0;
+    top: 0;
 }
 
 .coverage_legend {
@@ -560,4 +570,29 @@ body{
 
 .width-100 {
     width: 100%;
+}
+
+.legend {
+    display: inline-block;
+    font-size: 0.8em;
+    vertical-align: middle;
+}
+.legend .killed,
+.legend .uncertain {
+    background: none;
+}
+.legend .killed:before,
+.legend .uncertain:before {
+    content: "";
+    width: 20px;
+    display: inline-block;
+    border: 1px solid #aaa;
+    margin-right: 5px;
+    height: 10px;
+}
+.legend .killed:before {
+    background: #DFD;
+}
+.legend .uncertain:before {
+    background: #dde7ef;
 }

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
@@ -1,23 +1,24 @@
 package org.pitest.mutationtest.report.html;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.pitest.classinfo.ClassInfo;
 import org.pitest.mutationtest.DetectionStatus;
 import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.MutationStatusTestPair;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.MutationIdentifier;
 import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
 import org.pitest.mutationtest.engine.gregor.config.Mutator;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 public class MutationTestSummaryDataTest {
 
@@ -180,7 +181,11 @@ public class MutationTestSummaryDataTest {
   }
 
   private MutationResult aMutationResult(DetectionStatus status) {
-    return new MutationResult(null, new MutationStatusTestPair(1, status, "A test"));
+    return new MutationResult(aMutationDetails(), new MutationStatusTestPair(1, status, "A test"));
+  }
+
+  private MutationDetails aMutationDetails() {
+    return new MutationDetails(new MutationIdentifier(null, Collections.emptyList(), null), null, "", 0, 0);
   }
 
   private MutationTestSummaryData buildSummaryDataMutators() {


### PR DESCRIPTION
When using several modules, the current mutation coverage was not enough accurate. If the same mutation survived in one submodule but was killed by a test in another module (typically an integration test), the result was survived. The mutation coverage was then 0/2 (0%). Developer HAD TO analyze manually each line to be sure that the same mutation really survived.

Now developer can quickly see packages and files that need to be covered. Only the unique mutations are considered.