### PR TITLE
support passing project base

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -71,6 +71,7 @@ import static org.pitest.mutationtest.config.ConfigOption.MUTATION_THRESHOLD;
 import static org.pitest.mutationtest.config.ConfigOption.MUTATION_UNIT_SIZE;
 import static org.pitest.mutationtest.config.ConfigOption.OUTPUT_FORMATS;
 import static org.pitest.mutationtest.config.ConfigOption.PLUGIN_CONFIGURATION;
+import static org.pitest.mutationtest.config.ConfigOption.PROJECT_BASE;
 import static org.pitest.mutationtest.config.ConfigOption.REPORT_DIR;
 import static org.pitest.mutationtest.config.ConfigOption.SKIP_FAILING_TESTS;
 import static org.pitest.mutationtest.config.ConfigOption.SOURCE_DIR;
@@ -137,6 +138,7 @@ public class OptionsParser {
   private final OptionSpec<String>                   testPluginSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> includeLaunchClasspathSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> useClasspathJarSpec;
+  private final OptionSpec<File>                     projectBaseSpec;
   
   public OptionsParser(Predicate<String> dependencyFilter) {
 
@@ -365,6 +367,10 @@ public class OptionsParser {
     this.pluginPropertiesSpec = parserAccepts(PLUGIN_CONFIGURATION)
         .withRequiredArg().ofType(KeyValuePair.class)
         .describedAs("custom plugin properties");
+
+    this.projectBaseSpec = parserAccepts(PROJECT_BASE)
+            .withRequiredArg().ofType(File.class);
+
   }
 
   private OptionSpecBuilder parserAccepts(final ConfigOption option) {
@@ -452,6 +458,7 @@ public class OptionsParser {
 
     data.setIncludedTestMethods(this.includedTestMethodsSpec.values(userArgs));
     data.setJavaExecutable(this.javaExecutable.value(userArgs));
+    data.setProjectBase(this.projectBaseSpec.value(userArgs));
 
     if (userArgs.has("?")) {
       return new ParseResult(data, "See above for supported parameters.");

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -556,7 +556,14 @@ public class OptionsParserTest {
     final ReportOptions actual = parseAddingRequiredArgs("--fullMutationMatrix=true");
     assertTrue(actual.isFullMutationMatrix());
   }
-  
+
+  @Test
+  public void shouldParseProjectBase() {
+    final ReportOptions actual = parseAddingRequiredArgs(
+            "--projectBase", "foo");
+    assertEquals(new File("foo"), actual.getProjectBase());
+  }
+
   private String getNonCanonicalGregorEngineClassPath() {
     final String gregorEngineClassPath = GregorMutationEngine.class
         .getProtectionDomain().getCodeSource().getLocation().getFile();

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -230,7 +230,14 @@ public enum ConfigOption {
    * Allows very long classpaths that would otherwise exceed OS limits, but
    * may cause problems with some third party libraries.
    */
-  USE_CLASSPATH_JAR("useClasspathJar", false);
+  USE_CLASSPATH_JAR("useClasspathJar", false),
+
+  /**
+   * Base directory of a project. For a multi-module build this should
+   * be set to the directory that contains the top level build file. Usually
+   * this is the same directory as the source control root/
+   */
+  PROJECT_BASE("projectBase");
 
   private final String       text;
   private final Serializable defaultValue;

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -139,6 +139,8 @@ public class ReportOptions {
   
   private boolean                        useClasspathJar;
 
+  private File                           projectBase;
+
 
   public Verbosity getVerbosity() {
     return this.verbosity;
@@ -615,6 +617,14 @@ public class ReportOptions {
     this.useClasspathJar = useClasspathJar;
   }
 
+  public File getProjectBase() {
+    return projectBase;
+  }
+
+  public void setProjectBase(File projectBase) {
+    this.projectBase = projectBase;
+  }
+
   @Override
   public String toString() {
     return "ReportOptions [targetClasses=" + targetClasses
@@ -643,6 +653,5 @@ public class ReportOptions {
         + ", testPlugin=" + testPlugin + ", useClasspathJar=" + useClasspathJar
         + ", skipFailingTests=" + skipFailingTests + "]";
   }
-
 
 }


### PR DESCRIPTION
Although the parameter is currently unused, it would be useful in the
future to be able to identify the base dir of a project. For gradle
project this only seems to be possible from within the build script
itself.

This parameter is therefore being added without functionality so the
gradle plugin can be updated in advance.