### PR TITLE
filter mutation results for multiple (generated) methods in same LOC

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 128
+tab_width = 2

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsPrecursor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsPrecursor.java
@@ -1,30 +1,56 @@
 package org.pitest.mutationtest.statistics;
 
+import org.pitest.functional.FCollection;
+import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.engine.MutationDetails;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.pitest.functional.FCollection;
-import org.pitest.mutationtest.MutationResult;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toSet;
 
 class MutationStatisticsPrecursor {
-  private final Map<String, ScorePrecursor> mutatorTotalMap  = new HashMap<>();
-  private long                              numberOfTestsRun = 0;
+
+  private final Map<String, ScorePrecursor> mutatorTotalMap = new HashMap<>();
+  private long numberOfTestsRun = 0;
 
   public void registerResults(final Collection<MutationResult> results) {
-    results.forEach(register());
+
+    final Map<String, Map<Integer, Integer>> methodCountPerSourceLine = results.stream()
+      .map(MutationResult::getDetails)
+      .collect(
+        groupingBy(
+          MutationDetails::getFilename,
+          groupingBy(
+            MutationDetails::getLineNumber,
+            collectingAndThen(
+              mapping(MutationDetails::getMethod, toSet()),
+              Set::size))));
+
+    results.stream()
+      .filter(result ->
+        methodCountPerSourceLine
+          .get(result.getDetails().getFilename())
+          .get(result.getDetails().getLineNumber()) == 1)
+      .forEach(register());
+
   }
 
   private Consumer<MutationResult> register() {
     return mr -> {
       MutationStatisticsPrecursor.this.numberOfTestsRun = MutationStatisticsPrecursor.this.numberOfTestsRun
-          + mr.getNumberOfTestsRun();
+        + mr.getNumberOfTestsRun();
       final String key = mr.getDetails().getId().getMutator();
       ScorePrecursor total = MutationStatisticsPrecursor.this.mutatorTotalMap
-          .get(key);
+        .get(key);
       if (total == null) {
         total = new ScorePrecursor(key);
         MutationStatisticsPrecursor.this.mutatorTotalMap.put(key, total);
@@ -37,10 +63,9 @@ class MutationStatisticsPrecursor {
     final Iterable<Score> scores = getScores();
     final long totalMutations = FCollection.fold(addTotals(), 0L, scores);
     final long totalDetected = FCollection
-        .fold(addDetectedTotals(), 0L, scores);
+      .fold(addDetectedTotals(), 0L, scores);
     final long totalWithCoverage = FCollection.fold(addCoveredTotals(), 0L, scores);
-    return new MutationStatistics(scores, totalMutations, totalDetected, totalWithCoverage,
-        this.numberOfTestsRun);
+    return new MutationStatistics(scores, totalMutations, totalDetected, totalWithCoverage, this.numberOfTestsRun);
   }
 
   Iterable<Score> getScores() {

--- a/pitest-entry/src/test/java/com/example/MultipleSurvivorsInSingleLine.java
+++ b/pitest-entry/src/test/java/com/example/MultipleSurvivorsInSingleLine.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2010 Henry Coles
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.example;
+
+public class MultipleSurvivorsInSingleLine {
+
+  // generated code, e.g. from by-delegation in Kotlin can have multiple methods in a single line
+
+  // multiple covered methods in a single loc with 1 killed => treated as generated => should not be counted
+  // @formatter:off
+  public int coveredSurvivor1a() { return 1; } public int coveredSurvivor1b() { return 1; } public int killed1() { return 1; }
+  // @formatter:on
+
+  // multiple uncovered methods in a single loc => treated as generated => should not be counted
+  // @formatter:off
+  public int uncoveredSurvivor2a() { return 2; } public int uncoveredSurvivor2b() { return 2; }
+  // @formatter:on
+
+  // a single method in same loc, covered but not asserted => should count as survivor
+  public int coveredSurvivor3() {
+    return 3;
+  }
+
+  // a single method in same loc, not covered => should count as uncovered
+  public int uncoveredSurvivor4() {
+    return 4;
+  }
+
+  // a single method in same loc, covered and asserted => should count killed
+  public int killed5() {
+    return 5;
+  }
+}

--- a/pitest-entry/src/test/java/com/example/MultipleSurvivorsInSingleLineTest.java
+++ b/pitest-entry/src/test/java/com/example/MultipleSurvivorsInSingleLineTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010 Henry Coles
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.example;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultipleSurvivorsInSingleLineTest {
+
+  @Test
+  public void testSurvivingLine() {
+    final MultipleSurvivorsInSingleLine testee = new MultipleSurvivorsInSingleLine();
+
+    // called without assertion => surviving
+    testee.coveredSurvivor1a();
+    testee.coveredSurvivor1b();
+    testee.coveredSurvivor3();
+
+    // called with assertion => killed
+    assertEquals(1, testee.killed1());
+    assertEquals(5, testee.killed5());
+  }
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
@@ -16,6 +16,7 @@
 package org.pitest.mutationtest;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.pitest.mutationtest.DetectionStatus.KILLED;
 import static org.pitest.mutationtest.DetectionStatus.NO_COVERAGE;
@@ -40,6 +41,7 @@ import org.pitest.SystemTest;
 import org.pitest.classpath.ClassPath;
 import org.pitest.help.PitHelpError;
 import org.pitest.mutationtest.engine.gregor.Generated;
+import org.pitest.mutationtest.tooling.CombinedStatistics;
 import org.pitest.util.FileUtil;
 import org.pitest.util.IsolationUtils;
 
@@ -97,19 +99,29 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   @Test
   public void shouldReportSurvivingMutations() {
     this.data
-    .setTargetClasses(asList("com.example.CoveredButOnlyPartiallyTested*"));
+      .setTargetClasses(asList("com.example.CoveredButOnlyPartiallyTested*"));
     createAndRun();
     verifyResults(KILLED, SURVIVED);
   }
 
+  @Test
+  public void shouldReportMaxSurvivingLinesPerFile() {
+    this.data
+      .setTargetClasses(singletonList("com.example.MultipleSurvivorsInSingleLine*"));
+    final CombinedStatistics actual = createAndRun();
+    assertEquals(3, actual.getMutationStatistics().getTotalMutations());
+    assertEquals(1, actual.getMutationStatistics().getTotalDetectedMutations());
+    assertEquals(4, actual.getCoverageSummary().getNumberOfCoveredLines());
+    assertEquals(6, actual.getCoverageSummary().getNumberOfLines());
+  }
 
   @Test(expected = PitHelpError.class)
   public void shouldFailRunWithHelpfulMessageIfTestsNotGreen() {
     setMutators("MATH");
     this.data
-    .setTargetClasses(asList("com.example.FailsTestWhenEnvVariableSet*"));
+      .setTargetClasses(asList("com.example.FailsTestWhenEnvVariableSet*"));
     this.data.addChildJVMArgs(Arrays.asList("-D"
-        + FailsTestWhenEnvVariableSetTestee.class.getName() + "=true"));
+      + FailsTestWhenEnvVariableSetTestee.class.getName() + "=true"));
     createAndRun();
     // should not get here
   }
@@ -118,19 +130,19 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldNotFailRunIfSkipFailedTests() {
     setMutators("MATH");
     this.data
-    .setTargetClasses(asList("com.example.FailsTestWhenEnvVariableSet*"));
+      .setTargetClasses(asList("com.example.FailsTestWhenEnvVariableSet*"));
     this.data.addChildJVMArgs(Arrays.asList("-D"
-        + FailsTestWhenEnvVariableSetTestee.class.getName() + "=true"));
+      + FailsTestWhenEnvVariableSetTestee.class.getName() + "=true"));
     this.data.setSkipFailingTests(true);
     createAndRun();
     verifyResults(NO_COVERAGE);
   }
 
   @Test
-  public void shouldLoadResoucesOffClassPathFromFolderWithSpaces() {
+  public void shouldLoadResourcesOffClassPathFromFolderWithSpaces() {
     setMutators("RETURN_VALS");
     this.data
-    .setTargetClasses(asList("com.example.LoadsResourcesFromClassPath*"));
+      .setTargetClasses(asList("com.example.LoadsResourcesFromClassPath*"));
     this.data.setVerbose(true);
     createAndRun();
     verifyResults(KILLED);
@@ -140,7 +152,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldPickRelevantTestsFromSuppliedTestSuites() {
     this.data.setTargetClasses(asList("com.example.FullyCovered*"));
     this.data
-    .setTargetTests(predicateFor(com.example.SuiteForFullyCovered.class));
+      .setTargetTests(predicateFor(com.example.SuiteForFullyCovered.class));
     createAndRun();
     verifyResults(KILLED);
   }
@@ -157,8 +169,8 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldLimitNumberOfMutationsPerClass() {
     this.data.setTargetClasses(asGlobs(MultipleMutations.class));
     this.data
-    .setTargetTests(predicateFor(com.example.FullyCoveredTesteeTest.class));
-    this.data.setFeatures(Collections.singletonList("+CLASSLIMIT(limit[1])"));
+      .setTargetTests(predicateFor(com.example.FullyCoveredTesteeTest.class));
+    this.data.setFeatures(singletonList("+CLASSLIMIT(limit[1])"));
     createAndRun();
     verifyResults(NO_COVERAGE);
   }
@@ -199,17 +211,17 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   @Test
   public void willAllowExcludedClassesToBeReIncludedViaSuite() {
     this.data
-    .setTargetTests(predicateFor("com.example.*SuiteForFullyCovered*"));
+      .setTargetTests(predicateFor("com.example.*SuiteForFullyCovered*"));
     this.data.setTargetClasses(asList("com.example.FullyCovered*"));
     this.data.setExcludedClasses(asGlobs(FullyCoveredTesteeTest.class));
     createAndRun();
     verifyResults(KILLED);
   }
-  
+
   @Test
   public void computesFullMutationMatrix() {
     this.data
-    .setTargetTests(predicateFor("com.example.coverage.execute.samples.mutationMatrix.*"));
+      .setTargetTests(predicateFor("com.example.coverage.execute.samples.mutationMatrix.*"));
     this.data.setTargetClasses(asList("com.example.coverage.execute.samples.mutationMatrix.*"));
     this.data.setExcludedClasses(asGlobs(TestsForSimpleCalculator.class));
     this.data.setFullMutationMatrix(true);
@@ -218,7 +230,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     createAndRun();
     List<MutationResult> resultData = this.metaDataExtractor.getData();
     assertEquals(1, resultData.size());
-    
+
     MutationResult mutation = resultData.get(0);
     assertEquals(KILLED, mutation.getStatus());
     assertEquals(3, mutation.getNumberOfTestsRun());
@@ -236,13 +248,13 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
 
   @Test
   public void shouldMutateClassesSuppliedToAlternateClassPath()
-      throws IOException {
+    throws IOException {
     // yes, this is horrid
     final String location = FileUtil.randomFilename() + ".jar";
     try {
       try (FileOutputStream fos = new FileOutputStream(location)) {
         final InputStream stream = IsolationUtils.getContextClassLoader()
-             .getResourceAsStream("outofcp.jar");
+          .getResourceAsStream("outofcp.jar");
         copy(stream, fos);
       }
 
@@ -266,7 +278,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   @Test
   public void shouldSupportTestNG() {
     this.data
-    .setTargetClasses(asList("com.example.testng.FullyCovered*"));
+      .setTargetClasses(asList("com.example.testng.FullyCovered*"));
     this.data.setVerbose(true);
     this.data.setTestPlugin("testng");
     createAndRun();
@@ -277,7 +289,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldTerminateWhenThreadpoolCreated() {
     this.data.setTargetClasses(asGlobs(KeepAliveThread.class));
     this.data
-    .setTargetTests(predicateFor(com.example.KeepAliveThreadTest.class));
+      .setTargetTests(predicateFor(com.example.KeepAliveThreadTest.class));
     createAndRun();
     verifyResults(SURVIVED);
   }
@@ -287,7 +299,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("NEGATE_CONDITIONALS");
     this.data.setTargetClasses(asGlobs(CrashesJVMWhenMutated.class));
     this.data
-    .setTargetTests(predicateFor(com.example.TestCrashesJVMWhenMutated.class));
+      .setTargetTests(predicateFor(com.example.TestCrashesJVMWhenMutated.class));
     createAndRun();
 
     verifyResults(RUN_ERROR);
@@ -321,7 +333,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("INCREMENTS");
     this.data.setTargetClasses(asGlobs(HasMutationsInFinallyBlock.class));
     this.data
-    .setTargetTests(predicateFor(HasMutationInFinallyBlockNonTest.class));
+      .setTargetTests(predicateFor(HasMutationInFinallyBlockNonTest.class));
     this.data.setDetectInlinedCode(true);
     createAndRun();
 
@@ -332,7 +344,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldExitAfterFirstFailureWhenTestClassAnnotatedWithBeforeClass() {
     setMutators("RETURN_VALS");
     this.data
-    .setTargetClasses(asGlobs(CoveredByABeforeAfterClass.class));
+      .setTargetClasses(asGlobs(CoveredByABeforeAfterClass.class));
     this.data.setTargetTests(predicateFor(BeforeAfterClassTest.class));
 
     createAndRun();
@@ -346,9 +358,9 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("RETURN_VALS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.mutatablecodeintest.Mutee.class));
+      .setTargetClasses(asGlobs(com.example.mutatablecodeintest.Mutee.class));
     this.data
-    .setTargetTests(predicateFor(com.example.mutatablecodeintest.MuteeTest.class));
+      .setTargetTests(predicateFor(com.example.mutatablecodeintest.MuteeTest.class));
 
     createAndRun();
 
@@ -360,22 +372,21 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("RETURN_VALS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.testhasignores.Mutee.class));
+      .setTargetClasses(asGlobs(com.example.testhasignores.Mutee.class));
     this.data
-    .setTargetTests(predicateFor(com.example.testhasignores.MuteeTest.class));
+      .setTargetTests(predicateFor(com.example.testhasignores.MuteeTest.class));
 
     createAndRun();
 
     verifyResults(KILLED);
   }
 
-
   @Test
   public void shouldNotMutateStaticMethodsOnlyCalledFromInitializer() {
     setMutators("VOID_METHOD_CALLS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledOnlyFromInitializer.class));
+      .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledOnlyFromInitializer.class));
 
     createAndRun();
 
@@ -387,7 +398,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("VOID_METHOD_CALLS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledFromInitializerAndElseWhere.class));
+      .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledFromInitializerAndElseWhere.class));
 
     createAndRun();
 
@@ -400,11 +411,11 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("VOID_METHOD_CALLS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.staticinitializers.NonPrivateMethodsCalledFromInitializerOnly.class));
+      .setTargetClasses(asGlobs(com.example.staticinitializers.NonPrivateMethodsCalledFromInitializerOnly.class));
 
     createAndRun();
 
-    verifyResults(NO_COVERAGE,NO_COVERAGE,NO_COVERAGE);
+    verifyResults(NO_COVERAGE, NO_COVERAGE, NO_COVERAGE);
   }
 
   @Test
@@ -412,7 +423,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     setMutators("VOID_METHOD_CALLS");
 
     this.data
-    .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledInChainFromStaticInitializer.class));
+      .setTargetClasses(asGlobs(com.example.staticinitializers.MethodsCalledInChainFromStaticInitializer.class));
 
     createAndRun();
 
@@ -424,7 +435,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
   public void shouldNotMutateClassesAnnotatedWithGenerated() {
     setMutators("RETURN_VALS");
     this.data
-    .setTargetClasses(asGlobs(AnnotatedToAvoidAtClassLevel.class));
+      .setTargetClasses(asGlobs(AnnotatedToAvoidAtClassLevel.class));
 
     createAndRun();
 
@@ -433,14 +444,14 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
 
   @Generated
   public static class AnnotatedToAvoidAtClassLevel {
+
     public int mutateMe() {
       return 42;
     }
   }
 
-
   private static void copy(final InputStream in, final OutputStream out)
-      throws IOException {
+    throws IOException {
     // Read bytes and write to destination until eof
 
     final byte[] buf = new byte[1024];

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
@@ -26,6 +26,7 @@ import org.pitest.mutationtest.config.SettingsFactory;
 import org.pitest.mutationtest.config.TestPluginArguments;
 import org.pitest.mutationtest.engine.gregor.config.GregorEngineFactory;
 import org.pitest.mutationtest.incremental.NullHistoryStore;
+import org.pitest.mutationtest.tooling.CombinedStatistics;
 import org.pitest.mutationtest.tooling.JarCreatingJarFinder;
 import org.pitest.mutationtest.tooling.MutationCoverage;
 import org.pitest.mutationtest.tooling.MutationStrategies;
@@ -94,12 +95,12 @@ public abstract class ReportTestBase {
     return predicateFor(clazz.getName());
   }
 
-  protected void createAndRun() {
+  protected CombinedStatistics createAndRun() {
     final SettingsFactory settings = new SettingsFactory(this.data, this.plugins);
-    createAndRun(settings);
+    return createAndRun(settings);
   }
 
-  protected void createAndRun(SettingsFactory settings) {
+  protected CombinedStatistics createAndRun(SettingsFactory settings) {
     final JavaAgent agent = new JarCreatingJarFinder();
     try {
 
@@ -129,7 +130,7 @@ public abstract class ReportTestBase {
           code, this.data, new SettingsFactory(this.data, this.plugins),
           timings);
 
-      testee.runReport();
+      return testee.runReport();
     } catch (final IOException e) {
       throw Unchecked.translateCheckedException(e);
     } finally {


### PR DESCRIPTION
avoidsa false positives stemming from generated code from Kotlin by-delegation