### PR TITLE
poll minion processes to check they are alive

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/CoverageProcess.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/CoverageProcess.java
@@ -3,6 +3,7 @@ package org.pitest.coverage.execute;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.pitest.coverage.CoverageResult;
@@ -31,7 +32,11 @@ public class CoverageProcess {
 
   public ExitCode waitToDie() {
     try {
-      return this.crt.waitToFinish();
+      Optional<ExitCode> maybeExit = this.crt.waitToFinish(5);
+      while (!maybeExit.isPresent() && this.process.isAlive()) {
+        maybeExit = this.crt.waitToFinish(10);
+      }
+      return maybeExit.orElse(ExitCode.MINION_DIED);
     } finally {
       this.process.destroy();
     }

--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
@@ -145,7 +145,7 @@ public class DefaultCoverageGenerator implements CoverageGenerator {
     } else if (!exitCode.isOk()) {
       LOG.severe("Coverage generator Minion exited abnormally due to "
           + exitCode);
-      throw new PitError("Coverage generation minion exited abnormally!");
+      throw new PitError("Coverage generation minion exited abnormally! (" + exitCode + ")");
     } else {
       LOG.fine("Coverage generator Minion exited ok");
     }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/MutationTestUnit.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/MutationTestUnit.java
@@ -91,6 +91,9 @@ public class MutationTestUnit implements MutationAnalysisUnit {
   private static ExitCode waitForMinionToDie(final MutationTestProcess worker) {
     final ExitCode exitCode = worker.waitToDie();
     LOG.fine("Exit code was - " + exitCode);
+    if (exitCode == ExitCode.MINION_DIED) {
+      LOG.severe("Minion did not start or died during analysis. This may indicate an issue in your environment such as insufficient memory.");
+    }
     return exitCode;
   }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/execute/MutationTestProcess.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/execute/MutationTestProcess.java
@@ -3,6 +3,7 @@ package org.pitest.mutationtest.execute;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.HashMap;
+import java.util.Optional;
 
 import org.pitest.mutationtest.MutationStatusMap;
 import org.pitest.mutationtest.MutationStatusTestPair;
@@ -43,7 +44,11 @@ public class MutationTestProcess {
 
   public ExitCode waitToDie() {
     try {
-      return this.thread.waitToFinish();
+      Optional<ExitCode> maybeExit = this.thread.waitToFinish(5);
+      while (!maybeExit.isPresent() && this.process.isAlive()) {
+        maybeExit = this.thread.waitToFinish(10);
+      }
+      return maybeExit.orElse(ExitCode.MINION_DIED);
     } finally {
       this.process.destroy();
     }

--- a/pitest-entry/src/main/java/org/pitest/process/WrappingProcess.java
+++ b/pitest-entry/src/main/java/org/pitest/process/WrappingProcess.java
@@ -50,6 +50,10 @@ public class WrappingProcess {
         this.processArgs.getStdErr());
   }
 
+  public boolean isAlive() {
+    return process.isAlive();
+  }
+
   
    // Reportedly passing the classpath as an environment variable rather than on the command
    // line increases the allowable size of the classpath, but this has not been confirmed

--- a/pitest-entry/src/main/java/org/pitest/util/CommunicationThread.java
+++ b/pitest-entry/src/main/java/org/pitest/util/CommunicationThread.java
@@ -16,8 +16,11 @@ package org.pitest.util;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -54,15 +57,17 @@ public class CommunicationThread {
     return newFuture;
   }
 
-  public ExitCode waitToFinish() {
+  public Optional<ExitCode> waitToFinish(int pollSeconds) {
     try {
-      return this.future.get();
+      return Optional.of(this.future.get(pollSeconds, TimeUnit.SECONDS));
     } catch (final ExecutionException e) {
       LOG.log(Level.WARNING, "Error while watching child process", e);
-      return ExitCode.UNKNOWN_ERROR;
+      return Optional.of(ExitCode.UNKNOWN_ERROR);
     } catch (final InterruptedException e) {
       LOG.log(Level.WARNING, "interrupted while waiting for child process", e);
-      return ExitCode.UNKNOWN_ERROR;
+      return Optional.of(ExitCode.UNKNOWN_ERROR);
+    } catch (final TimeoutException e) {
+      return Optional.empty();
     }
 
   }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/MutationCoverageReportSystemTest.java
@@ -58,6 +58,7 @@ import com.example.JUnitThreeSuite;
 import com.example.KeepAliveThread;
 import com.example.MultipleMutations;
 import com.example.coverage.execute.samples.mutationMatrix.TestsForSimpleCalculator;
+import org.pitest.util.PitError;
 import org.pitest.util.Verbosity;
 
 @Category(SystemTest.class)
@@ -409,6 +410,22 @@ public class MutationCoverageReportSystemTest extends ReportTestBase {
     createAndRun();
 
     verifyResults();
+  }
+
+  @Test(timeout = 20000, expected = PitError.class)
+  public void shouldRecoverFromMinionThatDoesNotStart() {
+    setMutators("RETURN_VALS");
+
+    this.data
+            .setTargetClasses(asGlobs(com.example.testhasignores.Mutee.class));
+    this.data
+            .setTargetTests(predicateFor(com.example.testhasignores.MuteeTest.class));
+
+    this.data.addChildJVMArgs(asList("-Xmx1k"));
+
+    createAndRun();
+
+    // just running without a hang then erroring is success
   }
 
   @Generated

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
@@ -100,24 +100,13 @@ public class MutationTestMinion {
           new TimeOutDecoratedTestSource(paramsFromParent.timeoutStrategy,
               tests, this.reporter));
 
-      repeatedlySendDoneSignal();
+      this.reporter.done(ExitCode.OK);
     } catch (final Throwable ex) {
       ex.printStackTrace(System.out);
       LOG.log(Level.WARNING, "Error during mutation test", ex);
       this.reporter.done(ExitCode.UNKNOWN_ERROR);
     }
 
-  }
-
-  private void repeatedlySendDoneSignal() throws InterruptedException {
-    // there have been reports of the done signal getting lost, causing the main process
-    // to hang. The root cause of this issue has not been found, this attempts to mitigate it
-    // by resending the signal. We don't want to spend too long doing this, as it is better for
-    // the minion to end naturally, than be killed by the main process.
-    for (int i = 0; i != 10; i++) {
-      this.reporter.done(ExitCode.OK);
-      Thread.sleep(100);
-    }
   }
 
   private void configureVerbosity(MinionArguments paramsFromParent) {

--- a/pitest/src/main/java/org/pitest/util/ExitCode.java
+++ b/pitest/src/main/java/org/pitest/util/ExitCode.java
@@ -16,7 +16,7 @@ package org.pitest.util;
 
 public enum ExitCode {
 
-  OK(0), OUT_OF_MEMORY(11), UNKNOWN_ERROR(13), TIMEOUT(14), TEST_PLUGIN_ISSUE(15);
+  MINION_DIED(-1), OK(0), OUT_OF_MEMORY(11), UNKNOWN_ERROR(13), TIMEOUT(14), TEST_PLUGIN_ISSUE(15);
 
   private final int code;
 


### PR DESCRIPTION
Root cause of #1047 seems to be processes that are unable to start due
to insufficient memory. This results in the main process hanging,
waiting for their signal.

At some point the checks that the minion processes are alive look to
have been removed. This change reintroduces them with a simple poll.