### PR TITLE
filter boxed return constant boolean mutant in try

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EquivalentReturnMutationFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EquivalentReturnMutationFilter.java
@@ -2,6 +2,7 @@ package org.pitest.mutationtest.build.intercept.equivalent;
 
 import static org.pitest.bytecode.analysis.InstructionMatchers.anyInstruction;
 import static org.pitest.bytecode.analysis.InstructionMatchers.getStatic;
+import static org.pitest.bytecode.analysis.InstructionMatchers.isA;
 import static org.pitest.bytecode.analysis.InstructionMatchers.isInstruction;
 import static org.pitest.bytecode.analysis.InstructionMatchers.methodCallNamed;
 import static org.pitest.bytecode.analysis.InstructionMatchers.notAnInstruction;
@@ -16,6 +17,7 @@ import java.util.function.Predicate;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.pitest.bytecode.analysis.ClassTree;
@@ -97,7 +99,7 @@ class HardCodedTrueEquivalentFilter implements MutationInterceptor {
           .then(isInstruction(MUTATED_INSTRUCTION.read()))
           .zeroOrMore(QueryStart.match(anyInstruction()))
           .compile(QueryParams.params(AbstractInsnNode.class)
-                  .withIgnores(notAnInstruction())
+                  .withIgnores(notAnInstruction().or(isA(LabelNode.class)))
           );
 
   private static final Set<String> MUTATOR_IDS = new HashSet<>();
@@ -216,7 +218,7 @@ class PrimitiveEquivalentFilter implements MutationInterceptor {
  */
 class EmptyReturnsFilter implements MutationInterceptor {
 
-    private static final Slot<AbstractInsnNode> MUTATED_INSTRUCTION = Slot.create(AbstractInsnNode.class);
+  private static final Slot<AbstractInsnNode> MUTATED_INSTRUCTION = Slot.create(AbstractInsnNode.class);
 
   static final SequenceQuery<AbstractInsnNode> CONSTANT_ZERO = QueryStart
           .match(isZeroConstant())
@@ -232,7 +234,7 @@ class EmptyReturnsFilter implements MutationInterceptor {
           .then(isInstruction(MUTATED_INSTRUCTION.read()))
           .zeroOrMore(QueryStart.match(anyInstruction()))
           .compile(QueryParams.params(AbstractInsnNode.class)
-                  .withIgnores(notAnInstruction())
+                  .withIgnores(notAnInstruction().or(isA(LabelNode.class)))
           );
 
 

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/EquivalentReturnMutationFilterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/equivalent/EquivalentReturnMutationFilterTest.java
@@ -74,6 +74,18 @@ public class EquivalentReturnMutationFilterTest {
   }
 
   @Test
+  public void filtersEquivalentBoxedTrueMutantsInTryCatch() {
+    this.verifier.assertFiltersMutationsFromMutator(TRUE_RETURNS.getGloballyUniqueId()
+            , ReturnsBoxedTrueInTryCatch.class);
+  }
+
+  @Test
+  public void filtersEquivalentBoxedFalseMutantsInTryCatch() {
+    this.verifier.assertFiltersMutationsFromMutator(FALSE_RETURNS.getGloballyUniqueId()
+            , ReturnsBoxedFalseInTryCatch.class);
+  }
+
+  @Test
   public void filtersEquivalentPrimitiveLongMutants() {
     this.verifier.assertFiltersNMutationFromClass(1, AlreadyReturnsLong0.class);
   }
@@ -209,6 +221,28 @@ class ReturnsTrueInTryCatch {
     try {
       Double.valueOf(s);
       return true;
+    } catch (NumberFormatException ex) {
+      return HideConstant.hide(false);
+    }
+  }
+}
+
+class ReturnsBoxedTrueInTryCatch {
+  public Boolean a(String s) {
+    try {
+      Double.valueOf(s);
+      return true;
+    } catch (NumberFormatException ex) {
+      return HideConstant.hide(false);
+    }
+  }
+}
+
+class ReturnsBoxedFalseInTryCatch {
+  public Boolean a(String s) {
+    try {
+      Double.valueOf(s);
+      return false;
     } catch (NumberFormatException ex) {
       return HideConstant.hide(false);
     }


### PR DESCRIPTION
Ignore label nodes introduced by try catch block when filtering boxed
return true and return false mutants.