### PR TITLE
use final probe field when possible

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
@@ -71,7 +71,7 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
     }
 
     return new CoverageAnalyser(this, this.classId, this.probeCount,
-        methodVisitor, access, name, desc, signature, exceptions);
+        methodVisitor, access, name, desc, signature, exceptions, hasSuper);
 
   }
 

--- a/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/CoverageClassVisitor.java
@@ -41,6 +41,7 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
   private String    className;
   private boolean   foundClinit;
   private boolean   isInterface;
+  private boolean   hasSuper;
 
   public CoverageClassVisitor(final int classId, final ClassWriter writer) {
     super(writer, BridgeMethodFilter.INSTANCE);
@@ -57,9 +58,9 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
     super.visit(version, access, name, signature, superName, interfaces);
     this.className = name;
     this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
+    this.hasSuper = !superName.equals("java/lang/Object");
   }
-
-
+  
   @Override
   public MethodVisitor visitMethodIfRequired(final int access,
       final String name, final String desc, final String signature,
@@ -129,6 +130,11 @@ public class CoverageClassVisitor extends MethodFilteringAdapter {
     if (isInterface) {
       return Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_PUBLIC
               | Opcodes.ACC_SYNTHETIC;
+    }
+
+    if (!hasSuper) {
+      return Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_PRIVATE
+             | Opcodes.ACC_SYNTHETIC;
     }
 
     return Opcodes.ACC_STATIC | Opcodes.ACC_TRANSIENT | Opcodes.ACC_PRIVATE

--- a/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/CoverageAnalyser.java
@@ -21,21 +21,24 @@ public class CoverageAnalyser extends MethodNode {
   private final int                  classId;
   private final MethodVisitor        mv;
   private final int                  probeOffset;
+  private final boolean              useLazyInitialisation;
 
   public CoverageAnalyser(final CoverageClassVisitor parent, final int classId,
       final int probeOffset, final MethodVisitor mv, final int access,
       final String name, final String desc, final String signature,
-      final String[] exceptions) {
+      final String[] exceptions,
+      boolean useLazyInitialisation) {
     super(ASMVersion.ASM_VERSION, access, name, desc, signature, exceptions);
     this.mv = mv;
     this.parent = parent;
     this.classId = classId;
     this.probeOffset = probeOffset;
+    this.useLazyInitialisation = useLazyInitialisation;
   }
 
   @Override
   public void visitEnd() {
-    final List<Block> blocks = findRequriedProbeLocations();
+    final List<Block> blocks = findRequiredProbeLocations();
 
     this.parent.registerProbes(blocks.size());
 
@@ -43,13 +46,21 @@ public class CoverageAnalyser extends MethodNode {
         this.probeOffset, (this.probeOffset + blocks.size()) - 1, blocks);
 
     final DefaultInstructionCounter counter = new DefaultInstructionCounter();
-    accept(new InstructionTrackingMethodVisitor(
-        new ArrayProbeCoverageMethodVisitor(blocks, counter, this.classId,
-            this.mv, this.access, parent.getClassName(), this.name, this.desc,
-            this.probeOffset), counter));
+
+    if (useLazyInitialisation) {
+      accept(new InstructionTrackingMethodVisitor(
+              new LazyInitialisationArrayProbeCoverageMethodVisitor(blocks, counter, this.classId,
+                      this.mv, this.access, parent.getClassName(), this.name, this.desc,
+                      this.probeOffset), counter));
+    } else {
+      accept(new InstructionTrackingMethodVisitor(
+              new ArrayProbeCoverageMethodVisitor(blocks, counter, this.classId,
+                      this.mv, this.access, parent.getClassName(), this.name, this.desc,
+                      this.probeOffset), counter));
+    }
   }
 
-  private List<Block> findRequriedProbeLocations() {
+  private List<Block> findRequiredProbeLocations() {
     return ControlFlowAnalyser.analyze(this);
   }
 }

--- a/pitest/src/main/java/org/pitest/coverage/analysis/LazyInitialisationArrayProbeCoverageMethodVisitor.java
+++ b/pitest/src/main/java/org/pitest/coverage/analysis/LazyInitialisationArrayProbeCoverageMethodVisitor.java
@@ -1,0 +1,150 @@
+/*
+ * Based on http://code.google.com/p/javacoveragent/ by
+ * "alex.mq0" and "dmitry.kandalov"
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.pitest.coverage.analysis;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.pitest.mutationtest.engine.gregor.analysis.InstructionCounter;
+import sun.pitest.CodeCoverageStore;
+
+import java.util.List;
+
+/**
+ *
+ * Instruments a method adding probes at each block. Handles construction
+ * of class level probe array if it has not been initialised.
+ *
+ * Probes are implemented by adding an array to each class. Block hits are
+ * registered by a write to this local array. The array is registered upon class
+ * initialization with the CodeCoverageStore, and all methods in the same class
+ * share the same array. The coverage store class reads this array at the end of
+ * the test and handles communication of this data back to the parent process.
+ *
+ * The old approach was to allocate an array in *each* invocation of each method,
+ * and merge this in to a global array, which could get flushed between test runs.
+ * The approach implemented here requires far fewer allocations and is faster, plus
+ * it's better from a concurrency perspective (no locking needed except when first
+ * initializing the coverage probe array).
+ *
+ *
+ * Here's a source-level example of the instrumentation result:
+ *
+ * public class Foo {
+ *   public static final int $$pitCoverageProbeSize = 10; //however many blocks there are + 1
+ *   public static final byte[] $$pitCoverageProbes = CodeCoverageStore.getOrRegisterClassProbes(thisClassID,$$pitCoverageProbeSize);
+ *
+ *   private void bar(){
+ *     byte[] localRefToProbes = $$pitCoverageProbes;
+ *     //line of code
+ *     localRefToProbes[1] = 1; //assuming above line was probe 1
+ *   }
+ *
+ * }
+ *
+ * CodeCoverageStore maintains a reference to all of these $$pitCoverageProbes arrays
+ * and empties them out between each test.
+ *
+ */
+public class LazyInitialisationArrayProbeCoverageMethodVisitor extends AbstractCoverageStrategy {
+
+  private int           probeHitArrayLocal;
+
+  public LazyInitialisationArrayProbeCoverageMethodVisitor(List<Block> blocks,
+                                                           InstructionCounter counter,
+                                                           int classId,
+                                                           MethodVisitor writer,
+                                                           int access,
+                                                           String className,
+                                                           String name,
+                                                           String desc,
+                                                           int probeOffset) {
+    super(blocks, counter, classId, writer, access, className, name, desc, probeOffset);
+  }
+
+  @Override
+  public void visitMethodInsn(int opcode, String owner, String name,
+      String desc, boolean itf) {
+
+    super.visitMethodInsn(opcode, owner, name, desc, itf);
+  }
+
+  @Override
+  public void visitFieldInsn(int opcode, String owner, String name,
+      String desc) {
+    super.visitFieldInsn(opcode, owner, name, desc);
+  }
+
+  @Override
+  void prepare() {
+    if (getName().equals("<clinit>")) {
+        pushConstant(this.classId);
+        this.mv.visitFieldInsn(Opcodes.GETSTATIC, this.className, CodeCoverageStore.PROBE_LENGTH_FIELD_NAME,"I");
+        this.mv
+            .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,
+                "getOrRegisterClassProbes", "(II)[Z", false);
+        this.mv.visitFieldInsn(Opcodes.PUTSTATIC, className,
+            CodeCoverageStore.PROBE_FIELD_NAME, "[Z");
+    }
+    this.probeHitArrayLocal = newLocal(Type.getType("[Z"));
+
+    this.mv.visitFieldInsn(Opcodes.GETSTATIC, className,
+        CodeCoverageStore.PROBE_FIELD_NAME, "[Z");
+
+    this.mv.visitInsn(DUP); //duplicate array reference, one for null check and one to use
+
+    //Check if PROBE_FIELD_NAME has been initialised
+    Label notnull = new Label();
+    this.mv.visitJumpInsn(Opcodes.IFNONNULL,notnull);
+
+    //if not then initialise
+    this.mv.visitInsn(POP); //gte rid of null on top of stack
+    pushConstant(this.classId);
+    this.mv.visitFieldInsn(Opcodes.GETSTATIC, this.className, CodeCoverageStore.PROBE_LENGTH_FIELD_NAME,"I");
+    this.mv
+            .visitMethodInsn(Opcodes.INVOKESTATIC, CodeCoverageStore.CLASS_NAME,
+                    "getOrRegisterClassProbes", "(II)[Z", false);
+    this.mv.visitInsn(DUP);//duplicate array reference, one to store and one to use
+    this.mv.visitFieldInsn(Opcodes.PUTSTATIC, className,
+            CodeCoverageStore.PROBE_FIELD_NAME, "[Z");
+
+    //else do nothing
+    this.mv.visitLabel(notnull);
+
+    //Make sure that we recorded that the class was hit
+    this.mv.visitInsn(DUP);
+    this.mv.visitInsn(ICONST_0);
+    this.mv.visitInsn(ICONST_1);
+    this.mv.visitInsn(BASTORE);
+    this.mv.visitVarInsn(ASTORE, this.probeHitArrayLocal);
+  }
+
+  @Override
+  void generateProbeReportCode() {
+  }
+
+  @Override
+  void insertProbe() {
+    this.mv.visitVarInsn(ALOAD, this.probeHitArrayLocal);
+    pushConstant(this.probeOffset + this.probeCount);
+    this.mv.visitInsn(ICONST_1);
+    this.mv.visitInsn(BASTORE);
+  }
+
+}

--- a/pitest/src/test/java/com/example/coverage/execute/samples/simple/AnInterface.java
+++ b/pitest/src/test/java/com/example/coverage/execute/samples/simple/AnInterface.java
@@ -1,0 +1,4 @@
+package com.example.coverage.execute.samples.simple;
+
+public interface AnInterface {
+}

--- a/pitest/src/test/java/com/example/coverage/execute/samples/simple/EmptyClass.java
+++ b/pitest/src/test/java/com/example/coverage/execute/samples/simple/EmptyClass.java
@@ -1,0 +1,4 @@
+package com.example.coverage.execute.samples.simple;
+
+public class EmptyClass {
+}

--- a/pitest/src/test/java/com/example/coverage/execute/samples/simple/EmptyClassWithParent.java
+++ b/pitest/src/test/java/com/example/coverage/execute/samples/simple/EmptyClassWithParent.java
@@ -1,0 +1,4 @@
+package com.example.coverage.execute.samples.simple;
+
+public class EmptyClassWithParent extends EmptyClass {
+}


### PR DESCRIPTION
For the simple case of classes that have no parent the probe fields can
be made final. This reduces the scope for problems when interacting with
libraries that use reflection without checking the synthetic flag for
fields.