### PR TITLE
Allow supression of auto add of headless=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Read all about it at http://pitest.org
 ### 1.9.3 (unreleased)
 
 * #1052 - Support maven argLine property and single string argLines
+* #1054 - Provide control over auto addition of -Djava.awt.headless=true
+
+1054 Moves support of auto adding headless=true (to prevent keyboard focus being stolen on Macs) into a feature. 
+It is enabled by default, but can be disabled by adding `-MACOS_FOCUS` to the features string.
 
 ### 1.9.2
 

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.pitest.mutationtest.config.ReportOptions.DEFAULT_CHILD_JVM_ARGS;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -108,7 +107,6 @@ public class OptionsParserTest {
     final ReportOptions actual = parseAddingRequiredArgs("--jvmArgs", "foo,bar");
 
     List<String> expected = new ArrayList<>();
-    expected.addAll(DEFAULT_CHILD_JVM_ARGS);
     expected.add("foo");
     expected.add("bar");
     assertEquals(expected, actual.getJvmArgs());

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/autoconfig/KeepMacOsFocus.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/autoconfig/KeepMacOsFocus.java
@@ -1,0 +1,32 @@
+package org.pitest.mutationtest.autoconfig;
+
+import org.pitest.mutationtest.config.ConfigurationUpdater;
+import org.pitest.mutationtest.config.ReportOptions;
+import org.pitest.plugin.Feature;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Pitest steals keyboard focus in OSX unless java is launched in
+ * headless mode.
+ */
+public class KeepMacOsFocus implements ConfigurationUpdater {
+
+    @Override
+    public void updateConfig(ReportOptions toModify) {
+        toModify.addChildJVMArgs(singletonList("-Djava.awt.headless=true"));
+    }
+
+    @Override
+    public Feature provides() {
+        return Feature.named("MACOS_FOCUS")
+                .withOnByDefault(true)
+                .withDescription(description());
+    }
+
+    @Override
+    public String description() {
+        return "Auto add java.awt.headless=true to keep keyboard focus on Mac OS";
+    }
+
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/CompoundConfigurationUpdater.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/CompoundConfigurationUpdater.java
@@ -1,0 +1,34 @@
+package org.pitest.mutationtest.config;
+
+import org.pitest.plugin.Feature;
+import org.pitest.plugin.FeatureSelector;
+import org.pitest.plugin.FeatureSetting;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CompoundConfigurationUpdater implements ConfigurationUpdater {
+    private final FeatureSelector<ConfigurationUpdater> features;
+
+    public CompoundConfigurationUpdater(List<FeatureSetting> features,
+                                        Collection<ConfigurationUpdater> children) {
+        this.features = new FeatureSelector<>(features, children);
+    }
+
+    @Override
+    public void updateConfig(ReportOptions toModify) {
+        for (ConfigurationUpdater each : features.getActiveFeatures() ) {
+            each.updateConfig(toModify);
+        }
+    }
+
+    @Override
+    public Feature provides() {
+        return Feature.named("n/a");
+    }
+
+    @Override
+    public String description() {
+        return "n/a";
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigurationUpdater.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigurationUpdater.java
@@ -1,0 +1,8 @@
+package org.pitest.mutationtest.config;
+
+import org.pitest.plugin.ProvidesFeature;
+import org.pitest.plugin.ToolClasspathPlugin;
+
+public interface ConfigurationUpdater extends ToolClasspathPlugin, ProvidesFeature {
+    void updateConfig(ReportOptions toModify);
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
@@ -48,6 +48,7 @@ public class PluginServices {
     l.addAll(findGroupers());
     l.addAll(findTestPrioritisers());
     l.addAll(findInterceptors());
+    l.addAll(findConfigurationUpdaters());
     return l;
   }
 
@@ -62,6 +63,10 @@ public class PluginServices {
     l.addAll(findTestFrameworkPlugins());
     l.addAll(nullPlugins());
     return l;
+  }
+
+  public Collection<? extends ConfigurationUpdater> findConfigurationUpdaters() {
+    return load(ConfigurationUpdater.class);
   }
 
   public Collection<? extends MethodMutatorFactory> findMutationOperators() {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -64,8 +64,6 @@ import static org.pitest.functional.prelude.Prelude.or;
  */
 public class ReportOptions {
 
-  public static final List<String> DEFAULT_CHILD_JVM_ARGS = Collections.singletonList("-Djava.awt.headless=true");
-
   public static final Collection<String> LOGGING_CLASSES                = Arrays
       .asList(
           "java.util.logging",
@@ -96,9 +94,9 @@ public class ReportOptions {
   private Collection<String>             mutators;
   private Collection<String>             features;
 
-  private final List<String>             jvmArgs                        = new ArrayList<>(DEFAULT_CHILD_JVM_ARGS);
 
   private String                         argLine;
+  private final List<String>             jvmArgs                        = new ArrayList<>();
 
   private int                            numberOfThreads                = 0;
   private float                          timeoutFactor                  = PercentAndConstantTimeoutStrategy.DEFAULT_FACTOR;

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
@@ -73,6 +73,11 @@ public class SettingsFactory {
     return new CompoundListenerFactory(parser.parseFeatures(this.options.getFeatures()), findListeners());
   }
 
+  public ConfigurationUpdater createUpdater() {
+    final FeatureParser parser = new FeatureParser();
+    return new CompoundConfigurationUpdater(parser.parseFeatures(this.options.getFeatures()), new ArrayList<>(plugins.findConfigurationUpdaters()));
+  }
+
   public JavaExecutableLocator getJavaExecutable() {
     if (this.options.getJavaExecutable() != null) {
       return new KnownLocationJavaExecutableLocator(

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
@@ -71,6 +71,8 @@ public class EntryPoint {
   public AnalysisResult execute(File baseDir, ReportOptions data,
       SettingsFactory settings, Map<String, String> environmentVariables) {
 
+    updateData(data, settings);
+
     if (data.getVerbosity() == VERBOSE) {
       Log.getLogger().info("Project base directory is " + data.getProjectBase());
       Log.getLogger().info("---------------------------------------------------------------------------");
@@ -139,6 +141,11 @@ public class EntryPoint {
     List<String> args = new ArrayList<>(data.getJvmArgs());
     args.addAll(ArgLineParser.split(data.getArgLine()));
     return args;
+  }
+
+  private void updateData(ReportOptions data, SettingsFactory settings) {
+    settings.createUpdater().updateConfig(data);
+
   }
 
   private HistoryStore makeHistoryStore(ReportOptions data,  Optional<WriterFactory> historyWriter) {

--- a/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.config.ConfigurationUpdater
+++ b/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.config.ConfigurationUpdater
@@ -1,0 +1,1 @@
+org.pitest.mutationtest.autoconfig.KeepMacOsFocus

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/autoconfig/KeepMacOsFocusTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/autoconfig/KeepMacOsFocusTest.java
@@ -1,0 +1,32 @@
+package org.pitest.mutationtest.autoconfig;
+
+import org.junit.Test;
+import org.pitest.mutationtest.config.ReportOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KeepMacOsFocusTest {
+    KeepMacOsFocus underTest = new KeepMacOsFocus();
+
+    @Test
+    public void addsHeadlessTrueToJvmArgs() {
+        ReportOptions data = new ReportOptions();
+
+        underTest.updateConfig(data);
+        assertThat(data.getJvmArgs()).contains("-Djava.awt.headless=true");
+    }
+
+    @Test
+    public void featureIsNamedMacOsFocus() {
+        KeepMacOsFocus underTest = new KeepMacOsFocus();
+
+        assertThat(underTest.provides().name()).isEqualTo("macos_focus");
+    }
+
+    @Test
+    public void featureIsOnByDefault() {
+        KeepMacOsFocus underTest = new KeepMacOsFocus();
+
+        assertThat(underTest.provides().isOnByDefault()).isTrue();
+    }
+}

--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -373,11 +373,6 @@ public class PitMojoIT {
     assertThat(actual).doesNotContain("status='RUN_ERROR'");
   }
 
-  private void skipIfJavaVersionNotSupportByThirdParty() {
-    String javaVersion = System.getProperty("java.version");
-    assumeFalse(javaVersion.startsWith("9") || javaVersion.startsWith("10") || javaVersion.startsWith("11"));
-  }
-
   @Test
   @Ignore("yatspec is not available on maven central. Repo currently down")
   public void shouldWorkWithYatspec() throws Exception {
@@ -448,6 +443,12 @@ public class PitMojoIT {
     } catch(VerificationException ex) {
        assertThat(ex.getMessage()).contains("Please check you have correctly installed the pitest plugin for your project's test library");
     }
+  }
+
+
+  private void skipIfJavaVersionNotSupportByThirdParty() {
+    String javaVersion = System.getProperty("java.version");
+    assumeFalse(javaVersion.startsWith("9") || javaVersion.startsWith("10") || javaVersion.startsWith("11"));
   }
 
 

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -108,7 +108,6 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     final ReportOptions actual = parseConfig(xml);
 
     List<String> expectedArgs = new ArrayList<>();
-    expectedArgs.addAll(ReportOptions.DEFAULT_CHILD_JVM_ARGS);
     expectedArgs.add("foo");
     expectedArgs.add("bar");
 


### PR DESCRIPTION
New ConfigurationUpdater interface allows this to be handled as a
feature and disabled by passed features="-macos_focus"