### PR TITLE
allow multiple test engines

### DIFF
--- a/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
@@ -14,6 +14,7 @@ import com.example.coverage.execute.samples.simple.TesteeWithComplexConstructors
 import com.example.coverage.execute.samples.simple.TesteeWithMultipleLines;
 import com.example.coverage.execute.samples.simple.Tests;
 import com.example.coverage.execute.samples.simple.TestsForMultiBlockCoverage;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pitest.SystemTest;
@@ -285,6 +286,7 @@ public class CoverageProcessSystemTest {
   }
 
   @Test
+  @Ignore("we have testng on the classpath")
   public void shouldFailWithExitCode() throws Exception {
     final Consumer<CoverageResult> noOpHandler = a -> {
     };

--- a/pitest/src/main/java/org/pitest/junit/JUnitCompatibleConfiguration.java
+++ b/pitest/src/main/java/org/pitest/junit/JUnitCompatibleConfiguration.java
@@ -44,6 +44,12 @@ public class JUnitCompatibleConfiguration implements Configuration {
   }
 
   @Override
+  public int priority() {
+    // make sure we are used after any test plugins added to the classpath
+    return DEFAULT_PRIORITY + 1;
+  }
+
+  @Override
   public TestUnitFinder testUnitFinder() {
     return new CompoundTestUnitFinder(Arrays.asList(
         new JUnitCustomRunnerTestUnitFinder(this.config, this.excludedRunners, this.includedTestMethods),

--- a/pitest/src/main/java/org/pitest/mutationtest/config/MinionSettings.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/MinionSettings.java
@@ -3,8 +3,10 @@ package org.pitest.mutationtest.config;
 import org.pitest.classinfo.ClassByteArraySource;
 import org.pitest.mutationtest.MutationEngineFactory;
 import org.pitest.testapi.Configuration;
-import org.pitest.testapi.TestPluginFactory;
 import org.pitest.util.PitError;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MinionSettings {
 
@@ -26,16 +28,15 @@ public class MinionSettings {
 
 
   public Configuration getTestFrameworkPlugin(TestPluginArguments options, ClassByteArraySource source) {
-    for (final TestPluginFactory each : this.plugins.findTestFrameworkPlugins()) {
-      if (each.name().equals(options.getTestPlugin())) {
-        return each.createTestFrameworkConfiguration(options.getGroupConfig(),
-            source,
-            options.getExcludedRunners(),
-            options.getIncludedTestMethods());
-      }
-    }
-    throw new PitError("Could not load requested test plugin "
-        + options.getTestPlugin());
+    List<Configuration> configurations = this.plugins.findTestFrameworkPlugins().stream()
+            .map(p -> p.createTestFrameworkConfiguration(options.getGroupConfig(),
+                    source,
+                    options.getExcludedRunners(),
+                    options.getIncludedTestMethods()))
+            .collect(Collectors.toList());
+
+    return new PrioritisingTestConfiguration(configurations);
+
   }
 
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestConfiguration.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestConfiguration.java
@@ -1,0 +1,71 @@
+package org.pitest.mutationtest.config;
+
+import org.pitest.help.PitHelpError;
+import org.pitest.testapi.Configuration;
+import org.pitest.testapi.TestSuiteFinder;
+import org.pitest.testapi.TestUnitFinder;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class PrioritisingTestConfiguration implements Configuration {
+    private final List<Configuration> children;
+    private final TestUnitFinder finder;
+    private final TestSuiteFinder suiteFinder;
+
+    PrioritisingTestConfiguration(List<Configuration> children) {
+        this.children = pickChildren(children);
+        this.finder = makeFinder(this.children);
+        this.suiteFinder = makeSuiteFinder(this.children);
+    }
+
+    @Override
+    public TestUnitFinder testUnitFinder() {
+        return finder;
+    }
+
+    @Override
+    public TestSuiteFinder testSuiteFinder() {
+        return suiteFinder;
+    }
+
+    @Override
+    public Optional<PitHelpError> verifyEnvironment() {
+        return children.stream()
+                .map(Configuration::verifyEnvironment)
+                .findFirst()
+                .get();
+    }
+
+    private static List<Configuration> pickChildren(List<Configuration> configs) {
+        List<Configuration> working = configs.stream()
+                .filter(c -> !c.verifyEnvironment().isPresent())
+                .sorted(byPriority())
+                .collect(Collectors.toList());
+        // We don't have a working config, let it report errors later
+        if (working.isEmpty()) {
+            return configs;
+        }
+        return working;
+    }
+
+    private static Comparator<Configuration> byPriority() {
+        return Comparator.comparingInt(Configuration::priority);
+    }
+
+    private TestUnitFinder makeFinder(List<Configuration> children) {
+        List<TestUnitFinder> finders = children.stream()
+                .map(Configuration::testUnitFinder)
+                .collect(Collectors.toList());
+        return new PrioritisingTestUnitFinder(finders);
+    }
+
+    private TestSuiteFinder makeSuiteFinder(List<Configuration> children) {
+        List<TestSuiteFinder> finders = children.stream()
+                .map(Configuration::testSuiteFinder)
+                .collect(Collectors.toList());
+        return new PrioritisingTestSuiteFinder(finders);
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestSuiteFinder.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestSuiteFinder.java
@@ -1,0 +1,25 @@
+package org.pitest.mutationtest.config;
+
+import org.pitest.testapi.TestSuiteFinder;
+
+import java.util.Collections;
+import java.util.List;
+
+class PrioritisingTestSuiteFinder implements TestSuiteFinder {
+    private final List<TestSuiteFinder> orderedChildren;
+
+    PrioritisingTestSuiteFinder(List<TestSuiteFinder> orderedChildren) {
+        this.orderedChildren = orderedChildren;
+    }
+
+    @Override
+    public List<Class<?>> apply(Class<?> clazz) {
+        for (TestSuiteFinder each : orderedChildren) {
+            List<Class<?>> found = each.apply(clazz);
+            if (!found.isEmpty()) {
+                return found;
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestUnitFinder.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/PrioritisingTestUnitFinder.java
@@ -1,0 +1,26 @@
+package org.pitest.mutationtest.config;
+
+import org.pitest.testapi.TestUnit;
+import org.pitest.testapi.TestUnitFinder;
+
+import java.util.Collections;
+import java.util.List;
+
+class PrioritisingTestUnitFinder implements TestUnitFinder {
+    private final List<TestUnitFinder> orderedChildren;
+
+    PrioritisingTestUnitFinder(List<TestUnitFinder> orderedChildren) {
+        this.orderedChildren = orderedChildren;
+    }
+
+    @Override
+    public List<TestUnit> findTestUnits(Class<?> clazz) {
+       for (TestUnitFinder each : orderedChildren) {
+           List<TestUnit> found = each.findTestUnits(clazz);
+           if (!found.isEmpty()) {
+               return found;
+           }
+       }
+       return Collections.emptyList();
+    }
+}

--- a/pitest/src/main/java/org/pitest/testapi/Configuration.java
+++ b/pitest/src/main/java/org/pitest/testapi/Configuration.java
@@ -20,6 +20,12 @@ import org.pitest.help.PitHelpError;
 
 public interface Configuration {
 
+  int DEFAULT_PRIORITY = 10;
+
+  default int priority() {
+    return DEFAULT_PRIORITY;
+  }
+
   TestUnitFinder testUnitFinder();
 
   TestSuiteFinder testSuiteFinder();

--- a/pitest/src/main/java/org/pitest/testng/TestNGConfiguration.java
+++ b/pitest/src/main/java/org/pitest/testng/TestNGConfiguration.java
@@ -18,6 +18,8 @@ import java.util.Collection;
 
 import org.pitest.extension.common.NoTestSuiteFinder;
 import java.util.Optional;
+
+import org.pitest.help.Help;
 import org.pitest.help.PitHelpError;
 import org.pitest.testapi.Configuration;
 import org.pitest.testapi.TestGroupConfig;
@@ -46,6 +48,12 @@ public class TestNGConfiguration implements Configuration {
 
   @Override
   public Optional<PitHelpError> verifyEnvironment() {
+    try {
+      Class.forName("org.testng.annotations.Test");
+    } catch (NoClassDefFoundError | ClassNotFoundException er) {
+      return Optional.ofNullable(new PitHelpError(Help.NO_TEST_LIBRARY));
+    }
+
     return Optional.empty();
   }
 

--- a/pitest/src/test/java/org/pitest/mutationtest/config/PrioritisingTestConfigurationTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/config/PrioritisingTestConfigurationTest.java
@@ -1,0 +1,172 @@
+package org.pitest.mutationtest.config;
+
+import org.junit.Test;
+import org.pitest.help.Help;
+import org.pitest.help.PitHelpError;
+import org.pitest.testapi.Configuration;
+import org.pitest.testapi.Description;
+import org.pitest.testapi.ResultCollector;
+import org.pitest.testapi.TestSuiteFinder;
+import org.pitest.testapi.TestUnit;
+import org.pitest.testapi.TestUnitFinder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrioritisingTestConfigurationTest {
+
+    TestUnit findMe = fakeUnit("a");
+    TestUnit dontFindMe = fakeUnit("b");
+    private Class<?> dontFindThisClass = String.class;
+    private Class<?> findThisClass = Integer.class;
+
+    @Test
+    public void findsNoTestsWhenNothingMatchesChildConfiguration() {
+        Configuration findsNothing = configuration(1, emptyList());
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(findsNothing));
+        List<TestUnit> actual = testee.testUnitFinder().findTestUnits(String.class);
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    public void highestPriorityConfigurationFindsTest() {
+        Configuration c0 = configuration(2, dontFindMe);
+        Configuration c1 = configuration(1, findMe);
+        Configuration c2 = configuration(2, dontFindMe);
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(c0, c1, c2));
+
+        List<TestUnit> actual = testee.testUnitFinder().findTestUnits(String.class);
+
+        assertThat(actual).containsOnly(findMe);
+    }
+
+    @Test
+    public void configurationsWithEnvironmentalErrorsNotUsed() {
+        Configuration c0 = configuration(1, asList(dontFindMe), new PitHelpError(Help.NO_JUNIT));
+        Configuration c1 = configuration(2, findMe);
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(c0, c1));
+
+        List<TestUnit> actual = testee.testUnitFinder().findTestUnits(String.class);
+
+        assertThat(actual).containsOnly(findMe);
+    }
+
+    @Test
+    public void allowsMixedTestTypes() {
+        Configuration findsNothing = configuration(1, emptyList());
+        Configuration c1 = configuration(2, findMe);
+        Configuration c2 = configuration(3, dontFindMe);
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(findsNothing, c1, c2));
+
+        List<TestUnit> actual = testee.testUnitFinder().findTestUnits(String.class);
+
+        assertThat(actual).containsOnly(findMe);
+    }
+
+
+    @Test
+    public void reportsNoErrorIfAtLeastOneConfigValid() {
+        Configuration c0 = configuration(1, asList(dontFindMe), new PitHelpError(Help.NO_JUNIT));
+        Configuration c1 = configuration(2, findMe);
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(c0, c1));
+
+        assertThat(testee.verifyEnvironment()).isEmpty();
+    }
+
+    @Test
+    public void reportsErrorWhenAllConfigsInValid() {
+        Configuration c0 = configuration(1, asList(dontFindMe), new PitHelpError(Help.NO_JUNIT));
+        Configuration c1 = configuration(2, asList(dontFindMe), new PitHelpError(Help.NO_JUNIT));
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(c0, c1));
+
+        assertThat(testee.verifyEnvironment()).isPresent();
+    }
+
+    @Test
+    public void highestPriorityConfigurationFindsSuites() {
+        Configuration c0 = suiteConfiguration(2, dontFindThisClass);
+        Configuration c1 = suiteConfiguration(1, findThisClass);
+        Configuration c2 = suiteConfiguration(2, dontFindThisClass);
+        PrioritisingTestConfiguration testee = new PrioritisingTestConfiguration(asList(c0, c1, c2));
+
+        List<Class<?>> actual = testee.testSuiteFinder().apply(String.class);
+
+        assertThat(actual).containsOnly(findThisClass);
+    }
+
+    private TestUnit fakeUnit(String name) {
+        return new TestUnit() {
+            @Override
+            public void execute(ResultCollector rc) {
+
+            }
+
+            @Override
+            public Description getDescription() {
+                return new Description(name);
+            }
+        };
+    }
+
+    private Configuration configuration(int priority, TestUnit testUnit) {
+        return configuration(priority, asList(testUnit), null);
+    }
+
+    private Configuration configuration(int priority, List<TestUnit> testUnit) {
+        return configuration(priority, testUnit, null);
+    }
+
+    private Configuration configuration(int priority, List<TestUnit> testUnits, PitHelpError error) {
+        return new Configuration() {
+
+            @Override
+            public int priority() {
+                return priority;
+            }
+
+            @Override
+            public TestUnitFinder testUnitFinder() {
+                return c -> testUnits;
+            }
+
+            @Override
+            public TestSuiteFinder testSuiteFinder() {
+                return null;
+            }
+
+            @Override
+            public Optional<PitHelpError> verifyEnvironment() {
+                return Optional.ofNullable(error);
+            }
+        };
+    }
+
+    private Configuration suiteConfiguration(int priority, Class<?> suiteClass) {
+        return new Configuration() {
+
+            @Override
+            public int priority() {
+                return priority;
+            }
+
+            @Override
+            public TestUnitFinder testUnitFinder() {
+                return c -> emptyList();
+            }
+
+            @Override
+            public TestSuiteFinder testSuiteFinder() {
+                return c -> asList(suiteClass);
+            }
+
+            @Override
+            public Optional<PitHelpError> verifyEnvironment() {
+                return Optional.empty();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Adds support for multiple pitest test plugins. Pitest will attempt to use any testengine placed on its classpath, trying them in order of precedence. A test plugin must either completely handle a test class, or not handle it at all.

This enables support for legacy projects that mix Junit and TestNG.

As a result of this change the 'testPlugin' parameter is now redundant, but has been retained for this release.