### PR TITLE
reintroduce testPlugin parameter on command line

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -76,6 +76,7 @@ import static org.pitest.mutationtest.config.ConfigOption.SKIP_FAILING_TESTS;
 import static org.pitest.mutationtest.config.ConfigOption.SOURCE_DIR;
 import static org.pitest.mutationtest.config.ConfigOption.TARGET_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_FILTER;
+import static org.pitest.mutationtest.config.ConfigOption.TEST_PLUGIN;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_STRENGTH_THRESHOLD;
 import static org.pitest.mutationtest.config.ConfigOption.THREADS;
 import static org.pitest.mutationtest.config.ConfigOption.TIMEOUT_CONST;
@@ -133,6 +134,7 @@ public class OptionsParser {
   private final ArgumentAcceptingOptionSpec<Boolean> exportLineCoverageSpec;
   private final OptionSpec<String>                   javaExecutable;
   private final OptionSpec<KeyValuePair>             pluginPropertiesSpec;
+  private final OptionSpec<String>                   testPluginSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> includeLaunchClasspathSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> useClasspathJarSpec;
   
@@ -142,6 +144,12 @@ public class OptionsParser {
 
     this.parser = new OptionParser();
     this.parser.acceptsAll(Arrays.asList("h", "?"), "show help");
+
+    this.testPluginSpec = parserAccepts(TEST_PLUGIN)
+        .withRequiredArg()
+        .ofType(String.class)
+        .defaultsTo("junit")
+        .describedAs("this parameter is ignored and will be removed in a future release");
 
     this.reportDirSpec = parserAccepts(REPORT_DIR).withRequiredArg()
         .describedAs("directory to create report folder in").required();

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -21,6 +21,11 @@ import java.io.Serializable;
 public enum ConfigOption {
 
   /**
+   * Defunct parameter, to be removed once gradle plugin updated
+   */
+  TEST_PLUGIN("testPlugin"),
+
+  /**
    * The directory to write report sot
    */
   REPORT_DIR("reportDir"),


### PR DESCRIPTION
The gradle plugin seems to auto supply this parameter when not specified
by the user, resulting in an error.

Reintroducing for now, until gradle plugin is updated.