### PR TITLE
do not create history store when not required

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -25,7 +25,6 @@ import org.pitest.help.Help;
 import org.pitest.help.PitHelpError;
 import org.pitest.mutationtest.build.PercentAndConstantTimeoutStrategy;
 import org.pitest.mutationtest.incremental.FileWriterFactory;
-import org.pitest.mutationtest.incremental.NullWriterFactory;
 import org.pitest.mutationtest.incremental.WriterFactory;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.execute.Pitest;
@@ -469,12 +468,12 @@ public class ReportOptions {
     this.detectInlinedCode = b;
   }
 
-  public WriterFactory createHistoryWriter() {
+  public Optional<WriterFactory> createHistoryWriter() {
     if (this.historyOutputLocation == null) {
-      return new NullWriterFactory();
+      return Optional.empty();
     }
 
-    return new FileWriterFactory(this.historyOutputLocation);
+    return Optional.of(new FileWriterFactory(this.historyOutputLocation));
   }
 
   public Optional<Reader> createHistoryReader() {


### PR DESCRIPTION
At some point the performance of the history store has regressed substantially. This performance hit is being taken even when the history store is not in use. This change ensures a no-op history store is used unless history recording is requested.

Performance regression will be addressed seperately.