### PR TITLE
Support Maven Site Plugin 3.12.0+

### DIFF
--- a/pitest-maven-verification/pom.xml
+++ b/pitest-maven-verification/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
+			<version>3.8.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
@@ -107,4 +107,13 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-core</artifactId>
+				<version>3.8.6</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>

--- a/pitest-maven-verification/src/test/resources/pit-site-combined/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-combined/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-combined/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-combined/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-custom-config/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-custom-config/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-custom-config/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-custom-config/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-multiple-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-multiple-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-multiple-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-multiple-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-non-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-non-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-non-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-non-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
@@ -20,7 +20,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-reportonly/pom.xml
@@ -20,7 +20,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-skip/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-skip/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-skip/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-skip/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M1</version>
+                    <version>3.12.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven-verification/src/test/resources/pit-site-timestamped/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-site-timestamped/pom.xml
@@ -13,7 +13,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>4.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-api</artifactId>
-			<version>4.0.0-M1</version>
+			<version>3.1.0</version>
 		</dependency>
 		<!-- commons-collections, commons-beanutils, and plexus-utils specified
 		 due to vulnerable versions used by maven-reporting-impl:2.0.4.3-->
@@ -116,7 +116,7 @@
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-impl</artifactId>
-			<version>4.0.0-M1</version>
+			<version>3.1.0</version>
 		</dependency>
 	    <dependency>
 	        <groupId>backport-util-concurrent</groupId>

--- a/pitest-maven/pom.xml
+++ b/pitest-maven/pom.xml
@@ -46,7 +46,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.5</version>
+				<version>3.6.4</version>
 				<executions>
 					<execution>
 						<id>default-descriptor</id>
@@ -82,18 +82,19 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven.version}</version>
+			<version>3.8.6</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.4</version>
+			<version>3.6.4</version>
 			<scope>provided</scope><!-- annotations are needed only to build the plugin -->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-api</artifactId>
-			<version>${maven.version}</version>
+			<version>4.0.0-M1</version>
 		</dependency>
 		<!-- commons-collections, commons-beanutils, and plexus-utils specified
 		 due to vulnerable versions used by maven-reporting-impl:2.0.4.3-->
@@ -110,18 +111,18 @@
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-utils</artifactId>
-			<version>3.3.0</version>
+			<version>3.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.reporting</groupId>
 			<artifactId>maven-reporting-impl</artifactId>
-			<version>2.0.4.3</version>
+			<version>4.0.0-M1</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven.version}</version>
-		</dependency>
+	    <dependency>
+	        <groupId>backport-util-concurrent</groupId>
+	        <artifactId>backport-util-concurrent</artifactId>
+	        <version>3.1</version>
+	    </dependency>
 		<dependency>
 			<groupId>org.apache.maven.scm</groupId>
 			<artifactId>maven-scm-api</artifactId>
@@ -159,12 +160,14 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
+			<version>3.8.6</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-toolchain</artifactId>
 			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -185,9 +188,21 @@
 
 		<!-- test dependencies -->
 		<dependency>
-			<groupId>org.apache.maven.shared</groupId>
+			<groupId>org.apache.maven.plugin-testing</groupId>
 			<artifactId>maven-plugin-testing-harness</artifactId>
-			<version>1.1</version>
+			<version>3.3.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-classic</artifactId>
+		    <version>1.2.11</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+			<version>3.8.6</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -195,5 +210,21 @@
 
 	<properties>
 		<scm.version>1.9.4</scm.version>
+		<surefire.version>3.0.0-M7</surefire.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-interpolation</artifactId>
+				<version>1.21</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-core</artifactId>
+				<version>3.8.6</version>
+				<scope>provided</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 </project>

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -14,6 +14,7 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,8 +62,8 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
       }
 
       final ReportAggregator reportAggregator = reportAggregationBuilder
-              .inputCharSet(this.getInputEncoding())
-              .outputCharset(this.getOutputEncoding())
+              .inputCharSet(Charset.forName(this.getInputEncoding()))
+              .outputCharset(Charset.forName(this.getOutputEncoding()))
           .resultOutputStrategy(new DirectoryResultOutputStrategy(
               getReportsDirectory().getAbsolutePath(),
               new UndatedReportDirCreationStrategy()))

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
@@ -185,18 +185,18 @@ public class PitReportMojo extends AbstractMavenReport {
     return this.sourceDataFormats;
   }
 
-  public Charset getInputEncoding() {
+  public String getInputEncoding() {
     if (inputEncoding != null) {
-      return Charset.forName(inputEncoding);
+      return inputEncoding;
     }
-    return Charset.defaultCharset();
+    return Charset.defaultCharset().name();
   }
 
-  public Charset getOutputEncoding() {
+  public String getOutputEncoding() {
     if (outputEncoding != null) {
-      return Charset.forName(outputEncoding);
+      return outputEncoding;
     }
-    return Charset.defaultCharset();
+    return Charset.defaultCharset().name();
   }
 
   private ReportGenerationContext buildReportGenerationContext(Locale locale) {

--- a/pitest-maven/src/test/java/org/pitest/maven/report/PitReportMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/report/PitReportMojoTest.java
@@ -14,7 +14,7 @@
  */
 package org.pitest.maven.report;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
@@ -93,7 +93,7 @@ public class PitReportMojoTest {
     assertThat(actualContext.getReportsDataDirectory(),
         sameInstance(this.reportsDirectory));
     assertThat(actualContext.getSink(), sameInstance(this.sink));
-    assertThat(actualContext.getSiteDirectory().getPath(), is("abspath"
+    assertThat(actualContext.getSiteDirectory().getPath(), endsWith("abspath"
         + File.separator + "pit-reports"));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
 		<junit.version>4.11</junit.version>
 		<maven.version>2.2.1</maven.version>
 		<powermock.version>1.7.3</powermock.version>
-		<surefire.version>2.17</surefire.version>
+		<surefire.version>2.18.1</surefire.version> <!-- [2.19, 3.0.0-M7] seem to cause ASM-related test failures -->
 		<slf4j.version>1.7.12</slf4j.version>
 
 		<maven.failsafe-plugin.version>${surefire.version}</maven.failsafe-plugin.version>


### PR DESCRIPTION
This **breaks backward compatibility** with `maven-site-plugin:3.4.x` and possibly other old versions as well. A revision bump is recommended.

This commit updates the Maven plugin-related dependencies and modifies any code affected by breaking changes. Note, some artifact versions were specified using a common property. However, it appears those artifacts no longer follow the same versioning scheme.

Closes #1037