### PR TITLE
Set timeout for socket reads

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
@@ -63,6 +63,8 @@ public class CoverageMinion {
 
       final int port = Integer.parseInt(args[0]);
       s = new Socket("localhost", port);
+      // if we can't read/write in 10 seconds, something is badly wrong
+      s.setSoTimeout(10000);
 
       final SafeDataInputStream dis = new SafeDataInputStream(
           s.getInputStream());

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestMinion.java
@@ -135,6 +135,8 @@ public class MutationTestMinion {
     Socket s = null;
     try {
       s = new Socket("localhost", port);
+      // if we can't read/write in 20 seconds, something is badly wrong
+      s.setSoTimeout(20000);
       final SafeDataInputStream dis = new SafeDataInputStream(
           s.getInputStream());
 


### PR DESCRIPTION
Very occasionally the coverage process hangs while trying to read from
the communication socket. The root cause of this is not known, but
timing out is preferable to an infinite process hang.

Ten second timeout time is arbitary, picked to be unlikely to trigger
under normal circumstances. Set higher for mutation test minion as box
might be heavily loaded.