### PR TITLE
guess best number of threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ Read all about it at http://pitest.org
 
 * #1052 - Support maven argLine property and single string argLines
 * #1054 - Provide control over auto addition of -Djava.awt.headless=true
+* #1055 - Option to autoset number of threads
 
-1054 Moves support of auto adding headless=true (to prevent keyboard focus being stolen on Macs) into a feature. 
+1054 Moves support of auto adding headless=true (to prevent keyboard focus being stolen on Macs) into a feature.
 It is enabled by default, but can be disabled by adding `-MACOS_FOCUS` to the features string.
+
+1055 adds the option to guess the appropriate number of threads for the current machine by adding `+auto_threads`
+the features string. This option is disabled by default and designed for local use. It is not recommended
+for use on a CI server.
 
 ### 1.9.2
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/autoconfig/AutoSetThreads.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/autoconfig/AutoSetThreads.java
@@ -1,0 +1,61 @@
+package org.pitest.mutationtest.autoconfig;
+
+import org.pitest.mutationtest.config.ConfigurationUpdater;
+import org.pitest.mutationtest.config.ReportOptions;
+import org.pitest.plugin.Feature;
+import org.pitest.util.Log;
+
+import java.util.logging.Logger;
+
+/**
+ * Autosets number of threads based on the number of processors reported
+ * by the runtime.
+ *
+ * The optimum number to use will vary hugely with each codebase. Simplistic
+ * formula used here is unlikely to find the best setting, but will make a
+ * coarse guess for the current machine based on the number of reported
+ * cores. This number itself might be wrong in virtual environments, so
+ * feature is best used for local development only.
+ *
+ * Disabled by default to ensure build is consistent.
+ */
+public class AutoSetThreads implements ConfigurationUpdater {
+    private static final Logger LOG = Log.getLogger();
+
+    @Override
+    public void updateConfig(ReportOptions toModify) {
+        // this will be wrong in some environments, feature best used
+        // only for local dev
+        int cores = getCores();
+
+        // Based on experiments on a macbook, advantage of more threads
+        // tails off using a little over half of them
+        if (cores >= 8) {
+            cores = Math.round(cores / 1.5f);
+        } else {
+            // For fewer cores rule of thumb of cores - 1 seems to hold
+            cores = Math.max(1, cores - 1);
+        }
+
+
+        LOG.info("Overriding configured number of threads (" + toModify.getNumberOfThreads() + ") to be " + cores);
+        toModify.setNumberOfThreads(cores);
+    }
+
+
+    @Override
+    public Feature provides() {
+        return Feature.named("auto_threads")
+                .withOnByDefault(false)
+                .withDescription(description());
+    }
+
+    @Override
+    public String description() {
+        return "Auto set number of threads based on machine";
+    }
+
+    int getCores() {
+        return Runtime.getRuntime().availableProcessors();
+    }
+}

--- a/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.config.ConfigurationUpdater
+++ b/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.config.ConfigurationUpdater
@@ -1,1 +1,2 @@
 org.pitest.mutationtest.autoconfig.KeepMacOsFocus
+org.pitest.mutationtest.autoconfig.AutoSetThreads

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/autoconfig/AutoSetThreadsTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/autoconfig/AutoSetThreadsTest.java
@@ -1,0 +1,60 @@
+package org.pitest.mutationtest.autoconfig;
+
+import org.junit.Test;
+import org.pitest.mutationtest.config.ReportOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoSetThreadsTest {
+
+    int reportedCores = 1;
+
+    AutoSetThreads underTest = new AutoSetThreads() {
+        @Override
+        int getCores() {
+            return reportedCores;
+        }
+    };
+
+    @Test
+    public void isDisabledByDefault() {
+        assertThat(underTest.provides().isOnByDefault()).isFalse();
+    }
+
+    @Test
+    public void leavesNumberOfThreadsAs1IfOnly1Available() {
+        ReportOptions data = new ReportOptions();
+        reportedCores = 1;
+        data.setNumberOfThreads(1);
+        underTest.updateConfig(data);
+        assertThat(data.getNumberOfThreads()).isEqualTo(1);
+    }
+
+    @Test
+    public void usesThreeThreadsWhen4CoresAvailable() {
+        ReportOptions data = new ReportOptions();
+        reportedCores = 4;
+        data.setNumberOfThreads(1);
+        underTest.updateConfig(data);
+        assertThat(data.getNumberOfThreads()).isEqualTo(3);
+    }
+
+    @Test
+    public void usesFiveThreadsWhen8CoresAvailable() {
+        ReportOptions data = new ReportOptions();
+        reportedCores = 8;
+        data.setNumberOfThreads(1);
+        underTest.updateConfig(data);
+        assertThat(data.getNumberOfThreads()).isEqualTo(5);
+    }
+
+    @Test
+    public void uses8CoresWhen12Available() {
+        ReportOptions data = new ReportOptions();
+        reportedCores = 12;
+        data.setNumberOfThreads(1);
+        underTest.updateConfig(data);
+        assertThat(data.getNumberOfThreads()).isEqualTo(8);
+    }
+
+}


### PR DESCRIPTION
Adds the option to guess the appropriate number of threads for the current machine by adding `+auto_threads`
the features string. This option is disabled by default and designed for local use. It is not recommended
for use on a CI server.