### PR TITLE
Use all plugin dependencies

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -32,8 +32,6 @@ public class AbstractPitMojo extends AbstractMojo {
 
   private final Predicate<MavenProject> notEmptyProject;
   
-  private final Predicate<Artifact>   filter;
-
   private final PluginServices        plugins;
 
   // Concrete List types declared for all fields to work around maven 2 bug
@@ -370,15 +368,13 @@ public class AbstractPitMojo extends AbstractMojo {
   private final GoalStrategy          goalStrategy;
 
   public AbstractPitMojo() {
-    this(new RunPitStrategy(), new DependencyFilter(new PluginServices(
-        AbstractPitMojo.class.getClassLoader())), new PluginServices(
+    this(new RunPitStrategy(), new PluginServices(
         AbstractPitMojo.class.getClassLoader()), new NonEmptyProjectCheck());
   }
 
-  public AbstractPitMojo(final GoalStrategy strategy, final Predicate<Artifact> filter,
-      final PluginServices plugins, final Predicate<MavenProject> emptyProjectCheck) {
+  public AbstractPitMojo(final GoalStrategy strategy, final PluginServices plugins,
+      final Predicate<MavenProject> emptyProjectCheck) {
     this.goalStrategy = strategy;
-    this.filter = filter;
     this.plugins = plugins;
     this.notEmptyProject = emptyProjectCheck;
   }
@@ -471,7 +467,7 @@ public class AbstractPitMojo extends AbstractMojo {
 
   protected Optional<CombinedStatistics> analyse() throws MojoExecutionException {
     final ReportOptions data = new MojoToReportOptionsConverter(this,
-        new SurefireConfigConverter(), this.filter).convert();
+        new SurefireConfigConverter()).convert();
     return Optional.ofNullable(this.goalStrategy.execute(detectBaseDir(), data,
         this.plugins, this.environmentVariables));
   }
@@ -484,10 +480,6 @@ public class AbstractPitMojo extends AbstractMojo {
       return null;
     }
     return executionProject.getBasedir();
-  }
-
-  protected Predicate<Artifact> getFilter() {
-    return filter;
   }
 
   protected GoalStrategy getGoalStrategy() {

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -42,15 +42,12 @@ import java.util.function.Predicate;
 public class MojoToReportOptionsConverter {
 
   private final AbstractPitMojo                 mojo;
-  private final Predicate<Artifact>     dependencyFilter;
   private final Log                     log;
   private final SurefireConfigConverter surefireConverter;
 
   public MojoToReportOptionsConverter(final AbstractPitMojo mojo,
-      SurefireConfigConverter surefireConverter,
-      Predicate<Artifact> dependencyFilter) {
+      SurefireConfigConverter surefireConverter) {
     this.mojo = mojo;
-    this.dependencyFilter = dependencyFilter;
     this.log = mojo.getLog();
     this.surefireConverter = surefireConverter;
   }
@@ -227,7 +224,7 @@ public class MojoToReportOptionsConverter {
   }
 
   private void addOwnDependenciesToClassPath(final List<String> classPath) {
-    for (final Artifact dependency : filteredDependencies()) {
+    for (final Artifact dependency : this.mojo.getPluginArtifactMap().values()) {
       this.log.info("Adding " + dependency.getGroupId() + ":"
           + dependency.getArtifactId() + " to SUT classpath");
       classPath.add(dependency.getFile().getAbsolutePath());
@@ -262,11 +259,6 @@ public class MojoToReportOptionsConverter {
     } else {
         return Collections.emptyList();
     }
-  }
-
-  private Collection<Artifact> filteredDependencies() {
-    return FCollection.filter(this.mojo.getPluginArtifactMap().values(),
-        this.dependencyFilter);
   }
 
   private Collection<String> determineMutators() {

--- a/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -97,9 +96,9 @@ public class ScmMojo extends AbstractPitMojo {
   private File            scmRootDir;
 
   public ScmMojo(final RunPitStrategy executionStrategy,
-                 final ScmManager manager, Predicate<Artifact> filter,
-                 PluginServices plugins, boolean analyseLastCommit, Predicate<MavenProject> nonEmptyProjectCheck) {
-    super(executionStrategy, filter, plugins, nonEmptyProjectCheck);
+                 final ScmManager manager, PluginServices plugins,
+                 boolean analyseLastCommit, Predicate<MavenProject> nonEmptyProjectCheck) {
+    super(executionStrategy, plugins, nonEmptyProjectCheck);
     this.manager = manager;
     this.analyseLastCommit = analyseLastCommit;
   }
@@ -126,7 +125,7 @@ public class ScmMojo extends AbstractPitMojo {
     logClassNames();
     defaultTargetTestsIfNoValueSet();
     final ReportOptions data = new MojoToReportOptionsConverter(this,
-        new SurefireConfigConverter(), getFilter()).convert();
+        new SurefireConfigConverter()).convert();
     data.setFailWhenNoMutations(false);
 
     return Optional.ofNullable(this.getGoalStrategy().execute(detectBaseDir(), data,

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -50,9 +50,6 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
   protected List<String>        classPath;
 
   @Mock
-  protected Predicate<Artifact> filter;
-
-  @Mock
   protected PluginServices      plugins;
 
   @Override
@@ -92,7 +89,7 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
   }
 
   protected AbstractPitMojo createPITMojo(final String config) throws Exception {
-    final AbstractPitMojo pitMojo = new AbstractPitMojo(this.executionStrategy, this.filter,
+    final AbstractPitMojo pitMojo = new AbstractPitMojo(this.executionStrategy,
         this.plugins, p -> true);
     configurePitMojo(pitMojo, config);
     return pitMojo;

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -417,12 +417,11 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     try {
       final String pom = createPomWithConfiguration(xml);
       final AbstractPitMojo mojo = createPITMojo(pom);
-      Predicate<Artifact> filter = Mockito.mock(Predicate.class);
       when(
           this.surefireConverter.update(any(ReportOptions.class),
               any(Xpp3Dom.class))).then(returnsFirstArg());
       this.testee = new MojoToReportOptionsConverter(mojo,
-          this.surefireConverter, filter);
+          this.surefireConverter);
       return this.testee.convert();
     } catch (final Exception ex) {
       throw Unchecked.translateCheckedException(ex);

--- a/pitest-maven/src/test/java/org/pitest/maven/ScmMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/ScmMojoTest.java
@@ -53,7 +53,7 @@ public class ScmMojoTest extends BasePitMojoTest {
   public void setUp() throws Exception {
     super.setUp();
     this.testee = new ScmMojo(this.executionStrategy, this.manager,
-        this.filter, this.plugins, false,  i -> true);
+        this.plugins, false,  i -> true);
     this.testee.setScmRootDir(new File("foo"));
     when(this.project.getBuild()).thenReturn(this.build);
     when(this.project.getParent()).thenReturn(null);


### PR DESCRIPTION
Solves #910 

Allows adding dependencies like JUnit-Jupiter-Engine to pitest-maven's dependencies without having to add them to the project test classpath.