### PR TITLE
Allow plus in file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Read all about it at http://pitest.org
 
 ### 1.8.1-SNAPSHOT
 
+* #705  - Allow + in file paths (thanks @ali-ghanbari)
+* #903  - Filter mutants in singleton constructors
 * #1025 - Rework String Switch filtering
 * #1027 - Rework assert filtering and remove legacy filter mechanism
-* #903  - Filter mutants in singleton constructors
 * #1030 - Filter enum switch junk mutations
 
 ### 1.8.0

--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -26,12 +26,14 @@ public class Glob implements Predicate<String> {
   private final Pattern regex;
 
   public Glob(final String glob) {
+    String rectifiedGlob;
     if (glob.startsWith("~")) {
-      this.regex = Pattern.compile(glob.substring(1));
+      rectifiedGlob = glob.substring(1);
     } else {
-      this.regex = Pattern.compile(convertGlobToRegex(glob)
-      );
+      rectifiedGlob = convertGlobToRegex(glob);
     }
+    rectifiedGlob = rectifiedGlob.replace("+", "\\+");
+    this.regex = Pattern.compile(rectifiedGlob);
   }
 
   public boolean matches(final CharSequence seq) {

--- a/pitest/src/test/java/org/pitest/util/GlobTest.java
+++ b/pitest/src/test/java/org/pitest/util/GlobTest.java
@@ -69,10 +69,17 @@ public class GlobTest {
   }
 
   @Test
-  public void shouldBeCaseSensitice() {
+  public void shouldBeCaseSensitive() {
     final Glob glob = new Glob("foo*bar*car");
     assertTrue(glob.matches("foo!!!bar!!!car"));
     assertFalse(glob.matches("foo!!!Bar!!!car"));
+  }
+
+  @Test
+  public void matchesStringsWithPlusSign() {
+    final Glob glob = new Glob("foo+bar+car");
+    assertTrue(glob.matches("foo+bar+car"));
+    assertFalse(glob.matches("foo-Bar-car"));
   }
 
 }


### PR DESCRIPTION
Fix by @ali-ghanbari with added test case. Allows file paths with +
symbols. There is still a larger issue here with the globs being
converted to regexs that needs to be resolved.