### PR TITLE
Null flatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Read all about it at http://pitest.org
 
 ### current snapshot
 
+* #922 Filter equivalent stream.empty mutants in flatMap calls
 * #919 Filter junk mutations in java records
 
 ### 1.6.8

--- a/pitest-entry/src/main/java/org/pitest/bytecode/analysis/MethodTree.java
+++ b/pitest-entry/src/main/java/org/pitest/bytecode/analysis/MethodTree.java
@@ -59,6 +59,14 @@ public class MethodTree {
     return (this.rawNode.access & Opcodes.ACC_SYNTHETIC) != 0;
   }
 
+  public boolean isPrivate() {
+    return (this.rawNode.access & Opcodes.ACC_PRIVATE) != 0;
+  }
+
+  public boolean returns(ClassName clazz) {
+    return this.rawNode.desc.endsWith("L" + clazz.asInternalName() + ";");
+  }
+
   public List<AnnotationNode> annotations() {
     final List<AnnotationNode> annotaions = new ArrayList<>();
     if (this.rawNode.invisibleAnnotations != null) {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
@@ -1,6 +1,7 @@
 package org.pitest.mutationtest.build.intercept.equivalent;
 
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.pitest.bytecode.analysis.ClassTree;
 import org.pitest.bytecode.analysis.MethodTree;
 import org.pitest.classinfo.ClassName;
@@ -8,12 +9,39 @@ import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.MutationInterceptor;
 import org.pitest.mutationtest.engine.Mutater;
 import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator;
+import org.pitest.sequence.Context;
+import org.pitest.sequence.QueryParams;
+import org.pitest.sequence.QueryStart;
+import org.pitest.sequence.SequenceMatcher;
+import org.pitest.sequence.Slot;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.pitest.bytecode.analysis.InstructionMatchers.anyInstruction;
+import static org.pitest.bytecode.analysis.InstructionMatchers.isInstruction;
+import static org.pitest.bytecode.analysis.InstructionMatchers.methodCallTo;
+import static org.pitest.bytecode.analysis.InstructionMatchers.notAnInstruction;
+import static org.pitest.bytecode.analysis.InstructionMatchers.opCode;
+
 public class NullFlatMapFilter implements MutationInterceptor {
+
+    private static final boolean DEBUG = false;
+    private static final Slot<AbstractInsnNode> MUTATED_INSTRUCTION = Slot.create(AbstractInsnNode.class);
+
+    static final SequenceMatcher<AbstractInsnNode> RETURN_EMPTY_STREAM = QueryStart
+            .any(AbstractInsnNode.class)
+            .then(methodCallTo(ClassName.fromClass(Stream.class), "empty"))
+            .then(opCode(Opcodes.ARETURN).and(isInstruction(MUTATED_INSTRUCTION.read())))
+            .zeroOrMore(QueryStart.match(anyInstruction()))
+            .compile(QueryParams.params(AbstractInsnNode.class)
+                    .withIgnores(notAnInstruction())
+                    .withDebug(DEBUG)
+            );
+
+
     private ClassTree currentClass;
 
     @Override
@@ -34,16 +62,18 @@ public class NullFlatMapFilter implements MutationInterceptor {
     }
 
     private boolean mutatesStreamEmpty(MutationDetails mutationDetails) {
-        MethodTree mutated = currentClass.method(mutationDetails.getId().getLocation()).get();
-        if (!mutated.isPrivate() || !mutated.returns(ClassName.fromClass(Stream.class))) {
+        if (!mutationDetails.getMutator().equals(NullReturnValsMutator.NULL_RETURN_VALUES.getGloballyUniqueId())) {
             return false;
         }
 
-        if (mutated.instruction(mutationDetails.getInstructionIndex()).getOpcode() != Opcodes.ARETURN) {
+        MethodTree method = currentClass.method(mutationDetails.getId().getLocation()).get();
+        if (!method.isPrivate() || !method.returns(ClassName.fromClass(Stream.class))) {
             return false;
         }
 
-        return true;
+        final Context<AbstractInsnNode> context = Context.start(method.instructions(), DEBUG);
+        context.store(MUTATED_INSTRUCTION.write(), method.instruction(mutationDetails.getInstructionIndex()));
+        return RETURN_EMPTY_STREAM.matches(method.instructions(), context);
     }
 
     @Override

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
@@ -1,26 +1,36 @@
 package org.pitest.mutationtest.build.intercept.equivalent;
 
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InvokeDynamicInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodInsnNode;
 import org.pitest.bytecode.analysis.ClassTree;
 import org.pitest.bytecode.analysis.MethodTree;
 import org.pitest.classinfo.ClassName;
 import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.MutationInterceptor;
+import org.pitest.mutationtest.engine.Location;
 import org.pitest.mutationtest.engine.Mutater;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator;
 import org.pitest.sequence.Context;
+import org.pitest.sequence.Match;
 import org.pitest.sequence.QueryParams;
 import org.pitest.sequence.QueryStart;
 import org.pitest.sequence.SequenceMatcher;
 import org.pitest.sequence.Slot;
+import org.pitest.sequence.SlotRead;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.pitest.bytecode.analysis.InstructionMatchers.anyInstruction;
+import static org.pitest.bytecode.analysis.InstructionMatchers.isA;
 import static org.pitest.bytecode.analysis.InstructionMatchers.isInstruction;
 import static org.pitest.bytecode.analysis.InstructionMatchers.methodCallTo;
 import static org.pitest.bytecode.analysis.InstructionMatchers.notAnInstruction;
@@ -30,7 +40,6 @@ public class NullFlatMapFilter implements MutationInterceptor {
 
     private static final boolean DEBUG = false;
     private static final Slot<AbstractInsnNode> MUTATED_INSTRUCTION = Slot.create(AbstractInsnNode.class);
-
     static final SequenceMatcher<AbstractInsnNode> RETURN_EMPTY_STREAM = QueryStart
             .any(AbstractInsnNode.class)
             .then(methodCallTo(ClassName.fromClass(Stream.class), "empty"))
@@ -41,6 +50,17 @@ public class NullFlatMapFilter implements MutationInterceptor {
                     .withDebug(DEBUG)
             );
 
+    private static final Slot<ClassName> METHOD_OWNER = Slot.create(ClassName.class);
+    private static final Slot<String> METHOD_DESC = Slot.create(String.class);
+    static final SequenceMatcher<AbstractInsnNode> HAS_FLAT_MAP_CALL = QueryStart
+            .any(AbstractInsnNode.class)
+            .then(dynamicCallTo(METHOD_OWNER.read(), METHOD_DESC.read()))
+            .then(methodCallTo(ClassName.fromClass(Stream.class), "flatMap"))
+            .zeroOrMore(QueryStart.match(anyInstruction()))
+            .compile(QueryParams.params(AbstractInsnNode.class)
+                    .withIgnores(notAnInstruction().or(isA(LabelNode.class)))
+                    .withDebug(DEBUG)
+            );
 
     private ClassTree currentClass;
 
@@ -73,7 +93,76 @@ public class NullFlatMapFilter implements MutationInterceptor {
 
         final Context<AbstractInsnNode> context = Context.start(method.instructions(), DEBUG);
         context.store(MUTATED_INSTRUCTION.write(), method.instruction(mutationDetails.getInstructionIndex()));
-        return RETURN_EMPTY_STREAM.matches(method.instructions(), context);
+        return RETURN_EMPTY_STREAM.matches(method.instructions(), context)
+                && calledOnlyFromFlatMap(mutationDetails.getId().getLocation());
+    }
+
+    private boolean calledOnlyFromFlatMap(Location location) {
+        MethodTree mutated = currentClass.method(location).get();
+
+        boolean flatMapCallFound = false;
+        for (MethodTree each : currentClass.methods()) {
+            if (callsTarget(mutated, each)) {
+                flatMapCallFound = isFlatMapCall(mutated, each);
+                if (!flatMapCallFound) {
+                    return false;
+                }
+            }
+        }
+
+        return flatMapCallFound;
+
+    }
+
+    private boolean callsTarget(MethodTree target, MethodTree method) {
+        return method.instructions().stream()
+                .anyMatch(callTo(target.asLocation().getClassName(), target.asLocation().getMethodName().name())
+                        .or(dynamicCallTo(target.asLocation().getClassName(), target.asLocation().getMethodName().name())));
+    }
+
+    private Predicate<AbstractInsnNode> callTo(ClassName className, String name) {
+        return n -> {
+            if (n instanceof MethodInsnNode) {
+                MethodInsnNode call = (MethodInsnNode) n;
+                return call.owner.equals(className.asInternalName()) && call.name.equals(name);
+            }
+            return false;
+        };
+    }
+
+    private boolean isFlatMapCall(MethodTree mutated, MethodTree each) {
+        final Context<AbstractInsnNode> context = Context.start(each.instructions(), DEBUG);
+        context.store(METHOD_OWNER.write(), mutated.asLocation().getClassName());
+        context.store(METHOD_DESC.write(), mutated.asLocation().getMethodName().name());
+        boolean hasFlatMapCall = HAS_FLAT_MAP_CALL.matches(each.instructions(), context);
+        return hasFlatMapCall;
+    }
+
+
+    private static Match<AbstractInsnNode> dynamicCallTo(SlotRead<ClassName> owner, SlotRead<String> desc) {
+        return (c, t) -> dynamicCallTo(c.retrieve(owner).get(), c.retrieve(desc).get()).test(t);
+    }
+
+    private static Predicate<AbstractInsnNode> dynamicCallTo(ClassName owner, String desc) {
+        return (t) -> {
+            if ( t instanceof InvokeDynamicInsnNode) {
+                InvokeDynamicInsnNode call = (InvokeDynamicInsnNode) t;
+                return Arrays.stream(call.bsmArgs)
+                        .anyMatch(isHandle(owner, desc));
+            }
+            return false;
+        };
+    }
+
+    private static Predicate<Object> isHandle(ClassName owner, String name) {
+        return o -> {
+            if (o instanceof Handle) {
+                Handle handle = (Handle) o;
+                return handle.getOwner().equals(owner.asInternalName()) &&
+                        handle.getName().equals(name);
+            }
+            return false;
+        };
     }
 
     @Override

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilter.java
@@ -1,0 +1,53 @@
+package org.pitest.mutationtest.build.intercept.equivalent;
+
+import org.objectweb.asm.Opcodes;
+import org.pitest.bytecode.analysis.ClassTree;
+import org.pitest.bytecode.analysis.MethodTree;
+import org.pitest.classinfo.ClassName;
+import org.pitest.mutationtest.build.InterceptorType;
+import org.pitest.mutationtest.build.MutationInterceptor;
+import org.pitest.mutationtest.engine.Mutater;
+import org.pitest.mutationtest.engine.MutationDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class NullFlatMapFilter implements MutationInterceptor {
+    private ClassTree currentClass;
+
+    @Override
+    public InterceptorType type() {
+        return InterceptorType.FILTER;
+    }
+
+    @Override
+    public void begin(ClassTree clazz) {
+        currentClass = clazz;
+    }
+
+    @Override
+    public Collection<MutationDetails> intercept(Collection<MutationDetails> mutations, Mutater unused) {
+        return mutations.stream()
+                .filter(m -> !this.mutatesStreamEmpty(m))
+                .collect(Collectors.toList());
+    }
+
+    private boolean mutatesStreamEmpty(MutationDetails mutationDetails) {
+        MethodTree mutated = currentClass.method(mutationDetails.getId().getLocation()).get();
+        if (!mutated.isPrivate() || !mutated.returns(ClassName.fromClass(Stream.class))) {
+            return false;
+        }
+
+        if (mutated.instruction(mutationDetails.getInstructionIndex()).getOpcode() != Opcodes.ARETURN) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void end() {
+        currentClass = null;
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilterFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilterFactory.java
@@ -1,0 +1,24 @@
+package org.pitest.mutationtest.build.intercept.equivalent;
+
+import org.pitest.mutationtest.build.InterceptorParameters;
+import org.pitest.mutationtest.build.MutationInterceptor;
+import org.pitest.mutationtest.build.MutationInterceptorFactory;
+import org.pitest.plugin.Feature;
+
+public class NullFlatMapFilterFactory implements MutationInterceptorFactory {
+
+    @Override
+    public MutationInterceptor createInterceptor(InterceptorParameters params) {
+        return new NullFlatMapFilter();
+    }
+
+    @Override
+    public Feature provides() {
+        return null;
+    }
+
+    @Override
+    public String description() {
+        return null;
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilterFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatMapFilterFactory.java
@@ -14,11 +14,13 @@ public class NullFlatMapFilterFactory implements MutationInterceptorFactory {
 
     @Override
     public Feature provides() {
-        return null;
+        return Feature.named("FNULLSTREAM")
+                .withOnByDefault(true)
+                .withDescription("Filters equivalent mutations where null is passed to flatmap in place of Stream.empty");
     }
 
     @Override
     public String description() {
-        return null;
+        return "Null stream flatmap filter";
     }
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ImplicitNullCheckFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ImplicitNullCheckFilter.java
@@ -14,7 +14,6 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.pitest.bytecode.analysis.ClassTree;
-import org.pitest.bytecode.analysis.MethodMatchers;
 import org.pitest.bytecode.analysis.MethodTree;
 import org.pitest.classinfo.ClassName;
 import org.pitest.functional.FCollection;
@@ -68,9 +67,7 @@ public class ImplicitNullCheckFilter implements MutationInterceptor {
   private Predicate<MutationDetails> isAnImplicitNullCheck() {
     return a -> {
       final int instruction = a.getInstructionIndex();
-      final MethodTree method = ImplicitNullCheckFilter.this.currentClass.methods().stream()
-          .filter(MethodMatchers.forLocation(a.getId().getLocation()))
-          .findFirst()
+      final MethodTree method = ImplicitNullCheckFilter.this.currentClass.method(a.getId().getLocation())
           .get();
 
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);

--- a/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.build.MutationInterceptorFactory
+++ b/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.build.MutationInterceptorFactory
@@ -18,5 +18,6 @@ org.pitest.mutationtest.build.intercept.kotlin.KotlinFilterFactory
 org.pitest.mutationtest.filter.LimitNumberOfMutationsPerClassFilterFactory
 org.pitest.mutationtest.build.intercept.equivalent.EqualsPerformanceShortcutFilterFactory
 org.pitest.mutationtest.build.intercept.equivalent.EquivalentReturnMutationFilter
+org.pitest.mutationtest.build.intercept.equivalent.NullFlatMapFilterFactory
 
 org.pitest.plugin.export.MutantExportFactory

--- a/pitest-entry/src/test/java/com/example/HasPrivateStreamMethodUsedOnlyInSingleFlatMap.java
+++ b/pitest-entry/src/test/java/com/example/HasPrivateStreamMethodUsedOnlyInSingleFlatMap.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class HasPrivateStreamMethodUsedOnlyInSingleFlatMap {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    private Stream<String> aStream(String l) {
+        return Stream.empty();
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/MutationDiscoveryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/MutationDiscoveryTest.java
@@ -1,5 +1,6 @@
 package org.pitest.mutationtest.build;
 
+import com.example.HasPrivateStreamMethodUsedOnlyInSingleFlatMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.pitest.classinfo.ClassByteArraySource;
@@ -209,6 +210,16 @@ public class MutationDiscoveryTest {
     this.data.setMutators(Collections.singletonList("PRIMITIVE_RETURNS"));
     final Collection<MutationDetails>  actual = findMutants(AlreadyReturnsConstZero.class);
     assertThat(actual).isEmpty();
+  }
+
+  @Test
+  public void filtersEquivalentNullStreamMutantsUsedInFlatMapCalls() {
+    final Collection<MutationDetails> actual = findMutants(HasPrivateStreamMethodUsedOnlyInSingleFlatMap.class);
+
+    this.data.setFeatures(Collections.singletonList("-FNULLSTREAM"));
+    final Collection<MutationDetails> actualWithoutFilter = findMutants(HasPrivateStreamMethodUsedOnlyInSingleFlatMap.class);
+
+    assertThat(actual.size()).isLessThan(actualWithoutFilter.size());
   }
 
   @Test

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.MutationInterceptor;
 import org.pitest.mutationtest.build.intercept.javafeatures.FilterTester;
+import org.pitest.mutationtest.engine.gregor.mutators.NullMutateEverything;
 import org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator;
 import org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator;
 
@@ -17,7 +18,7 @@ public class NullFlatmapTest {
     MutationInterceptor testee = new NullFlatMapFilterFactory().createInterceptor(null);
 
     FilterTester verifier = new FilterTester("", this.testee, NullReturnValsMutator.NULL_RETURN_VALUES,
-            VoidMethodCallMutator.VOID_METHOD_CALL_MUTATOR);
+            new NullMutateEverything());
 
     @Test
     public void declaresTypeAsFilter() {
@@ -25,8 +26,8 @@ public class NullFlatmapTest {
     }
 
     @Test
-    public void filtersNullReturnMutantWhenMethodUsedOnlyInFlatMap() {
-        verifier.assertFiltersNMutationFromClass(111, HasPrivateStreamMethodUsedOnlyInSingleFlatMap.class);
+    public void filtersNullReturnMutantWhenMethodUsedOnlyInFlatMap() { //
+        verifier.assertFiltersNMutationFromClass(1, HasPrivateStreamMethodUsedOnlyInSingleFlatMap.class);
     }
 
     @Test

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
@@ -1,0 +1,97 @@
+package org.pitest.mutationtest.build.intercept.equivalent;
+
+import org.junit.Test;
+import org.pitest.mutationtest.build.InterceptorType;
+import org.pitest.mutationtest.build.MutationInterceptor;
+import org.pitest.mutationtest.build.intercept.javafeatures.FilterTester;
+import org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator;
+import org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NullFlatmapTest {
+
+    MutationInterceptor testee = new NullFlatMapFilterFactory().createInterceptor(null);
+
+    FilterTester verifier = new FilterTester("", this.testee, NullReturnValsMutator.NULL_RETURN_VALUES,
+            VoidMethodCallMutator.VOID_METHOD_CALL_MUTATOR);
+
+    @Test
+    public void declaresTypeAsFilter() {
+        assertThat(this.testee.type()).isEqualTo(InterceptorType.FILTER);
+    }
+
+    @Test
+    public void filtersNullReturnMutantWhenMethodUsedOnlyInFlatMap() {
+        verifier.assertFiltersNMutationFromClass(111, HasPrivateStreamMethodUsedOnlyInSingleFlatMap.class);
+    }
+
+    @Test
+    public void doesNotFilterNullReturnsInPublicStreamMethods() {
+        verifier.assertFiltersNMutationFromClass(0, HasPublicStreamMethodUsedOnlyInSingleFlatMap.class);
+    }
+
+    @Test
+    public void doesNotFilterOtherMutantsInNullReturnsStreamMethods() {
+        verifier.assertFiltersNMutationFromClass(1, HasPrivateStreamMethodUsedOnlyInSingleFlatMapThatHasOtherMutableCode.class);
+    }
+
+    @Test
+    public void doesNotFilterNullReturnsWhenOriginalNotEmptyStream() {
+        verifier.assertFiltersNMutationFromClass(0, HasPrivateStreamMethodThatDoesNotReturnEmpty.class);
+    }
+
+}
+
+class HasPrivateStreamMethodUsedOnlyInSingleFlatMap {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    private Stream<String> aStream(String l) {
+        return Stream.empty();
+    }
+}
+
+class HasPrivateStreamMethodUsedOnlyInSingleFlatMapThatHasOtherMutableCode {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    private Stream<String> aStream(String l) {
+        System.out.println("Keep mutating me");
+        return Stream.empty();
+    }
+}
+
+class HasPrivateStreamMethodThatDoesNotReturnEmpty {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    private Stream<String> aStream(String l) {
+        return Stream.of("");
+    }
+}
+
+
+class HasPublicStreamMethodUsedOnlyInSingleFlatMap {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    public Stream<String> aStream(String l) {
+        return Stream.empty();
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
@@ -1,12 +1,12 @@
 package org.pitest.mutationtest.build.intercept.equivalent;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.MutationInterceptor;
 import org.pitest.mutationtest.build.intercept.javafeatures.FilterTester;
 import org.pitest.mutationtest.engine.gregor.mutators.NullMutateEverything;
 import org.pitest.mutationtest.engine.gregor.mutators.NullReturnValsMutator;
-import org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -45,6 +45,12 @@ public class NullFlatmapTest {
         verifier.assertFiltersNMutationFromClass(0, HasPrivateStreamMethodThatDoesNotReturnEmpty.class);
     }
 
+    @Test
+    @Ignore
+    public void doesNotFilterNullReturnsWhenNonFlatMapCallsExist() {
+        verifier.assertFiltersNMutationFromClass(0, HasPrivateStreamMethodCalledNotFromFlatMap.class);
+    }
+
 }
 
 class HasPrivateStreamMethodUsedOnlyInSingleFlatMap {
@@ -68,6 +74,23 @@ class HasPrivateStreamMethodUsedOnlyInSingleFlatMapThatHasOtherMutableCode {
 
     private Stream<String> aStream(String l) {
         System.out.println("Keep mutating me");
+        return Stream.empty();
+    }
+}
+
+class HasPrivateStreamMethodCalledNotFromFlatMap {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    public Stream<String> alsoMakesCall() {
+        return aStream("")
+                .map(s -> s + "boo");
+    }
+
+    private Stream<String> aStream(String l) {
         return Stream.empty();
     }
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
@@ -1,6 +1,5 @@
 package org.pitest.mutationtest.build.intercept.equivalent;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.MutationInterceptor;
@@ -46,7 +45,11 @@ public class NullFlatmapTest {
     }
 
     @Test
-    @Ignore
+    public void doesNotFilterNullReturnsWhenNoFlatMapCallsExist() {
+        verifier.assertFiltersNMutationFromClass(0, NotCalledFromFlatMap.class);
+    }
+
+    @Test
     public void doesNotFilterNullReturnsWhenNonFlatMapCallsExist() {
         verifier.assertFiltersNMutationFromClass(0, HasPrivateStreamMethodCalledNotFromFlatMap.class);
     }
@@ -74,6 +77,17 @@ class HasPrivateStreamMethodUsedOnlyInSingleFlatMapThatHasOtherMutableCode {
 
     private Stream<String> aStream(String l) {
         System.out.println("Keep mutating me");
+        return Stream.empty();
+    }
+}
+
+class NotCalledFromFlatMap {
+    public Stream<String> makesCall() {
+        return aStream("")
+                .map(s -> s + "boo");
+    }
+
+    private Stream<String> aStream(String l) {
         return Stream.empty();
     }
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/NullFlatmapTest.java
@@ -54,6 +54,10 @@ public class NullFlatmapTest {
         verifier.assertFiltersNMutationFromClass(0, HasPrivateStreamMethodCalledNotFromFlatMap.class);
     }
 
+    @Test
+    public void doesNotFilterEligibleMutantsInMethodsWithSameName() {
+        verifier.assertFiltersNMutationFromClass(1, HasMutableMethodWithSameNameButDifferentSignature.class);
+    }
 }
 
 class HasPrivateStreamMethodUsedOnlyInSingleFlatMap {
@@ -130,6 +134,29 @@ class HasPublicStreamMethodUsedOnlyInSingleFlatMap {
     }
 
     public Stream<String> aStream(String l) {
+        return Stream.empty();
+    }
+}
+
+class HasMutableMethodWithSameNameButDifferentSignature {
+    public Stream<String> makesCall(List<String> l) {
+        return l.stream()
+                .flatMap(this::aStream);
+
+    }
+
+    public Stream<Object> makesCall(List<Integer> l, int unused) {
+        return l.stream()
+                .map(this::aStream);
+
+    }
+
+    private Stream<String> aStream(String l) {
+        return Stream.empty();
+    }
+
+    // can mutate this one
+    private Stream<String> aStream(int i) {
         return Stream.empty();
     }
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/javafeatures/FilterTester.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/javafeatures/FilterTester.java
@@ -247,8 +247,14 @@ public class FilterTester {
     softly.assertThat(actual)
     .describedAs("Expected to filter out " + n + " mutants but filtered "
                   + (mutations.size() - actual.size()) + " for compiler " + s.compiler
-                  + " " + s.clazz)
+                  + " " + s.clazz + " [original mutants " + describe(mutations) + "]")
     .hasSize(mutations.size() - n);
+  }
+
+  private String describe(List<MutationDetails> mutations) {
+    return mutations.stream()
+            .map(m -> m.getMutator())
+            .collect(Collectors.joining(","));
   }
 
   private void checkHasNMutants(int n, Sample s, SoftAssertions softly,

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NullMutateEverything.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/mutators/NullMutateEverything.java
@@ -58,6 +58,7 @@ class MutateEveryThing extends MethodVisitor {
   @Override
   public void visitIincInsn(final int var, final int increment) {
     mutate("visitIincInsn");
+    super.visitIincInsn(var, increment);
   }
 
   @Override
@@ -65,71 +66,84 @@ class MutateEveryThing extends MethodVisitor {
     if (opcode != Opcodes.RETURN) {
       mutate("visitInsn", opcode);
     }
+    super.visitInsn(opcode);
   }
 
   @Override
   public void visitIntInsn(int opcode, int operand) {
     mutate("visitIntInsn", opcode);
+    super.visitIntInsn(opcode,operand);
   }
 
   @Override
   public void visitVarInsn(int opcode, int var) {
     mutate("visitVarInsn", opcode);
+    super.visitVarInsn(opcode,var);
   }
 
   @Override
   public void visitTypeInsn(int opcode, String type) {
     mutate("visitTypeInsn", opcode);
+    super.visitTypeInsn(opcode, type);
   }
 
   @Override
   public void visitFieldInsn(int opcode, String owner, String name,
       String desc) {
     mutate("visitFieldInsn", opcode);
+    super.visitFieldInsn(opcode, owner, name, desc);
   }
 
   @Override
   public void visitMethodInsn(int opcode, String owner, String name,
       String desc, boolean itf) {
     mutate("visitMethodInsn", opcode);
+    super.visitMethodInsn(opcode, owner, name, desc, itf);
   }
 
   @Override
   public void visitInvokeDynamicInsn(String name, String desc, Handle bsm,
       Object... bsmArgs) {
     mutate("visitInvokeDynamicInsn");
+    super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
   }
 
   @Override
   public void visitJumpInsn(int opcode, Label label) {
     mutate("visitJumpInsn", opcode);
+    super.visitJumpInsn(opcode, label);
   }
 
   @Override
   public void visitLdcInsn(Object cst) {
     mutate("visitLdcInsn");
+    super.visitLdcInsn(cst);
   }
 
   @Override
   public void visitTableSwitchInsn(int min, int max, Label dflt,
       Label... labels) {
     mutate("visitTableSwitchInsn");
+    super.visitTableSwitchInsn(min, max, dflt, labels);
   }
 
   @Override
   public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
     mutate("visitLookupSwitchInsn");
+    super.visitLookupSwitchInsn(dflt, keys, labels);
   }
 
   @Override
   public void visitMultiANewArrayInsn(String desc, int dims) {
     mutate("visitMultiANewArrayInsn");
+    super.visitMultiANewArrayInsn(desc, dims);
   }
 
   @Override
   public void visitTryCatchBlock(Label start, Label end, Label handler,
       String type) {
     mutate("visitTryCatchBlock");
+    super.visitTryCatchBlock(start, end, handler, type);
   }
 
   private void mutate(String string, int opcode) {


### PR DESCRIPTION
Flat map treats null and Stream.empty() equivalently, so when return `Stream.empty()` is mutated to `return null` the mutant survives.

This change filters out mutants of this type if

* the mutant is in a private method
* the method is only called via flatMap
