### PR TITLE
ensure pitest and jdk cannot be instrumented

### DIFF
--- a/pitest-entry/src/test/java/com/example/systemtest/EatsMemoryWhenMutated.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/EatsMemoryWhenMutated.java
@@ -1,0 +1,21 @@
+package com.example.systemtest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EatsMemoryWhenMutated {
+    public static int loop() throws InterruptedException {
+        int i = 1;
+        final List<String[]> vals = new ArrayList<>();
+        Thread.sleep(1500);
+        do {
+            i++;
+            vals.add(new String[9999999]);
+            vals.add(new String[9999999]);
+            vals.add(new String[9999999]);
+            vals.add(new String[9999999]);
+        } while (i < 1);
+        i++;
+        return i;
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/FailingTest.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/FailingTest.java
@@ -1,0 +1,12 @@
+package com.example.systemtest;
+
+import org.pitest.simpletest.TestAnnotationForTesting;
+
+import static org.junit.Assert.assertEquals;
+
+public class FailingTest {
+    @TestAnnotationForTesting
+    public void fail() {
+        assertEquals(1, 2);
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/InfiniteLoop.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/InfiniteLoop.java
@@ -1,0 +1,17 @@
+package com.example.systemtest;
+
+public class InfiniteLoop {
+    public static int loop() {
+        int i = 1;
+        do {
+            i++;
+            try {
+                Thread.sleep(1);
+            } catch (final InterruptedException e) {
+                e.printStackTrace();
+            }
+        } while (i < 1);
+        i++;
+        return i;
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/NoMutations.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/NoMutations.java
@@ -1,0 +1,5 @@
+package com.example.systemtest;
+
+public class NoMutations {
+
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/NoMutationsTest.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/NoMutationsTest.java
@@ -1,0 +1,10 @@
+package com.example.systemtest;
+
+import org.pitest.simpletest.TestAnnotationForTesting;
+
+public class NoMutationsTest {
+    @TestAnnotationForTesting
+    public void pass() {
+
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/NoTests.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/NoTests.java
@@ -1,0 +1,5 @@
+package com.example.systemtest;
+
+public class NoTests {
+
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/OneMutationFullTest.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/OneMutationFullTest.java
@@ -1,0 +1,12 @@
+package com.example.systemtest;
+
+import org.pitest.simpletest.TestAnnotationForTesting;
+
+import static org.junit.Assert.assertEquals;
+
+public class OneMutationFullTest {
+    @TestAnnotationForTesting
+    public void testReturnOne() {
+        assertEquals(1, OneMutationOnly.returnOne());
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/OneMutationFullTestWithSystemPropertyDependency.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/OneMutationFullTestWithSystemPropertyDependency.java
@@ -1,0 +1,14 @@
+package com.example.systemtest;
+
+import org.pitest.simpletest.TestAnnotationForTesting;
+
+import static org.junit.Assert.assertEquals;
+
+public class OneMutationFullTestWithSystemPropertyDependency {
+    @TestAnnotationForTesting
+    public void testReturnOne() {
+        if (System.getProperty("foo").equals("foo")) {
+            assertEquals(1, OneMutationOnly.returnOne());
+        }
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/OneMutationOnly.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/OneMutationOnly.java
@@ -1,0 +1,7 @@
+package com.example.systemtest;
+
+public class OneMutationOnly {
+    public static int returnOne() {
+        return 1;
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/OneMutationTest.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/OneMutationTest.java
@@ -1,0 +1,5 @@
+package com.example.systemtest;
+
+public class OneMutationTest {
+
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/ThreeMutations.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/ThreeMutations.java
@@ -1,0 +1,15 @@
+package com.example.systemtest;
+
+public class ThreeMutations {
+    public static int returnOne() {
+        return 1;
+    }
+
+    public static int returnTwo() {
+        return 2;
+    }
+
+    public static int returnThree() {
+        return 3;
+    }
+}

--- a/pitest-entry/src/test/java/com/example/systemtest/ThreeMutationsTwoMeaningfullTests.java
+++ b/pitest-entry/src/test/java/com/example/systemtest/ThreeMutationsTwoMeaningfullTests.java
@@ -1,0 +1,22 @@
+package com.example.systemtest;
+
+import org.pitest.simpletest.TestAnnotationForTesting;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThreeMutationsTwoMeaningfullTests {
+    @TestAnnotationForTesting
+    public void testReturnOne() {
+        assertEquals(1, ThreeMutations.returnOne());
+    }
+
+    @TestAnnotationForTesting
+    public void testReturnTwo() {
+        assertEquals(2, ThreeMutations.returnTwo());
+    }
+
+    @TestAnnotationForTesting
+    public void coverButDoNotTestReturnThree() {
+        ThreeMutations.returnThree();
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/execute/CoverageProcessSystemTest.java
@@ -62,7 +62,7 @@ public class CoverageProcessSystemTest {
   // check all the specialised implementations broadly work
   @Test
   public void shouldCalculateCoverageForSingleBlockMethods()
-      throws IOException, InterruptedException, ExecutionException {
+      throws IOException, InterruptedException {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TestsForMultiBlockCoverage.class);
     assertCoverage(coveredClasses, "test1", 1);
   }
@@ -74,8 +74,7 @@ public class CoverageProcessSystemTest {
   }
 
   @Test
-  public void shouldCalculateCoverageForConstructors() throws IOException,
-  InterruptedException, ExecutionException {
+  public void shouldCalculateCoverageForConstructors() throws Exception {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TesteeWithComplexConstructorsTest.class);
     assertTrue(coversBlock(coveredClasses, "testHigh", 0));
     assertTrue(coversBlock(coveredClasses, "testHigh", 1));
@@ -88,22 +87,19 @@ public class CoverageProcessSystemTest {
   }
 
   @Test
-  public void shouldCalculateCoverageFor4BlockMethods() throws IOException,
-  InterruptedException, ExecutionException {
+  public void shouldCalculateCoverageFor4BlockMethods() throws Exception {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TestsForMultiBlockCoverage.class);
     assertCoverage(coveredClasses, "test4", 2);
   }
 
   @Test
-  public void shouldCalculateCoverageFor5BlockMethods() throws IOException,
-  InterruptedException, ExecutionException {
+  public void shouldCalculateCoverageFor5BlockMethods() throws Exception {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TestsForMultiBlockCoverage.class);
     assertCoverage(coveredClasses, "test5", 2);
   }
 
   @Test
-  public void shouldCalculateCoverageForBlockMethods() throws IOException,
-  InterruptedException, ExecutionException {
+  public void shouldCalculateCoverageForBlockMethods() throws Exception {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TestsForMultiBlockCoverage.class);
     assertCoverage(coveredClasses, "test6", 2);
   }
@@ -171,7 +167,7 @@ public class CoverageProcessSystemTest {
 
   @Test
   public void shouldCalculateCoverageForAllRelevantClasses()
-      throws Exception{
+      throws Exception {
 
     final List<CoverageResult> coveredClasses = runCoverageForTest(Tests.class);
 
@@ -215,7 +211,7 @@ public class CoverageProcessSystemTest {
 
   @Test
   public void shouldCalculateCoverageForLargeMethodThatThrowsException()
-      throws IOException, InterruptedException {
+      throws Exception {
     final List<CoverageResult> coveredClasses = runCoverageForTest(TestThrowsExceptionFromLargeMethodTestee.class);
 
     final ClassName clazz = ClassName

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
@@ -23,7 +23,6 @@ import static org.pitest.mutationtest.DetectionStatus.NO_COVERAGE;
 import static org.pitest.mutationtest.DetectionStatus.SURVIVED;
 import static org.pitest.mutationtest.DetectionStatus.TIMED_OUT;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +31,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import com.example.systemtest.EatsMemoryWhenMutated;
+import com.example.systemtest.InfiniteLoop;
+import com.example.systemtest.NoMutations;
+import com.example.systemtest.NoMutationsTest;
+import com.example.systemtest.NoTests;
+import com.example.systemtest.OneMutationFullTest;
+import com.example.systemtest.OneMutationFullTestWithSystemPropertyDependency;
+import com.example.systemtest.OneMutationOnly;
+import com.example.systemtest.ThreeMutations;
+import com.example.systemtest.ThreeMutationsTwoMeaningfullTests;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -97,59 +106,11 @@ public class TestMutationTesting {
             .<MutationResultListener> singletonList(this.metaDataExtractor));
   }
 
-  public static class NoMutations {
-
-  }
-
-  public static class OneMutationOnly {
-    public static int returnOne() {
-      return 1;
-    }
-  }
-
-  public static class ThreeMutations {
-    public static int returnOne() {
-      return 1;
-    }
-
-    public static int returnTwo() {
-      return 2;
-    }
-
-    public static int returnThree() {
-      return 3;
-    }
-  }
-
-  public static class OneMutationFullTest {
-    @TestAnnotationForTesting
-    public void testReturnOne() {
-      assertEquals(1, OneMutationOnly.returnOne());
-    }
-  }
-
   @Test
   public void shouldKillAllCoveredMutations() {
     run(OneMutationOnly.class, OneMutationFullTest.class,
         "RETURN_VALS");
     verifyResults(KILLED);
-  }
-
-  public static class ThreeMutationsTwoMeaningfullTests {
-    @TestAnnotationForTesting
-    public void testReturnOne() {
-      assertEquals(1, ThreeMutations.returnOne());
-    }
-
-    @TestAnnotationForTesting
-    public void testReturnTwo() {
-      assertEquals(2, ThreeMutations.returnTwo());
-    }
-
-    @TestAnnotationForTesting
-    public void coverButDoNotTestReturnThree() {
-      ThreeMutations.returnThree();
-    }
   }
 
   @Test
@@ -159,54 +120,16 @@ public class TestMutationTesting {
     verifyResults(SURVIVED, KILLED, KILLED);
   }
 
-  public static class FailingTest {
-    @TestAnnotationForTesting
-    public void fail() {
-      assertEquals(1, 2);
-    }
-  }
-
-  public static class NoMutationsTest {
-    @TestAnnotationForTesting
-    public void pass() {
-
-    }
-  }
-
   @Test
   public void shouldReportNoResultsIfNoMutationsPossible() {
     run(NoMutations.class, NoMutationsTest.class, "RETURN_VALS");
     verifyResults();
   }
 
-  public static class NoTests {
-
-  }
-
   @Test
   public void shouldReportStatusOfNoCoverageWhenNoTestsAvailable() {
     run(ThreeMutations.class, NoTests.class, "RETURN_VALS");
     verifyResults(NO_COVERAGE, NO_COVERAGE, NO_COVERAGE);
-  }
-
-  public static class OneMutationTest {
-
-  }
-
-  public static class InfiniteLoop {
-    public static int loop() {
-      int i = 1;
-      do {
-        i++;
-        try {
-          Thread.sleep(1);
-        } catch (final InterruptedException e) {
-          e.printStackTrace();
-        }
-      } while (i < 1);
-      i++;
-      return i;
-    }
   }
 
   public static class InfiniteLoopTest {
@@ -221,15 +144,6 @@ public class TestMutationTesting {
     run(InfiniteLoop.class, InfiniteLoopTest.class,
         "INCREMENTS");
     verifyResults(KILLED, TIMED_OUT);
-  }
-
-  public static class OneMutationFullTestWithSystemPropertyDependency {
-    @TestAnnotationForTesting
-    public void testReturnOne() {
-      if (System.getProperty("foo").equals("foo")) {
-        assertEquals(1, OneMutationOnly.returnOne());
-      }
-    }
   }
 
   @Test
@@ -257,23 +171,6 @@ public class TestMutationTesting {
         "UNVIABLE_CLASS_MUTATOR");
     verifyResults(NON_VIABLE, NON_VIABLE);
 
-  }
-
-  public static class EatsMemoryWhenMutated {
-    public static int loop() throws InterruptedException {
-      int i = 1;
-      final List<String[]> vals = new ArrayList<>();
-      Thread.sleep(1500);
-      do {
-        i++;
-        vals.add(new String[9999999]);
-        vals.add(new String[9999999]);
-        vals.add(new String[9999999]);
-        vals.add(new String[9999999]);
-      } while (i < 1);
-      i++;
-      return i;
-    }
   }
 
   public static class EatsMemoryTest {

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/config/SettingsFactoryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/config/SettingsFactoryTest.java
@@ -91,9 +91,9 @@ public class SettingsFactoryTest {
   @Test
   public void shouldNotAllowUserToCalculateCoverageForCoreClasses() {
     this.options.setTargetClasses(Collections
-        .singleton("java/Integer"));
+        .singleton("java.Integer"));
     final CoverageOptions actual = this.testee.createCoverageOptions();
-    assertFalse(actual.getFilter().test("java/Integer"));
+    assertFalse(actual.getFilter().test("java.Integer"));
   }
 
   @Test

--- a/pitest/src/main/java/org/pitest/coverage/execute/CoverageOptions.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoverageOptions.java
@@ -67,12 +67,14 @@ public class CoverageOptions implements Serializable {
 
   private static Predicate<String> commonClasses() {
     return Prelude.or(
-        glob("java/*"),
-        glob("sun/*"),
-        glob("org/pitest/coverage/*"),
-        glob("org/pitest/reloc/*"),
-        glob("org/pitest/boot/*"));
+            glob("org.pitest.*"),
+            glob("java.*"),
+            glob("javax.*"),
+            glob("com.sun*"),
+            glob("org.junit*"),
+            glob("sun.*"));
   }
+
 
   private static Glob glob(String match) {
     return new Glob(match);

--- a/pitest/src/test/java/org/pitest/coverage/execute/CoverageOptionsTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/execute/CoverageOptionsTest.java
@@ -16,47 +16,47 @@ public class CoverageOptionsTest {
 
   @Test
   public void shouldIncludeTargettedClasses() {
-    this.testee = new CoverageOptions(Collections.singletonList("com/example/*"), Collections.<String>emptyList(), this.pitConfig, DEFAULT, 0);
+    this.testee = new CoverageOptions(Collections.singletonList("com.example.*"), Collections.<String>emptyList(), this.pitConfig, DEFAULT, 0);
 
-    assertThat(this.testee.getFilter().test("com/example/Foo")).isTrue();
+    assertThat(this.testee.getFilter().test("com.example.Foo")).isTrue();
   }
 
   @Test
   public void shouldExcludeExcludedClasses() {
-    this.testee = new CoverageOptions(Collections.singletonList("com/example/*"), Collections.singletonList("com/example/NotMe"), this.pitConfig, DEFAULT, 0);
+    this.testee = new CoverageOptions(Collections.singletonList("com.example.*"), Collections.singletonList("com.example.NotMe"), this.pitConfig, DEFAULT, 0);
 
-    assertThat(this.testee.getFilter().test("com/example/Foo")).isTrue();
-    assertThat(this.testee.getFilter().test("com/example/NotMe")).isFalse();
+    assertThat(this.testee.getFilter().test("com.example.Foo")).isTrue();
+    assertThat(this.testee.getFilter().test("com.example.NotMe")).isFalse();
   }
 
   @Test
   public void shouldNotCoverJDKClassesWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("java/lang/Integer")).isFalse();
+    assertThat(this.testee.getFilter().test("java.lang.Integer")).isFalse();
   }
 
   @Test
   public void shouldNotCoverSunClassesWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("sun/foo/Bar")).isFalse();
+    assertThat(this.testee.getFilter().test("sun.foo.Bar")).isFalse();
   }
 
   @Test
   public void shouldNotCoverJUnitWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("sun/foo/Bar")).isFalse();
+    assertThat(this.testee.getFilter().test("sun.foo.Bar")).isFalse();
   }
 
   @Test
   public void shouldNotCoverPitestBootWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("org/pitest/boot/HotSwapAgent")).isFalse();
+    assertThat(this.testee.getFilter().test("org.pitest.boot.HotSwapAgent")).isFalse();
   }
 
   @Test
   public void shouldNotCoverPitestCoverageWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("org/pitest/coverage/execute/Minion")).isFalse();
+    assertThat(this.testee.getFilter().test("org.pitest.coverage.execute.Minion")).isFalse();
   }
 
   @Test
   public void shouldNotCoverPitestRelocWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("org/pitest/reloc/Foo")).isFalse();
+    assertThat(this.testee.getFilter().test("org.pitest.reloc.Foo")).isFalse();
   }
 
 }


### PR DESCRIPTION
These checks would only come into play if the user sets an over wide
target glob, but were previously broken.