### PR TITLE
Fix inconsistent spacing in logging

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -125,7 +125,7 @@ public class MutationCoverage {
     final MutationEngine engine = this.strategies.factory().createEngine(args);
 
     List<MutationAnalysisUnit> preScanMutations = findMutations(engine, args);
-    LOG.info("Created  " + preScanMutations.size() + " mutation test units in pre scan");
+    LOG.info("Created " + preScanMutations.size() + " mutation test units in pre scan");
 
     // throw error if configured to do so
     checkMutationsFound(preScanMutations);
@@ -162,7 +162,7 @@ public class MutationCoverage {
             engine, args, allInterceptors());
     this.timings.registerEnd(Timings.Stage.BUILD_MUTATION_TESTS);
 
-    LOG.info("Created  " + tus.size() + " mutation test units" );
+    LOG.info("Created " + tus.size() + " mutation test units" );
 
     recordClassPath(history, coverageData);
 

--- a/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
@@ -167,7 +167,7 @@ public class CoverageMinion {
         .findTestUnitsForAllSuppliedClasses(classes.stream()
                 .flatMap(ClassName.nameToClass())
                 .collect(Collectors.toList()));
-    LOG.info(() -> "Found  " + tus.size() + " tests");
+    LOG.info(() -> "Found " + tus.size() + " tests");
     return tus;
   }
 

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
@@ -119,7 +119,7 @@ public class MutationTestWorker {
       final List<TestUnit> relevantTests) {
     final MutationStatusTestPair mutationDetected;
     if ((relevantTests == null) || relevantTests.isEmpty()) {
-      LOG.info(() -> "No test coverage for mutation  " + mutationId + " in "
+      LOG.info(() -> "No test coverage for mutation " + mutationId + " in "
           + mutatedClass.getDetails().getMethod());
       mutationDetected =  MutationStatusTestPair.notAnalysed(0, DetectionStatus.RUN_ERROR);
     } else {


### PR DESCRIPTION
This change is betting on that nobody is parsing the log output verbatim for further consumption.