### PR TITLE
Pass data from stdout and stderr of spawned processes line by line to…

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/WorkerFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/WorkerFactory.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-import static org.pitest.functional.prelude.Prelude.printWith;
+import static org.pitest.functional.prelude.Prelude.printlnWith;
 
 public class WorkerFactory {
 
@@ -58,7 +58,7 @@ public class WorkerFactory {
     final ProcessArgs args = ProcessArgs.withClassPath(this.classPath)
         .andLaunchOptions(this.config.getLaunchOptions())
         .andBaseDir(this.baseDir).andStdout(captureStdOutIfVerbose())
-        .andStderr(printWith("stderr "));
+        .andStderr(printlnWith("stderr "));
 
     final SocketFinder sf = new SocketFinder();
     return new MutationTestProcess(
@@ -67,7 +67,7 @@ public class WorkerFactory {
 
   private Consumer<String> captureStdOutIfVerbose() {
     if (this.verbose) {
-      return Prelude.printWith("stdout ");
+      return printlnWith("stdout ");
     } else {
       return Prelude.noSideEffect(String.class);
     }

--- a/pitest-entry/src/main/java/org/pitest/process/ProcessArgs.java
+++ b/pitest-entry/src/main/java/org/pitest/process/ProcessArgs.java
@@ -14,8 +14,8 @@
  */
 package org.pitest.process;
 
-import static org.pitest.functional.prelude.Prelude.print;
-import static org.pitest.functional.prelude.Prelude.printTo;
+import static org.pitest.functional.prelude.Prelude.println;
+import static org.pitest.functional.prelude.Prelude.printlnTo;
 
 import java.io.File;
 import java.util.Collections;
@@ -28,8 +28,8 @@ import org.pitest.classpath.ClassPath;
 public final class ProcessArgs {
 
   private final String        launchClassPath;
-  private Consumer<String> stdout     = print(String.class);
-  private Consumer<String> stdErr     = printTo(String.class, System.err);
+  private Consumer<String> stdout     = println(String.class);
+  private Consumer<String> stdErr     = printlnTo(String.class, System.err);
   private List<String>        jvmArgs    = Collections.emptyList();
   private JavaAgent           javaAgentFinder;
   private File                workingDir = null;

--- a/pitest/src/main/java/org/pitest/functional/prelude/Prelude.java
+++ b/pitest/src/main/java/org/pitest/functional/prelude/Prelude.java
@@ -73,25 +73,25 @@ public abstract class Prelude {
     return id();
   }
 
-  public static final <T> Consumer<T> print() {
-    return printTo(System.out);
+  public static final <T> Consumer<T> println() {
+    return printlnTo(System.out);
   }
 
-  public static final <T> Consumer<T> print(final Class<T> type) {
-    return print();
+  public static final <T> Consumer<T> println(final Class<T> type) {
+    return println();
   }
 
-  public static final <T> Consumer<T> printTo(final Class<T> type,
+  public static final <T> Consumer<T> printlnTo(final Class<T> type,
       final PrintStream stream) {
-    return printTo(stream);
+    return printlnTo(stream);
   }
 
-  public static final <T> Consumer<T> printTo(final PrintStream stream) {
-    return a -> stream.print(a);
+  public static final <T> Consumer<T> printlnTo(final PrintStream stream) {
+    return a -> stream.println(a);
   }
 
-  public static <T> Consumer<T> printWith(final T t) {
-    return a -> System.out.print(t + " : " + a);
+  public static <T> Consumer<T> printlnWith(final T t) {
+    return a -> System.out.println(t + " : " + a);
   }
 
   public static <T extends Number> Predicate<T> isGreaterThan(final T value) {

--- a/pitest/src/test/java/org/pitest/functional/prelude/PreludeTest.java
+++ b/pitest/src/test/java/org/pitest/functional/prelude/PreludeTest.java
@@ -27,8 +27,8 @@ public class PreludeTest {
   public void printToShouldPrintValueToStream() {
     final Integer i = Integer.valueOf(42);
     final PrintStream stream = Mockito.mock(PrintStream.class);
-    Prelude.printTo(stream).accept(i);
-    verify(stream).print(i);
+    Prelude.printlnTo(stream).accept(i);
+    verify(stream).println(i);
   }
 
 }


### PR DESCRIPTION
… the consumer - Fix for #596.

This ensures, that the prefixes added by a consumer do not occur in the middle of the message, which happened in the old implementation if the message was longer than 256 bytes (often the case for stacktraces).