### PR TITLE
Fixed tests not failing when maxSurviving=0 and typo

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/MutationCoverageReport.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/MutationCoverageReport.java
@@ -50,7 +50,7 @@ public class MutationCoverageReport {
               data.getTestStrengthThreshold());
       throwErrorIfScoreBelowMutationThreshold(stats.getMutationStatistics(),
           data.getMutationThreshold());
-      throwErrorIfMoreThanMaxSuvivingMutants(stats.getMutationStatistics(), data.getMaximumAllowedSurvivors());
+      throwErrorIfMoreThanMaxSurvivingMutants(stats.getMutationStatistics(), data.getMaximumAllowedSurvivors());
     }
 
   }
@@ -81,9 +81,9 @@ public class MutationCoverageReport {
     }
   }
 
-  private static void throwErrorIfMoreThanMaxSuvivingMutants(
+  private static void throwErrorIfMoreThanMaxSurvivingMutants(
       final MutationStatistics stats, final long threshold) {
-    if ((threshold > 0)
+    if ((threshold >= 0)
         && (stats.getTotalSurvivingMutations() > threshold)) {
       throw new RuntimeException("Had "
           + stats.getTotalSurvivingMutations() + " surviving mutants, but only "


### PR DESCRIPTION
Currently when maxSurviving is set to 0, an error will still not be thrown due to this restriction `if ((threshold > 0)` in src/main/java/org/pitest/mutationtest/commandline/MutationCoverageReport.java in `throwErrorIfMoreThanMaxSuvivingMutants`.

We can safely set it to `if ((threshold >= 0)` as the default is -1.

This should finish the fixes that were started to address this issue: [https://github.com/hcoles/pitest/issues/269](https://github.com/hcoles/pitest/issues/269).

Also fixed a typo in that method's name changing `throwErrorIfMoreThanMaxSuvivingMutants` to `throwErrorIfMoreThanMaxSurvivingMutants`.

Let me know if any additional information/clarification from me would be helpful.

Thanks!