### PR TITLE
Added the option to get all mutator IDs

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/config/Mutator.java
@@ -287,6 +287,10 @@ public final class Mutator {
     return fromStrings(MUTATORS.keySet());
   }
 
+  public static Collection<String> getAllMutatorIds() {
+    return MUTATORS.keySet();
+  }
+
   private static Collection<MethodMutatorFactory> stronger() {
     return combine(
         newDefaults(),


### PR DESCRIPTION
Fix for #916.

Would be extremely helpful for the PITclipse Plug-in. See [Issue 114 of PITclipse](https://github.com/pitest/pitclipse/issues/114)