### PR TITLE
Mitigate chance to get NPE on accidental dependency

### DIFF
--- a/pitest/src/main/java/org/pitest/classpath/ClassPath.java
+++ b/pitest/src/main/java/org/pitest/classpath/ClassPath.java
@@ -37,6 +37,8 @@ import org.pitest.util.ManifestUtils;
 import org.pitest.util.PitError;
 import org.pitest.util.StreamUtil;
 
+import static org.pitest.util.ManifestUtils.CLASSPATH_JAR_FILE_PREFIX;
+
 public class ClassPath {
 
   private static final Logger         LOG = Log.getLogger();
@@ -115,7 +117,7 @@ public class ClassPath {
 
   public static Collection<String> getClassPathElementsAsPaths() {
     final Set<String> filesAsString = new LinkedHashSet<>();
-    FCollection.mapTo(getClassPathElementsAsFiles(), file -> file.getPath(),
+    FCollection.mapTo(getClassPathElementsAsFiles(), File::getPath,
         filesAsString);
     return filesAsString;
   }
@@ -138,8 +140,8 @@ public class ClassPath {
    * @param elements existing elements
    */
   private static void addEntriesFromClasspathManifest(final Set<File> elements) {
-    Optional<File> maybeJar = elements.stream().filter( f -> f.getName().startsWith("classpath") && f.getName().endsWith(".jar"))
-    .findFirst();
+    Optional<File> maybeJar = elements.stream().filter(f -> f.getName().startsWith(CLASSPATH_JAR_FILE_PREFIX) && f.getName().endsWith(".jar"))
+        .findFirst();
     maybeJar.ifPresent(file -> elements.addAll(ManifestUtils.readClasspathManifest(file)));
   }
 

--- a/pitest/src/main/java/org/pitest/util/ManifestUtils.java
+++ b/pitest/src/main/java/org/pitest/util/ManifestUtils.java
@@ -34,6 +34,8 @@ import java.util.zip.ZipOutputStream;
  */
 public class ManifestUtils {
 
+  public static final String CLASSPATH_JAR_FILE_PREFIX = "pitest-classpath-jar-file-";
+
   // Method based on
   // https://github.com/JetBrains/intellij-community/blob/master/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/ForkedByModuleSplitter.java
   // JetBrains copyright notice and licence retained above.
@@ -59,7 +61,7 @@ public class ManifestUtils {
     }
     attributes.put(Attributes.Name.CLASS_PATH, classpathForManifest.toString());
 
-    File jarFile = File.createTempFile("classpath", ".jar");
+    File jarFile = File.createTempFile(CLASSPATH_JAR_FILE_PREFIX, ".jar");
     try (BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(jarFile));
         ZipOutputStream jarPlugin = new JarOutputStream(out, manifest);
         )  {


### PR DESCRIPTION
With its name matching "classpath*.jar".

Fixes #822.