### PR TITLE
filter loops with small integer comparison constant

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
@@ -55,9 +55,7 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
   private Collection<MutationDetails> findTimeoutMutants(Location location,
       Collection<MutationDetails> mutations, Mutater m) {
 
-    final MethodTree method = this.currentClass.methods().stream()
-        .filter(forLocation(location))
-        .findFirst()
+    final MethodTree method = this.currentClass.method(location)
         .get();
 
     //  give up if our matcher thinks loop is already infinite

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
@@ -168,7 +168,7 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     this.data.setTargetClasses(asGlobs(CoveredByEasyMock.class));
     this.data.setTargetTests(predicateFor(com.example.EasyMockTest.class));
     createAndRun();
-    verifyResults(KILLED, KILLED, KILLED);
+    verifyResults(KILLED, KILLED);
   }
 
   @Test

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterTest.java
@@ -5,15 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.Test;
-import org.pitest.classinfo.ClassByteArraySource;
-import org.pitest.classpath.ClassloaderByteArraySource;
 import org.pitest.mutationtest.build.InterceptorType;
 import org.pitest.mutationtest.build.intercept.javafeatures.FilterTester;
 import org.pitest.mutationtest.engine.gregor.config.Mutator;
 import org.pitest.mutationtest.engine.gregor.mutators.IncrementsMutator;
 
 public class AvoidForLoopCounterTest {
-  ClassByteArraySource    source = ClassloaderByteArraySource.fromContext();
 
   AvoidForLoopCounterFilter testee = new AvoidForLoopCounterFilter();
   private static final String             PATH      = "forloops/{0}_{1}";
@@ -60,6 +57,33 @@ public class AvoidForLoopCounterTest {
   @Test
   public void shouldFilterIncrementsInArrayLoop() {
     this.verifier.assertFiltersNMutationFromSample(1, "HasArrayIteration");
+  }
+
+  @Test
+  public void shouldFilterLoopsWithLessThanClause() {
+    this.verifier.assertFiltersNMutationFromClass(1, LessThanLoop.class);
+  }
+
+  @Test
+  public void shouldFilterLoopsWithSmallConstant() {
+    this.verifier.assertFiltersNMutationFromClass(1, SmallConstantLoop.class);
+  }
+
+
+  static class LessThanLoop {
+    void foo() {
+      for (int i = 0; i < 10; i++) {
+        System.out.println("" + i);
+      }
+    }
+  }
+
+  static class SmallConstantLoop {
+    void foo() {
+      for (int i = 0; i < 2; i++) {
+        System.out.println("" + i);
+      }
+    }
   }
 
   static class IHaveNoLoops {

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopBaseTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopBaseTest.java
@@ -24,7 +24,7 @@ import org.pitest.util.ResourceFolderByteArraySource;
 
 public abstract class InfiniteLoopBaseTest {
 
-  ClassByteArraySource    source = ClassloaderByteArraySource.fromContext();
+  ClassByteArraySource source = ClassloaderByteArraySource.fromContext();
 
   abstract InfiniteLoopFilter testee();
 


### PR DESCRIPTION
Broadens analysis to avoid for loop counters. Previously loops comparing to small integers with specialised opcodes were not picked up.