### PR TITLE
Add throwables in CheckTestHasFailedResultListener

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/execute/CheckTestHasFailedResultListener.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/CheckTestHasFailedResultListener.java
@@ -25,6 +25,7 @@ public class CheckTestHasFailedResultListener implements TestListener {
 
   private final List<Description>   succeedingTests = new ArrayList<>();
   private final List<Description>   failingTests = new ArrayList<>();
+  public final List<String> throwables = new ArrayList<>();
   private final boolean       recordPassingTests;
   private int                 testsRun        = 0;
 
@@ -35,6 +36,11 @@ public class CheckTestHasFailedResultListener implements TestListener {
   @Override
   public void onTestFailure(final TestResult tr) {
     this.failingTests.add(tr.getDescription());
+
+    if (tr.getThrowable() != null) {
+      // TO DO: expand the data that we capture from the throwable instance.
+      this.throwables.add(tr.getThrowable().getClass().descriptorString());
+    }
   }
 
   @Override

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
@@ -205,6 +205,12 @@ public class MutationTestWorker {
 
   private MutationStatusTestPair createStatusTestPair(
       final CheckTestHasFailedResultListener listener) {
+
+    System.out.println("printing throwables!");
+    for (String t : listener.throwables) {
+      System.out.println(t);
+    }
+
     List<String> failingTests = listener.getFailingTests().stream()
         .map(Description::getQualifiedName).collect(Collectors.toList());
     List<String> succeedingTests = listener.getSucceedingTests().stream()


### PR DESCRIPTION
- adding a new property on CheckTestHasFailedResultListener to store all throwbales encountered.
- printing the list of throwables from the result listener in MutationTestWorker.