### PR TITLE
Guarantee order of mutation operators

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/GregorMutater.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/GregorMutater.java
@@ -19,14 +19,14 @@ import static org.pitest.functional.prelude.Prelude.and;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -46,13 +46,13 @@ public class GregorMutater implements Mutater {
   private final Map<String, String>       computeCache   = new HashMap<>();
   private final Predicate<MethodInfo>     filter;
   private final ClassByteArraySource      byteSource;
-  private final Set<MethodMutatorFactory> mutators       = new HashSet<>();
+  private final List<MethodMutatorFactory> mutators;
 
   public GregorMutater(final ClassByteArraySource byteSource,
       final Predicate<MethodInfo> filter,
       final Collection<MethodMutatorFactory> mutators) {
     this.filter = filter;
-    this.mutators.addAll(mutators);
+    this.mutators = orderAndDeDuplicate(mutators);
     this.byteSource = byteSource;
   }
 
@@ -132,6 +132,15 @@ public class GregorMutater implements Mutater {
 
   private static Predicate<MethodInfo> isGeneratedEnumMethod() {
     return MethodInfo::isGeneratedEnumMethod;
+  }
+
+  private List<MethodMutatorFactory> orderAndDeDuplicate(Collection<MethodMutatorFactory> mutators) {
+    // deduplication is based on object identity, so dubious that this adds any value
+    // however left in place for now to replicate HashSet behaviour
+    return mutators.stream()
+            .distinct()
+            .sorted(Comparator.comparing(MethodMutatorFactory::getGloballyUniqueId))
+            .collect(Collectors.toList());
   }
 
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutatingClassVisitor.java
@@ -14,9 +14,7 @@
  */
 package org.pitest.mutationtest.engine.gregor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.objectweb.asm.ClassVisitor;
@@ -32,15 +30,15 @@ class MutatingClassVisitor extends ClassVisitor {
 
   private final Predicate<MethodInfo>    filter;
   private final ClassContext              context;
-  private final Set<MethodMutatorFactory> methodMutators = new HashSet<>();
+  private final List<MethodMutatorFactory> methodMutators;
 
   MutatingClassVisitor(final ClassVisitor delegateClassVisitor,
       final ClassContext context, final Predicate<MethodInfo> filter,
-      final Collection<MethodMutatorFactory> mutators) {
+      final List<MethodMutatorFactory> mutators) {
     super(ASMVersion.ASM_VERSION, delegateClassVisitor);
     this.context = context;
     this.filter = filter;
-    this.methodMutators.addAll(mutators);
+    this.methodMutators = mutators;
   }
 
   @Override


### PR DESCRIPTION
The order of iteration of a hashset is not guaranteed. It is unclear if
this has any observable consequences, but determinism is always
preferable, and aids debugging.

The order that operators applied is now explicitly based on the mutator
id. It is unclear if there is any benefit to the de-deplication
performed by the HashSet, but this has been retained.