### PR TITLE
Add missing property for jvmArgs parameter #464

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -171,7 +171,7 @@ public class AbstractPitMojo extends AbstractMojo {
   /**
    * Arguments to pass to child processes
    */
-  @Parameter
+  @Parameter(property = "jvmArgs")
   private ArrayList<String>           jvmArgs;
 
   /**


### PR DESCRIPTION
Hi,

I would like to suggest a fix for the issue #464 when `jvmArgs` property is not being picked up by `pitest-maven-plugin` if passed through the CLI.

For example, in the case when I can't make any changes in `pom.xml` I would like to be able to supply the argument (e.g. `-DjvmArgs=-ea`) through the CLI and expect it to be injected into the plugin. 

Thank you,
Yuriy