### PR TITLE
fix tests to run on java 18

### DIFF
--- a/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/NakedReceiverMutatorTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/engine/gregor/mutators/experimental/NakedReceiverMutatorTest.java
@@ -56,14 +56,6 @@ public class NakedReceiverMutatorTest extends MutatorTestBase {
     assertNoMutants(HasStaticMethodCallWithSameType.class);
   }
 
-  @Test
-  public void willReplaceCallToMethodWithDifferentGenericTypeDueToTypeErasure()
-      throws Exception {
-    final Mutant mutant = getFirstMutant(CallsMethodsWithGenericTypes.class);
-    final Foo<String> receiver = new Foo<>("3");
-    assertMutantCallableReturns(new CallsMethodsWithGenericTypes(receiver),
-        mutant, receiver);
-  }
 
   @Test
   public void shouldRemoveDslMethods() throws Exception {
@@ -95,20 +87,6 @@ public class NakedReceiverMutatorTest extends MutatorTestBase {
     }
   }
 
-  private static class CallsMethodsWithGenericTypes
-      implements Callable<Foo<?>> {
-    private final Foo<String> myArg;
-
-    public CallsMethodsWithGenericTypes(Foo<String> myArg) {
-      this.myArg = myArg;
-    }
-
-    @Override
-    public Foo<?> call() {
-      return this.myArg.returnsFooInteger();
-    }
-  }
-
   static class HasStaticMethodCallWithSameType {
     public void call() {
       HasStaticMethodCallWithSameType.instance();
@@ -116,22 +94,6 @@ public class NakedReceiverMutatorTest extends MutatorTestBase {
 
     private static HasStaticMethodCallWithSameType instance() {
       return new HasStaticMethodCallWithSameType();
-    }
-  }
-
-  static class Foo<T> extends ArrayList<T> {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1L;
-
-    public Foo(T arg) {
-      super(singletonList(arg));
-    }
-
-    public Foo<Integer> returnsFooInteger() {
-      return new Foo<>(2);
     }
   }
 

--- a/pitest/src/test/java/org/pitest/verifier/mutants/IntMutantVerifier.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/IntMutantVerifier.java
@@ -1,0 +1,118 @@
+package org.pitest.verifier.mutants;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.TraceClassVisitor;
+import org.pitest.classpath.ClassPath;
+import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+import org.pitest.simpletest.ExcludedPrefixIsolationStrategy;
+import org.pitest.simpletest.Transformation;
+import org.pitest.simpletest.TransformingClassLoader;
+import org.pitest.util.Unchecked;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.IntSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verification based on instantiating mutated versions of a class.
+ * <p>
+ * Classes must implement java.util.IntFunction and provide a default
+ * constructor.
+ */
+public class IntMutantVerifier<B> extends MutatorVerifier {
+
+    private final GregorMutater engine;
+    private final Class<? extends IntFunction<B>> target;
+
+    public IntMutantVerifier(GregorMutater engine, Class<? extends IntFunction<B>> target, Predicate<MutationDetails> filter) {
+        super(engine, target, filter);
+        this.engine = engine;
+        this.target = target;
+    }
+
+    /**
+     * Suppliers allow consumable inputs (eg streams) can be reused
+     */
+    public void firstMutantShouldReturn(IntSupplier input, B expected) {
+        assertThat(runWithoutMutation(input.getAsInt()))
+                .describedAs("Expected unmutated code to return different value to mutated code")
+                .isNotEqualTo(expected);
+
+        List<MutationDetails> mutations = findMutations();
+        assertThat(mutateAndCall(input.getAsInt(), getFirstMutant(mutations)))
+                .isEqualTo(expected);
+    }
+
+    private B runWithoutMutation(int input) {
+        return this.runInClassLoader(target.getClassLoader(), input);
+    }
+
+    private B mutateAndCall(int input, Mutant mutant) {
+        ClassLoader loader = this.createClassLoader(mutant);
+        return this.runInClassLoader(loader, input);
+    }
+
+    private ClassLoader createClassLoader(Mutant mutant) {
+        return new TransformingClassLoader(new ClassPath(),
+                this.createTransformation(mutant),
+                new ExcludedPrefixIsolationStrategy(new String[0]),
+                Object.class.getClassLoader());
+    }
+
+    private Transformation createTransformation(Mutant mutant) {
+        return (name, bytes) -> name.equals(mutant.getDetails().getClassName().asJavaName()) ? mutant.getBytes() : bytes;
+    }
+
+    private B runInClassLoader(ClassLoader loader, int input) {
+        try {
+            Class<?> forLoader = loader.loadClass(target.getName());
+
+            Constructor c = forLoader.getDeclaredConstructor();
+            c.setAccessible(true);
+            IntFunction<B> instance = (IntFunction<B>) c.newInstance();
+            return instance.apply(input);
+        } catch (ReflectiveOperationException ex) {
+            throw Unchecked.translateCheckedException(ex);
+        }
+    }
+
+    protected Mutant getFirstMutant(final Collection<MutationDetails> actual) {
+        assertThat(actual)
+                .describedAs("Expecting at least one mutant to be generated")
+                .isNotEmpty();
+        final Mutant mutant = this.engine.getMutation(actual.iterator().next()
+                .getId());
+        verifyMutant(mutant);
+        return mutant;
+    }
+
+    private void verifyMutant(Mutant mutant) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        CheckClassAdapter.verify(new ClassReader(mutant.getBytes()), false, pw);
+        assertThat(sw.toString())
+                .describedAs("Mutant is not a valid class")
+                .isEmpty();
+    }
+
+    private String printMutant(Mutant mutant) {
+        ClassReader reader = new ClassReader(mutant.getBytes());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        reader.accept(new TraceClassVisitor(null, new ASMifier(), new PrintWriter(bos)), 8);
+        return bos.toString();
+    }
+}

--- a/pitest/src/test/java/org/pitest/verifier/mutants/LongMutantVerifier.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/LongMutantVerifier.java
@@ -1,0 +1,114 @@
+package org.pitest.verifier.mutants;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.TraceClassVisitor;
+import org.pitest.classpath.ClassPath;
+import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+import org.pitest.simpletest.ExcludedPrefixIsolationStrategy;
+import org.pitest.simpletest.Transformation;
+import org.pitest.simpletest.TransformingClassLoader;
+import org.pitest.util.Unchecked;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.IntSupplier;
+import java.util.function.LongFunction;
+import java.util.function.LongSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verification based on instantiating mutated versions of a class.
+ * <p>
+ * Classes must implement java.util.IntFunction and provide a default
+ * constructor.
+ */
+public class LongMutantVerifier<B> extends MutatorVerifier {
+
+    private final GregorMutater engine;
+    private final Class<? extends LongFunction<B>> target;
+
+    public LongMutantVerifier(GregorMutater engine, Class<? extends LongFunction<B>> target, Predicate<MutationDetails> filter) {
+        super(engine, target, filter);
+        this.engine = engine;
+        this.target = target;
+    }
+
+    /**
+     * Suppliers allow consumable inputs (eg streams) can be reused
+     */
+    public void firstMutantShouldReturn(LongSupplier input, B expected) {
+        assertThat(runWithoutMutation(input.getAsLong()))
+                .describedAs("Expected unmutated code to return different value to mutated code")
+                .isNotEqualTo(expected);
+
+        List<MutationDetails> mutations = findMutations();
+        assertThat(mutateAndCall(input.getAsLong(), getFirstMutant(mutations)))
+                .isEqualTo(expected);
+    }
+
+    private B runWithoutMutation(long input) {
+        return this.runInClassLoader(target.getClassLoader(), input);
+    }
+
+    private B mutateAndCall(long input, Mutant mutant) {
+        ClassLoader loader = this.createClassLoader(mutant);
+        return this.runInClassLoader(loader, input);
+    }
+
+    private ClassLoader createClassLoader(Mutant mutant) {
+        return new TransformingClassLoader(new ClassPath(),
+                this.createTransformation(mutant),
+                new ExcludedPrefixIsolationStrategy(new String[0]),
+                Object.class.getClassLoader());
+    }
+
+    private Transformation createTransformation(Mutant mutant) {
+        return (name, bytes) -> name.equals(mutant.getDetails().getClassName().asJavaName()) ? mutant.getBytes() : bytes;
+    }
+
+    private B runInClassLoader(ClassLoader loader, long input) {
+        try {
+            Class<?> forLoader = loader.loadClass(target.getName());
+
+            Constructor c = forLoader.getDeclaredConstructor();
+            c.setAccessible(true);
+            LongFunction<B> instance = (LongFunction<B>) c.newInstance();
+            return instance.apply(input);
+        } catch (ReflectiveOperationException ex) {
+            throw Unchecked.translateCheckedException(ex);
+        }
+    }
+
+    protected Mutant getFirstMutant(final Collection<MutationDetails> actual) {
+        assertThat(actual)
+                .describedAs("Expecting at least one mutant to be generated")
+                .isNotEmpty();
+        final Mutant mutant = this.engine.getMutation(actual.iterator().next()
+                .getId());
+        verifyMutant(mutant);
+        return mutant;
+    }
+
+    private void verifyMutant(Mutant mutant) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        CheckClassAdapter.verify(new ClassReader(mutant.getBytes()), false, pw);
+        assertThat(sw.toString())
+                .describedAs("Mutant is not a valid class")
+                .isEmpty();
+    }
+
+}

--- a/pitest/src/test/java/org/pitest/verifier/mutants/MutantVerifier.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/MutantVerifier.java
@@ -1,0 +1,119 @@
+package org.pitest.verifier.mutants;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.ASMifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+import org.objectweb.asm.util.TraceClassVisitor;
+import org.pitest.classpath.ClassPath;
+import org.pitest.mutationtest.engine.Mutant;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+import org.pitest.simpletest.ExcludedPrefixIsolationStrategy;
+import org.pitest.simpletest.Transformation;
+import org.pitest.simpletest.TransformingClassLoader;
+import org.pitest.util.Unchecked;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verification based on instantiating mutated versions of a class.
+ * <p>
+ * Classes must implement java.util.Function and provide a default
+ * constructor.
+ */
+public class MutantVerifier<A, B> extends MutatorVerifier {
+
+    private final GregorMutater engine;
+    private final Class<? extends Function<A, B>> target;
+
+    public MutantVerifier(GregorMutater engine, Class<? extends Function<A, B>> target, Predicate<MutationDetails> filter) {
+        super(engine, target, filter);
+        this.engine = engine;
+        this.target = target;
+    }
+
+    /**
+     * Suppliers allow consumable inputs (eg streams) can be reused
+     */
+    public void firstMutantShouldReturn(Supplier<A> input, B expected) {
+        assertThat(runWithoutMutation(input.get()))
+                .describedAs("Expected unmutated code to return different value to mutated code")
+                .isNotEqualTo(expected);
+
+        List<MutationDetails> mutations = findMutations();
+        assertThat(mutateAndCall(input.get(), getFirstMutant(mutations)))
+                .isEqualTo(expected);
+    }
+
+    private B runWithoutMutation(A input) {
+        return this.runInClassLoader(target.getClassLoader(), input);
+    }
+
+    private B mutateAndCall(A input, Mutant mutant) {
+        ClassLoader loader = this.createClassLoader(mutant);
+        return this.runInClassLoader(loader, input);
+    }
+
+    private ClassLoader createClassLoader(Mutant mutant) {
+        return new TransformingClassLoader(new ClassPath(),
+                this.createTransformation(mutant),
+                new ExcludedPrefixIsolationStrategy(new String[0]),
+                Object.class.getClassLoader());
+    }
+
+    private Transformation createTransformation(Mutant mutant) {
+        return (name, bytes) -> name.equals(mutant.getDetails().getClassName().asJavaName()) ? mutant.getBytes() : bytes;
+    }
+
+    private B runInClassLoader(ClassLoader loader, A input) {
+        try {
+            Class<?> forLoader = loader.loadClass(target.getName());
+
+            Constructor c = forLoader.getDeclaredConstructor();
+            c.setAccessible(true);
+            Function<A, B> instance = (Function<A, B>) c.newInstance();
+            return instance.apply(input);
+        } catch (ReflectiveOperationException ex) {
+            throw Unchecked.translateCheckedException(ex);
+        }
+    }
+
+    protected Mutant getFirstMutant(final Collection<MutationDetails> actual) {
+        assertThat(actual)
+                .describedAs("Expecting at least one mutant to be generated")
+                .isNotEmpty();
+        final Mutant mutant = this.engine.getMutation(actual.iterator().next()
+                .getId());
+        verifyMutant(mutant);
+        return mutant;
+    }
+
+    private void verifyMutant(Mutant mutant) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        CheckClassAdapter.verify(new ClassReader(mutant.getBytes()), false, pw);
+        assertThat(sw.toString())
+                .describedAs("Mutant is not a valid class")
+                .isEmpty();
+    }
+
+    private String printMutant(Mutant mutant) {
+        ClassReader reader = new ClassReader(mutant.getBytes());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        reader.accept(new TraceClassVisitor(null, new ASMifier(), new PrintWriter(bos)), 8);
+        return bos.toString();
+    }
+
+
+
+}

--- a/pitest/src/test/java/org/pitest/verifier/mutants/MutatorVerifier.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/MutatorVerifier.java
@@ -1,0 +1,51 @@
+package org.pitest.verifier.mutants;
+
+import org.pitest.classinfo.ClassName;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verification based on class type only
+ */
+public class MutatorVerifier {
+
+    private final GregorMutater engine;
+    private final Class<?> clazz;
+    private Predicate<MutationDetails> filter;
+
+    public MutatorVerifier(GregorMutater engine, Class<?> clazz, Predicate<MutationDetails> filter) {
+        this.engine = engine;
+        this.clazz = clazz;
+        this.filter = filter;
+    }
+
+    public void createsNMutants(int n) {
+        assertThat(findMutations()).hasSize(n);
+    }
+
+    public void noMutantsCreated() {
+        assertThat(findMutations()).isEmpty();
+    }
+
+    public void firstMutantIsDescribedAs(String expected) {
+        List<MutationDetails> mutants = findMutations();
+        assertThat(mutants)
+                .describedAs("No mutations created")
+                .isNotEmpty();
+        assertThat(findMutations().get(0).getDescription()).isEqualTo(expected);
+    }
+
+    List<MutationDetails> findMutations() {
+        return this.engine.findMutations(ClassName.fromClass(clazz)).stream()
+                .filter(filter)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/pitest/src/test/java/org/pitest/verifier/mutants/MutatorVerifierStart.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/MutatorVerifierStart.java
@@ -1,0 +1,62 @@
+package org.pitest.verifier.mutants;
+
+import org.pitest.classpath.ClassloaderByteArraySource;
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.gregor.GregorMutater;
+import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
+import java.util.function.Predicate;
+
+public class MutatorVerifierStart {
+
+    private final MethodMutatorFactory mmf;
+    private final Predicate<MethodInfo> filter;
+    private final Predicate<MutationDetails> mutantFilter;
+
+    public MutatorVerifierStart(MethodMutatorFactory mmf, Predicate<MethodInfo> filter, Predicate<MutationDetails> mutantFilter) {
+        this.mmf = mmf;
+        this.filter = filter;
+        this.mutantFilter = mutantFilter;
+    }
+
+    public static MutatorVerifierStart forMutator(MethodMutatorFactory m) {
+        return new MutatorVerifierStart(m, method -> true, mf -> true);
+    }
+
+    public MutatorVerifierStart mutatingOnly(Predicate<MethodInfo> filter) {
+        return new MutatorVerifierStart(mmf, filter, mutantFilter);
+    }
+
+    public MutatorVerifierStart consideringOnlyMutantsMatching(Predicate<MutationDetails> mutantFilter) {
+        return new MutatorVerifierStart(mmf, filter, mutantFilter);
+    }
+
+    public MutatorVerifier forClass(Class<?> clazz) {
+        GregorMutater engine = makeEngine();
+        return new MutatorVerifier(engine, clazz, mutantFilter);
+    }
+
+    public <A,B> MutantVerifier<A,B> forFunctionClass(Class<? extends Function<A,B>> clazz) {
+        GregorMutater engine = makeEngine();
+        return new MutantVerifier<A,B>(engine, clazz, mutantFilter);
+    }
+
+    public <B> IntMutantVerifier<B> forIntFunctionClass(Class<? extends IntFunction<B>> clazz) {
+        GregorMutater engine = makeEngine();
+        return new IntMutantVerifier<>(engine, clazz, mutantFilter);
+    }
+
+    public <B> LongMutantVerifier<B> forLongFunctionClass(Class<? extends LongFunction<B>> clazz) {
+        GregorMutater engine = makeEngine();
+        return new LongMutantVerifier<>(engine, clazz, mutantFilter);
+    }
+
+    private GregorMutater makeEngine() {
+        return new GregorMutater(ClassloaderByteArraySource.fromContext(), filter, Arrays.asList(new NullMutator(), mmf, new NullMutator()));
+    }
+}

--- a/pitest/src/test/java/org/pitest/verifier/mutants/NullMutator.java
+++ b/pitest/src/test/java/org/pitest/verifier/mutants/NullMutator.java
@@ -1,0 +1,29 @@
+package org.pitest.verifier.mutants;
+
+import org.objectweb.asm.MethodVisitor;
+import org.pitest.bytecode.ASMVersion;
+import org.pitest.mutationtest.engine.gregor.MethodInfo;
+import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
+import org.pitest.mutationtest.engine.gregor.MutationContext;
+
+/**
+ * Non mutating mutator. We add this to the verifier as a (not very robust) check
+ * that the mutators are providing a unique id. If they returned an empty string
+ * as their id this mutator might be picked up instead (depending on order).
+ */
+public class NullMutator implements MethodMutatorFactory {
+    @Override
+    public MethodVisitor create(MutationContext mutationContext, MethodInfo methodInfo, MethodVisitor methodVisitor) {
+        return new MethodVisitor(ASMVersion.ASM_VERSION) {};
+    }
+
+    @Override
+    public String getGloballyUniqueId() {
+        return "";
+    }
+
+    @Override
+    public String getName() {
+        return "";
+    }
+}


### PR DESCRIPTION
Introduces new mutant verifier approach, allow mutators to be tested
without serialising with xstream.