### PR TITLE
Do not produce timestamped reports by default

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -221,7 +221,7 @@ public class OptionsParser {
             "whether or not to try and detect code inlined from finally blocks");
 
     this.timestampedReportsSpec = parserAccepts(TIME_STAMPED_REPORTS)
-        .withOptionalArg().ofType(Boolean.class).defaultsTo(true)
+        .withOptionalArg().ofType(Boolean.class).defaultsTo(false)
         .describedAs("whether or not to generated timestamped directories");
 
     this.timeoutFactorSpec = parserAccepts(TIMEOUT_FACTOR).withOptionalArg()

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -147,14 +147,14 @@ public class OptionsParserTest {
   }
 
   @Test
-  public void shouldCreateTimestampedReportsByDefault() {
+  public void shouldNotCreateTimestampedReportsByDefault() {
     final ReportOptions actual = parseAddingRequiredArgs();
-    assertTrue(actual.shouldCreateTimeStampedReports());
+    assertFalse(actual.shouldCreateTimeStampedReports());
   }
 
   @Test
   public void shouldDetermineIfSuppressTimestampedReportsFlagIsSet() {
-    final ReportOptions actual = parseAddingRequiredArgs("--timestampedReports");
+    final ReportOptions actual = parseAddingRequiredArgs("--timestampedReports=true");
     assertTrue(actual.shouldCreateTimeStampedReports());
   }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -62,7 +62,7 @@ public enum ConfigOption {
   /**
    * Do/don't create timestamped folders for reports
    */
-  TIME_STAMPED_REPORTS("timestampedReports", true),
+  TIME_STAMPED_REPORTS("timestampedReports", false),
 
   /**
    * Number of threads to use

--- a/pitest-maven-verification/src/test/resources/pit-158-coverage/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-158-coverage/pom.xml
@@ -44,7 +44,6 @@
 				<configuration>
 					<verbose>true</verbose>
 				    <outputFormats><value>XML</value></outputFormats>
-				    <timestampedReports>false</timestampedReports>
 					<exportLineCoverage>true</exportLineCoverage>
 					<mutators>
 						<mutator>VOID_METHOD_CALLS</mutator>

--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -192,7 +192,7 @@ public class AbstractPitMojo extends AbstractMojo {
   /**
    * Create timestamped subdirectory for report
    */
-  @Parameter(defaultValue = "true", property = "timestampedReports")
+  @Parameter(defaultValue = "false", property = "timestampedReports")
   private boolean                     timestampedReports;
 
   /**

--- a/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/PitReportMojo.java
@@ -92,7 +92,7 @@ public class PitReportMojo extends AbstractMavenReport {
    * 
    */
   @Parameter(property = "pit.report.outputdir", defaultValue = "pit-reports")
-  private String                  siteReportDirectory;
+  private String siteReportDirectory;
 
   @Parameter(property = "pit.inputEncoding", defaultValue = "${project.build.sourceEncoding}")
   private String inputEncoding;


### PR DESCRIPTION
The vast majority of users disable timestamped reports. Defaulting the parameter to true no longer makes sense.