### PR TITLE
Support for standard argLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Read all about it at http://pitest.org
 
 ## Releases
 
+### 1.9.3 (unreleased)
+
+* #1052 - Support maven argLine property and single string argLines
+
 ### 1.9.2
 
 * #1050 - Check minions are alive to prevent process hangs

--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -260,6 +260,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
     this.setOption(ConfigOption.OUTPUT_ENCODING, value);
   }
 
+  public void setArgLine(String value) {
+    this.setOption(ConfigOption.ARG_LINE, value);
+  }
+
   private void setOption(final ConfigOption option, final String value) {
     if (!"".equals(value)) {
       this.options.put(option.getParamName(), value);
@@ -269,6 +273,7 @@ public class PitestTask extends Task { // NO_UCD (test only)
   public void setUseClasspathJar(String value) {
     this.setOption(ConfigOption.USE_CLASSPATH_JAR, value);
   }
+
 
 
 }

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -489,6 +489,12 @@ public class PitestTaskTest {
     verify(this.arg).setValue("--outputEncoding=US-ASCII");
   }
 
+  @Test
+  public void passesArgLineToJavaTask() {
+    this.pitestTask.setArgLine("-Dfoo=\"bar\"");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--argLine=-Dfoo=\"bar\"");
+  }
 
   private static class PathMatcher implements ArgumentMatcher<Path> {
 

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -43,6 +43,7 @@ import java.util.Properties;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import static org.pitest.mutationtest.config.ConfigOption.ARG_LINE;
 import static org.pitest.mutationtest.config.ConfigOption.AVOID_CALLS;
 import static org.pitest.mutationtest.config.ConfigOption.CHILD_JVM;
 import static org.pitest.mutationtest.config.ConfigOption.CLASSPATH;
@@ -107,6 +108,7 @@ public class OptionsParser {
   private final OptionSpec<File>                     historyInputSpec;
   private final OptionSpec<String>                   mutators;
   private final OptionSpec<String>                   features;
+  private final OptionSpec<String>                   argLine;
   private final OptionSpec<String>                   jvmArgs;
   private final CommaAwareArgsProcessor              jvmArgsProcessor;
   private final OptionSpec<Float>                    timeoutFactorSpec;
@@ -202,6 +204,9 @@ public class OptionsParser {
     this.features = parserAccepts(FEATURES).withRequiredArg()
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("comma separated list of features to enable/disable.");
+
+    this.argLine = parserAccepts(ARG_LINE).withRequiredArg()
+            .describedAs("argline for child JVMs");
 
     this.jvmArgs = parserAccepts(CHILD_JVM).withRequiredArg()
         .describedAs("comma separated list of child JVM args");
@@ -415,6 +420,8 @@ public class OptionsParser {
     data.setSourceDirs(this.sourceDirSpec.values(userArgs));
     data.setMutators(this.mutators.values(userArgs));
     data.setFeatures(this.features.values(userArgs));
+
+    data.setArgLine(this.argLine.value(userArgs));
 
     data.addChildJVMArgs(this.jvmArgsProcessor.values(userArgs));
     

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -97,6 +97,13 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldSetArgLine() {
+    final ReportOptions actual = parseAddingRequiredArgs("--argLine", "-Dfoo=\"bar\"");
+
+    assertThat(actual.getArgLine()).isEqualTo("-Dfoo=\"bar\"");
+  }
+
+  @Test
   public void shouldParseCommaSeparatedListOfJVMArgs() {
     final ReportOptions actual = parseAddingRequiredArgs("--jvmArgs", "foo,bar");
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -54,6 +54,10 @@ public enum ConfigOption {
    */
   CHILD_JVM("jvmArgs"),
 
+  /**
+   * Arguments to launch child processes with expressed as single line
+   */
+  ARG_LINE("argLine"),
 
   /**
    * Do/don't create timestamped folders for reports

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -97,6 +97,9 @@ public class ReportOptions {
   private Collection<String>             features;
 
   private final List<String>             jvmArgs                        = new ArrayList<>(DEFAULT_CHILD_JVM_ARGS);
+
+  private String                         argLine;
+
   private int                            numberOfThreads                = 0;
   private float                          timeoutFactor                  = PercentAndConstantTimeoutStrategy.DEFAULT_FACTOR;
   private long                           timeoutConstant                = PercentAndConstantTimeoutStrategy.DEFAULT_CONSTANT;
@@ -217,6 +220,14 @@ public class ReportOptions {
 
   public void addChildJVMArgs(final List<String> args) {
     this.jvmArgs.addAll(args);
+  }
+
+  public String getArgLine() {
+    return argLine;
+  }
+
+  public void setArgLine(String argLine) {
+    this.argLine = argLine;
   }
 
   public ClassPath getClassPath() {
@@ -628,6 +639,7 @@ public class ReportOptions {
     this.outputEncoding = outputEncoding;
   }
 
+
   @Override
   public String toString() {
     return new StringJoiner(", ", ReportOptions.class.getSimpleName() + "[", "]")
@@ -644,6 +656,7 @@ public class ReportOptions {
             .add("mutators=" + mutators)
             .add("features=" + features)
             .add("jvmArgs=" + jvmArgs)
+            .add("argLine=" + argLine)
             .add("numberOfThreads=" + numberOfThreads)
             .add("timeoutFactor=" + timeoutFactor)
             .add("timeoutConstant=" + timeoutConstant)
@@ -676,4 +689,6 @@ public class ReportOptions {
             .add("outputEncoding=" + outputEncoding)
             .toString();
   }
+
+
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
@@ -18,6 +18,7 @@ import org.pitest.mutationtest.incremental.ObjectOutputStreamHistoryStore;
 import org.pitest.mutationtest.incremental.WriterFactory;
 import org.pitest.plugin.Feature;
 import org.pitest.plugin.FeatureParameter;
+import org.pitest.process.ArgLineParser;
 import org.pitest.process.JavaAgent;
 import org.pitest.process.LaunchOptions;
 import org.pitest.util.Log;
@@ -28,6 +29,8 @@ import org.pitest.util.Timings;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -97,7 +100,7 @@ public class EntryPoint {
 
     final CoverageOptions coverageOptions = settings.createCoverageOptions();
     final LaunchOptions launchOptions = new LaunchOptions(ja,
-        settings.getJavaExecutable(), data.getJvmArgs(), environmentVariables)
+        settings.getJavaExecutable(), createJvmArgs(data), environmentVariables)
         .usingClassPathJar(data.useClasspathJar());
     final ProjectClassPaths cps = data.getMutationClassPaths();
 
@@ -130,6 +133,12 @@ public class EntryPoint {
       historyWriter.close();
     }
 
+  }
+
+  private List<String> createJvmArgs(ReportOptions data) {
+    List<String> args = new ArrayList<>(data.getJvmArgs());
+    args.addAll(ArgLineParser.split(data.getArgLine()));
+    return args;
   }
 
   private HistoryStore makeHistoryStore(ReportOptions data,  Optional<WriterFactory> historyWriter) {

--- a/pitest-entry/src/main/java/org/pitest/process/ArgLineParser.java
+++ b/pitest-entry/src/main/java/org/pitest/process/ArgLineParser.java
@@ -1,0 +1,107 @@
+package org.pitest.process;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import static org.pitest.process.ArgLineParser.State.START;
+
+/**
+ * Simple state machine to split arglines into sections. Arglines may
+ * contain single or double quotes, which might be escaped.
+ */
+public class ArgLineParser {
+
+    private static final String ESCAPE_CHAR = "\\";
+    private static final String SINGLE_QUOTE = "\'";
+    public static final String DOUBLE_QUOTE = "\"";
+
+    public static List<String> split(String in) {
+        return process(stripWhiteSpace(in));
+    }
+
+    private static List<String> process(String in) {
+        if (in.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final StringTokenizer tokenizer = new StringTokenizer(in, "\"\' \\", true);
+        List<String> tokens = new ArrayList<>();
+
+        Deque<State> state = new ArrayDeque<>();
+        state.push(START);
+        StringBuilder current = new StringBuilder();
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            switch (state.peek()) {
+                case START:
+                    if (token.equals(SINGLE_QUOTE)) {
+                        state.push(State.IN_QUOTE);
+                    } else if (token.equals(DOUBLE_QUOTE)) {
+                        state.push(State.IN_DOUBLE_QUOTE);
+                    } else if (token.equals(" ")) {
+                        if (current.length() != 0) {
+                            tokens.add(current.toString());
+                            current = new StringBuilder();
+                        }
+                    } else {
+                        current.append(token);
+                        if (token.equals(ESCAPE_CHAR)) {
+                            state.push(State.IN_ESCAPE);
+                        }
+                    }
+                    break;
+                case IN_QUOTE:
+                    if (token.equals(SINGLE_QUOTE)) {
+                        state.pop();
+                    } else {
+                        current.append(token);
+                        if (token.equals(ESCAPE_CHAR)) {
+                            state.push(State.IN_ESCAPE);
+                        }
+                    }
+                    break;
+                case IN_DOUBLE_QUOTE:
+                    if (token.equals(DOUBLE_QUOTE)) {
+                        state.pop();
+                    } else {
+                        current.append(token);
+                        if (token.equals(ESCAPE_CHAR)) {
+                            state.push(State.IN_ESCAPE);
+                        }
+                    }
+                    break;
+                case IN_ESCAPE:
+                    current.append(token);
+                    if (!token.equals(ESCAPE_CHAR)) {
+                        state.pop();
+                    }
+                    break;
+            }
+        }
+
+        if (current.length() != 0) {
+            tokens.add(current.toString());
+        }
+
+        if (state.size() != 1) {
+            throw new RuntimeException("Unclosed quote in " + in);
+        }
+
+        return tokens;
+    }
+
+    private static String stripWhiteSpace(String in) {
+        if (in == null) {
+            return "";
+        }
+        return in.replaceAll("\\s", " ").trim();
+    }
+
+    enum State {
+        START, IN_ESCAPE, IN_QUOTE, IN_DOUBLE_QUOTE
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/process/LaunchOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/process/LaunchOptions.java
@@ -33,14 +33,17 @@ public class LaunchOptions {
   }
   
   public LaunchOptions(JavaAgent javaAgentFinder,
-      JavaExecutableLocator javaExecutable, List<String> childJVMArgs,
-      Map<String, String> environmentVariables) {
+                       JavaExecutableLocator javaExecutable,
+                       List<String> childJVMArgs,
+                       Map<String, String> environmentVariables) {
     this(javaAgentFinder, javaExecutable, childJVMArgs, environmentVariables, false);
   }
 
   public LaunchOptions(JavaAgent javaAgentFinder,
-      JavaExecutableLocator javaExecutable, List<String> childJVMArgs,
-      Map<String, String> environmentVariables, boolean usingClassPathJar) {
+                       JavaExecutableLocator javaExecutable,
+                       List<String> childJVMArgs,
+                       Map<String, String> environmentVariables,
+                       boolean usingClassPathJar) {
     this.javaAgentFinder = javaAgentFinder;
     this.childJVMArgs = childJVMArgs;
     this.javaExecutable = javaExecutable;

--- a/pitest-entry/src/main/java/org/pitest/process/WrappingProcess.java
+++ b/pitest-entry/src/main/java/org/pitest/process/WrappingProcess.java
@@ -1,7 +1,6 @@
 package org.pitest.process;
 
 import static org.pitest.functional.prelude.Prelude.or;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -34,7 +33,8 @@ public class WrappingProcess {
     final String[] args = { "" + this.port };
 
     final ProcessBuilder processBuilder = createProcessBuilder(
-        this.processArgs.getJavaExecutable(), this.processArgs.getJvmArgs(),
+        this.processArgs.getJavaExecutable(),
+            this.processArgs.getJvmArgs(),
         this.minionClass, Arrays.asList(args),
         this.processArgs.getJavaAgentFinder(),
         this.processArgs.getLaunchClassPath());
@@ -109,6 +109,7 @@ public class WrappingProcess {
     cmd.addAll(args);
 
     addPITJavaAgent(agentJarLocator, cmd);
+
     addLaunchJavaAgents(cmd);
 
     cmd.add(mainClass.getName());

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
@@ -106,7 +106,7 @@ public abstract class ReportTestBase {
       final CoverageOptions coverageOptions = createCoverageOptions(settings.createCoverageOptions().getPitConfig());
       final LaunchOptions launchOptions = new LaunchOptions(agent,
           new DefaultJavaExecutableLocator(), this.data.getJvmArgs(),
-          new HashMap<String, String>());
+          new HashMap<>());
 
       final PathFilter pf = new PathFilter(p -> true, p -> true);
       final ProjectClassPaths cps = new ProjectClassPaths(

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
@@ -232,12 +232,11 @@ public class TestMutationTesting {
       final JavaAgent agent,
       final Collection<String> mutators) {
 
-    // data.setConfiguration(this.config);
     final CoverageOptions coverageOptions = createCoverageOptions(data);
 
     final LaunchOptions launchOptions = new LaunchOptions(agent,
         new DefaultJavaExecutableLocator(), data.getJvmArgs(),
-        new HashMap<String, String>());
+        new HashMap<>());
 
     final PathFilter pf = new PathFilter(
         Prelude.not(new DefaultDependencyPathPredicate()),

--- a/pitest-entry/src/test/java/org/pitest/process/ArgLineParserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/process/ArgLineParserTest.java
@@ -1,0 +1,139 @@
+package org.pitest.process;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+public class ArgLineParserTest {
+
+    @Test
+    public void parsesNullToEmptyList() {
+        List<String> actual = ArgLineParser.split(null);
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    public void parsesEmptyStringToEmptyList() {
+        List<String> actual = ArgLineParser.split("");
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    public void parsesWhiteSpaceToEmptyList() {
+        List<String> actual = ArgLineParser.split(" ");
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    public void parsesUnquotedItems() {
+        List<String> actual = ArgLineParser.split("foo bar");
+        assertThat(actual).containsExactly("foo", "bar");
+    }
+
+    @Test
+    public void parsesUnquotedItemsWithIrregularWhiteSpace() {
+        List<String> actual = ArgLineParser.split("foo    bar       car");
+        assertThat(actual).containsExactly("foo", "bar", "car");
+    }
+
+    @Test
+    public void parsesDoubleQuotedItems() {
+        List<String> actual = ArgLineParser.split("foo \" in double quotes \" bar");
+        assertThat(actual).containsExactly("foo", " in double quotes ", "bar");
+    }
+
+    @Test
+    public void parsesSingleQuotedItems() {
+        List<String> actual = ArgLineParser.split("foo ' in single quotes   ' bar");
+        assertThat(actual).containsExactly("foo", " in single quotes   ", "bar");
+    }
+
+    @Test
+    public void parsesDoubleQuoteWithinSingleQuote() {
+        List<String> actual = ArgLineParser.split("foo ' \" ' bar");
+        assertThat(actual).containsExactly("foo", " \" ", "bar");
+    }
+
+    @Test
+    public void parsesSingleQuoteWithinDoubleQuote() {
+        List<String> actual = ArgLineParser.split("foo \" ' \" bar");
+        assertThat(actual).containsExactly("foo", " ' ", "bar");
+    }
+
+    @Test
+    public void escapedDoubleQuoteRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo \\\" bar");
+        assertThat(actual).containsExactly("foo", "\\\"" , "bar");
+    }
+
+    @Test
+    public void escapedSingleQuoteRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo \\' bar");
+        assertThat(actual).containsExactly("foo", "\\'" , "bar");
+    }
+
+    @Test
+    public void escapesEscapeChar() {
+        List<String> actual = ArgLineParser.split("foo \\\\' bar");
+        assertThat(actual).containsExactly("foo", "\\\\'" , "bar");
+    }
+
+    @Test
+    public void escapedDoubleQuoteInDoubleQuotesRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo \"bar\\\" car\" la");
+        assertThat(actual).containsExactly("foo", "bar\\\" car", "la");
+    }
+
+    @Test
+    public void escapedSingleQuoteInDoubleQuotesRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo \"bar\\' car\" la");
+        assertThat(actual).containsExactly("foo", "bar\\' car", "la");
+    }
+
+    @Test
+    public void escapedSingleQuoteInSingleQuotesRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo 'bar\\' car' la");
+        assertThat(actual).containsExactly("foo", "bar\\' car", "la");
+    }
+
+    @Test
+    public void escapedDoubleQuoteInSingleQuotesRemainsEscaped() {
+        List<String> actual = ArgLineParser.split("foo 'bar\\\" car' la");
+        assertThat(actual).containsExactly("foo", "bar\\\" car", "la");
+    }
+
+    @Test
+    public void multipleEscapedQuotesRemainEscaped() {
+        List<String> actual = ArgLineParser.split("foo 'bar\\\" \\\" \\' car' la");
+        assertThat(actual).containsExactly("foo", "bar\\\" \\\" \\' car", "la");
+    }
+
+    @Test
+    public void errorsOnUnclosedSingleQuote() {
+        assertThatCode(() -> ArgLineParser.split("foo '"))
+                .hasMessageContaining("Unclosed quote");
+    }
+
+    @Test
+    public void errorsOnUnclosedDoubleQuote() {
+        assertThatCode(() -> ArgLineParser.split("foo \""))
+                .hasMessageContaining("Unclosed quote");
+    }
+
+    @Test
+    public void handlesRealExampleArgLine() {
+        String argLine = "-Dfile.encoding=UTF-8\n" +
+                "      -Dnet.bytebuddy.experimental=true\n" +
+                "      --add-opens=java.base/java.lang=ALL-UNNAMED\n" +
+                "      --add-opens=java.base/java.math=ALL-UNNAMED\n";
+
+        List<String> actual = ArgLineParser.split(argLine);
+        assertThat(actual).containsExactly("-Dfile.encoding=UTF-8",
+                "-Dnet.bytebuddy.experimental=true",
+                "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                "--add-opens=java.base/java.math=ALL-UNNAMED");
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/process/WrappingProcessTest.java
+++ b/pitest-entry/src/test/java/org/pitest/process/WrappingProcessTest.java
@@ -33,8 +33,8 @@ public class WrappingProcessTest {
   InterruptedException {
 
     final LaunchOptions launchOptions = new LaunchOptions(NullJavaAgent.instance(),
-        new DefaultJavaExecutableLocator(), Collections.<String> emptyList(),
-        new HashMap<String, String>());
+        new DefaultJavaExecutableLocator(), Collections.emptyList(),
+        new HashMap<>());
 
     final ProcessArgs processArgs = ProcessArgs
         .withClassPath(new ClassPath().getLocalClassPath())

--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -166,6 +166,12 @@ public class AbstractPitMojo extends AbstractMojo {
   private ArrayList<String>           jvmArgs;
 
   /**
+   * Single line commandline argument
+   */
+  @Parameter(property = "argLine")
+  private String                      argLine;
+
+  /**
    * Formats to output during analysis phase
    */
   @Parameter(property = "outputFormats")
@@ -589,6 +595,10 @@ public class AbstractPitMojo extends AbstractMojo {
 
   public List<String> getJvmArgs() {
     return withoutNulls(this.jvmArgs);
+  }
+
+  public String getArgLine() {
+    return argLine;
   }
 
   public List<String> getOutputFormats() {

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -116,6 +116,9 @@ public class MojoToReportOptionsConverter {
     if (this.mojo.getJvmArgs() != null) {
       data.addChildJVMArgs(this.mojo.getJvmArgs());
     }
+    if (this.mojo.getArgLine() != null) {
+      data.setArgLine(this.mojo.getArgLine());
+    }
 
     data.setMutators(determineMutators());
     data.setFeatures(determineFeatures());


### PR DESCRIPTION
Surefire and other plugins support the `argLine` property for passing
parameters to child jvms in the form of a single string.

Pitest currently supports passing a list of properties using the jvmArgs
param. This requires duplicating values already specified in the
argLine.

The list format also causes problems when the arguments contain
delimiters, for which some unsatisfactory workarounds have been applied.

This change adds a new argLine property to pitest, which is read from
the standard maven property by default. It can be set explicitly for Ant
and the command line.

The existing jvmArgs parameter is retained, and can be used to set
additional arguments for pitest.

fixes #1052