### PR TITLE
Parse String directly to primitive type

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStore.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/incremental/ObjectOutputStreamHistoryStore.java
@@ -109,7 +109,7 @@ public class ObjectOutputStreamHistoryStore implements HistoryStore {
 
   private void restoreClassPath() {
     try {
-      final long classPathSize = Long.valueOf(this.input.readLine());
+      final long classPathSize = Long.parseLong(this.input.readLine());
       for (int i = 0; i != classPathSize; i++) {
         final ClassHistory coverage = deserialize(this.input.readLine(),
             ClassHistory.class);

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
@@ -121,7 +121,7 @@ public class MutationTestMinion {
 
     enablePowerMockSupport();
 
-    final int port = Integer.valueOf(args[0]);
+    final int port = Integer.parseInt(args[0]);
 
     Socket s = null;
     try {


### PR DESCRIPTION
We have 2 cases where a boxed primitive is created from a String, just to extract the unboxed primitive value 

It is more efficient to just call the static parseXXX method

Problem: 

The goal is to convert a String to an int and its currently being done like this:

String => **int => Integer** => int                
 
                       ^ This is inside Integer.valueOf

Where a more efficient way of converting is by doing:

**String => int**

       ^ Integer.parseInt