### PR TITLE
Automatically release to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+on:
+  push:
+    branches:
+      - release
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # sonatype nexus sometimes hangs
+    timeout-minutes: 20
+    steps:
+      # The build number is stored as a tag in git
+      # If it needs to be reset (eg after a major number version change)
+      # run
+      # git tag -d build-number-<x>
+      # git push --delete origin build-number-<x>
+      - name: Generate build number
+        id: buildnumber
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{secrets.github_token}}
+      - name: Install gpg secret key
+        run: |
+          cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 8
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Publish JAR
+        run: mvn -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE}} -B -Prelease deploy scm:tag -Drevision=${{ steps.buildnumber.outputs.build_number }} -DskipTests=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ target/
 *.iml
 .checkstyle
 dependency-reduced-pom.xml
+.flattened-pom.xml
 */bin

--- a/perform_release.sh
+++ b/perform_release.sh
@@ -1,1 +1,0 @@
-mvn -Darguments="-Dcheckstyle.skip=true" release:perform

--- a/pitest-aggregator/pom.xml
+++ b/pitest-aggregator/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.pitest</groupId>
 		<artifactId>pitest-parent</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-aggregator</artifactId>
 	<description>Aggregates the output of report XML documents into a new combined HTML report</description>

--- a/pitest-ant/pom.xml
+++ b/pitest-ant/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-ant</artifactId>
 	<name>pitest-ant</name>
@@ -77,7 +77,11 @@
 						</configuration>
 					</execution>
 				</executions>
-
+			</plugin>
+			<!-- must run after shade -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 	</build>

--- a/pitest-build-config/pom.xml
+++ b/pitest-build-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pitest-parent</artifactId>
     <groupId>org.pitest</groupId>
-    <version>1.5.3-SNAPSHOT</version>
+    <version>1.6.${revision}</version>
   </parent>
 
 </project>

--- a/pitest-command-line/pom.xml
+++ b/pitest-command-line/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-command-line</artifactId>
 	<name>pitest-command-line</name>
@@ -56,7 +56,11 @@
 				</executions>
 
 			</plugin>
-
+			<!-- must run after shade -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 
 	</build>

--- a/pitest-entry/pom.xml
+++ b/pitest-entry/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-entry</artifactId>
 	<name>pitest-entry</name>
@@ -34,6 +34,11 @@
 					</execution>
 				</executions>
 
+			</plugin>
+			<!-- must run after shade -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pitest-groovy-verification/pom.xml
+++ b/pitest-groovy-verification/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-groovy-verification</artifactId>
 	<packaging>jar</packaging>
@@ -18,9 +18,10 @@
 		<plugins>
 		    <!-- Don't deploy to Maven Central -->
             <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
+					<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
 

--- a/pitest-html-report/pom.xml
+++ b/pitest-html-report/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-html-report</artifactId>
 	<name>pitest-html-report</name>
@@ -64,6 +64,11 @@
 					</execution>
 				</executions>
 
+			</plugin>
+			<!-- must run after shade -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
 
 		</plugins>

--- a/pitest-java8-verification/pom.xml
+++ b/pitest-java8-verification/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -14,13 +14,6 @@
 
 	<build>
 		<plugins>
-		    <!-- Don't deploy to Maven Central -->
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>

--- a/pitest-maven-verification/pom.xml
+++ b/pitest-maven-verification/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-maven-verification</artifactId>
 	<packaging>jar</packaging>
@@ -14,13 +14,6 @@
 
 	<build>
 		<plugins>
-			<!-- Don't deploy to Maven Central -->
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>

--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest-maven</artifactId>
 	<packaging>maven-plugin</packaging>
@@ -59,13 +59,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pitest/pom.xml
+++ b/pitest/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>pitest-parent</artifactId>
 		<groupId>org.pitest</groupId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.6.${revision}</version>
 	</parent>
 	<artifactId>pitest</artifactId>
 	<packaging>jar</packaging>
@@ -113,34 +113,11 @@
 						</configuration>
 					</execution>
 				</executions>
-
 			</plugin>
+			<!-- must run after shade -->
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>javadoc</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<failOnError>false</failOnError>
-				</configuration>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
 	</organization>
 	<artifactId>pitest-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.5.3-SNAPSHOT</version>
+	<version>1.6.${revision}</version>
 	<name>pitest-parent</name>
 	<url>http://pitest.org</url>
 	<description>Mutation testing system for java - parent project</description>
 	<scm>
 		<url>https://github.com/hcoles/pitest</url>
-		<connection>scm:git:git@github.com:hcoles/pitest.git</connection>
-		<developerConnection>scm:git:git@github.com:hcoles/pitest.git</developerConnection>
+          <!-- must use https url rather than git one for tagging to work -->
+		<developerConnection>scm:git:https://github.com/hcoles/pitest.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -60,33 +60,35 @@
 	<modules>
 		<module>pitest-build-config</module>
 		<module>pitest</module>
-                <module>pitest-entry</module>
-                <module>pitest-maven</module>
-                <module>pitest-ant</module>
+        <module>pitest-entry</module>
+        <module>pitest-maven</module>
+		<module>pitest-ant</module>
 		<module>pitest-command-line</module>
 		<module>pitest-html-report</module>
-		<module>pitest-maven-verification</module>
 		<module>pitest-aggregator</module>
-		<module>pitest-java8-verification</module>
 	</modules>
 
-	<prerequisites>
-		<maven>3.2.5</maven>
-	</prerequisites>
-
 	<profiles>
-			<profile>
-			<id>java8</id>
-			<!-- Groovy verifiation currently not working with java 9 -->
+		<profile>
+			<!-- A bug in the nexus plugin (https://issues.sonatype.org/browse/NEXUS-19853)
+			     means we cannot properly skip the upload of the verification modules during a release.
+			     As a workaround they are therefore activated in this profile.
+			-->
+			<id>verification</id>
 			<activation>
-				<jdk>1.8</jdk>
+				<property>
+					<name>!skipTests</name>
+				</property>
 			</activation>
 			<modules>
-				<module>pitest-groovy-verification</module>
+				<module>pitest-java8-verification</module>
+				<module>pitest-maven-verification</module>
+				<!-- disabled until working with java 9+ -->
+				<!-- <module>pitest-groovy-verification</module> -->
 			</modules>
 		</profile>
 		<profile>
-			<id>release-sign-artifacts</id>
+			<id>release</id>
 			<activation>
 				<property>
 					<name>performRelease</name>
@@ -98,16 +100,18 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>
@@ -169,17 +173,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<artifactId>maven-release-plugin</artifactId>
-					<version>2.4.2</version>
-					<dependencies>
-						<dependency>
-							<groupId>org.apache.maven.scm</groupId>
-							<artifactId>maven-scm-provider-gitexe</artifactId>
-							<version>1.9.4</version>
-						</dependency>
-					</dependencies>
-				</plugin>
-				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
 					<version>3.1.0</version>
@@ -187,7 +180,7 @@
 						<dependency>
 							<groupId>org.pitest</groupId>
 							<artifactId>pitest-build-config</artifactId>
-							<version>1.5.3-SNAPSHOT</version>
+							<version>${project.version}</version>
 						</dependency>
 					</dependencies>
 					<executions>
@@ -207,7 +200,33 @@
 						</execution>
 					</executions>
 				</plugin>
-
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>1.6</version>
+					<executions>
+						<execution>
+							<id>sign-artifacts</id>
+							<phase>verify</phase>
+							<goals>
+								<goal>sign</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<gpgArguments>
+							<arg>--pinentry-mode</arg>
+							<arg>loopback</arg>
+						</gpgArguments>
+					</configuration>
+				</plugin>
+				<plugin>
+					<artifactId>maven-scm-plugin</artifactId>
+					<version>1.11.2</version>
+					<configuration>
+						<tag>${project.version}</tag>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
@@ -248,6 +267,14 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>3.0.1</version>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -258,6 +285,31 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>3.2.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>flatten-maven-plugin</artifactId>
+					<version>1.2.5</version>
+					<configuration>
+						<updatePomFile>true</updatePomFile>
+						<flattenMode>resolveCiFriendliesOnly</flattenMode>
+					</configuration>
+					<executions>
+						<execution>
+							<id>flatten</id>
+							<phase>package</phase>
+							<goals>
+								<goal>flatten</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>flatten.clean</id>
+							<phase>clean</phase>
+							<goals>
+								<goal>clean</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -280,17 +332,42 @@
 					<version>3.3</version>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.8</version>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>1.6.7</version>
+					<extensions>true</extensions>
+					<configuration>
+						<serverId>ossrh</serverId>
+						<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+						<autoReleaseAfterClose>true</autoReleaseAfterClose>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.2.0</version>
+					<executions>
+						<execution>
+							<id>javadoc</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<failOnError>false</failOnError>
+						<additionalparam>-Xdoclint:none</additionalparam>
+					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<!-- execute for every child -->
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
 	</build>
 
 	<distributionManagement>
@@ -307,6 +384,8 @@
 	<!-- versions of libraries which are used in different projects or which 
 		are used for few artifacts -->
 	<properties>
+		<!-- this revision number used only for local builds, release version is held within ci -->
+		<revision>0-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -1,1 +1,0 @@
-mvn -e -DpreparationGoals=clean release:prepare


### PR DESCRIPTION
Release automatically when code is merged into the release branch.

The maven release plugin is no longer used, instead tracking of the
build number is moved into git, where the minor version is tracked as a tag.

Updating the major version requires manual changed to the poms, which
needs to be addressed in the future, but fortuantely major version
updates are rare.

If a major version is changed the minor version must be reset. This can be done with

```bash
git tag -d build-number-<x>
git push --delete origin build-number-<x>
```

Where `x` is the current build number.

The current development version is always x.x.0-SNAPSHOT.