### PR TITLE
Add pitest-aggregate api for aggragating XML report

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -27,6 +27,7 @@ import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.MutationResultListener;
 import org.pitest.mutationtest.SourceLocator;
 import org.pitest.mutationtest.report.html.MutationHtmlReportListener;
+import org.pitest.mutationtest.report.xml.XMLReportListener;
 import org.pitest.mutationtest.tooling.SmartSourceLocator;
 import org.pitest.util.Log;
 import org.pitest.util.ResultOutputStrategy;
@@ -53,6 +54,23 @@ public final class ReportAggregator {
 
     final MutationResultListener mutationResultListener = createResultListener(mutationMetaData);
 
+    aggregateReport(mutationMetaData, mutationResultListener);
+  }
+
+  public void aggregateXmlReport(boolean fullMutationMatrix) throws ReportAggregationException {
+    final MutationMetaData mutationMetaData =
+        new MutationMetaData(new ArrayList<>(this.mutationLoader.loadData()));
+
+    final MutationResultListener mutationResultListener =
+        new XMLReportListener(this.resultOutputStrategy, fullMutationMatrix);
+
+    aggregateReport(mutationMetaData, mutationResultListener);
+  }
+
+  private void aggregateReport(
+      MutationMetaData mutationMetaData,
+      MutationResultListener mutationResultListener
+  ) {
     mutationResultListener.runStart();
 
     for (final ClassMutationResults mutationResults : mutationMetaData.toClassResults()) {

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -63,6 +63,7 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
           .build();
 
       reportAggregator.aggregateReport();
+      reportAggregator.aggregateXmlReport(false);
     } catch (final Exception e) {
       throw new MavenReportException(e.getMessage(), e);
     }


### PR DESCRIPTION
### Change Background
I have a multi-module project and was wanted to create an aggregated XML report of all my module for sonar. I have chosen to not set this project up using submodule in sonar due to various reasons and as such I need a single mutation report. I notice that the report aggregator only does aggregated HTML report at the moment. While aggregating the XML reports could simply be done b reading these reports in as xml objects, combining them and rewriting them, I feel like doing this using the Listeners would produce a more consistent format with what pitest is producing.

### Change Content
Simple change based off the original function to aggregate HTML, but using the XMLReportListener instead of the MutationHtmlReportListener.