### PR TITLE
add aggregated results to report aggregator and configurable thresholds to maven aggregator mojo

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/AggregationResult.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/AggregationResult.java
@@ -1,0 +1,32 @@
+package org.pitest.aggregate;
+
+public class AggregationResult {
+  private final long mutations;
+  private final long mutationsSurvived;
+  private final int  mutationCoverage;
+
+  private final int testStrength;
+
+  public AggregationResult(long mutations, long mutationsSurvived, int mutationCoverage, int testStrength) {
+    this.mutations = mutations;
+    this.mutationsSurvived = mutationsSurvived;
+    this.mutationCoverage = mutationCoverage;
+    this.testStrength = testStrength;
+  }
+
+  public long getMutations() {
+    return mutations;
+  }
+
+  public long getMutationsSurvived() {
+    return mutationsSurvived;
+  }
+
+  public int getMutationCoverage() {
+    return mutationCoverage;
+  }
+
+  public int getTestStrength() {
+    return testStrength;
+  }
+}

--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -51,17 +51,23 @@ public final class ReportAggregator {
     this.outputCharset = outputCharset;
   }
 
-  public void aggregateReport() throws ReportAggregationException {
+  public AggregationResult aggregateReport() throws ReportAggregationException {
     final MutationMetaData mutationMetaData = new MutationMetaData(new ArrayList<>(this.mutationLoader.loadData()));
 
     final MutationResultListener mutationResultListener = createResultListener(mutationMetaData);
+    final ReportAggregatorResultListener reportAggregatorResultListener = new ReportAggregatorResultListener();
 
+    reportAggregatorResultListener.runStart();
     mutationResultListener.runStart();
 
     for (final ClassMutationResults mutationResults : mutationMetaData.toClassResults()) {
+      reportAggregatorResultListener.handleMutationResult(mutationResults);
       mutationResultListener.handleMutationResult(mutationResults);
     }
+    reportAggregatorResultListener.runEnd();
     mutationResultListener.runEnd();
+
+    return reportAggregatorResultListener.result();
   }
 
   private MutationResultListener createResultListener(final MutationMetaData mutationMetaData) throws ReportAggregationException {

--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregatorResultListener.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregatorResultListener.java
@@ -1,0 +1,32 @@
+package org.pitest.aggregate;
+
+import org.pitest.mutationtest.ClassMutationResults;
+import org.pitest.mutationtest.MutationResultListener;
+import org.pitest.mutationtest.report.html.MutationTotals;
+
+public class ReportAggregatorResultListener implements MutationResultListener {
+  MutationTotals totals = new MutationTotals();
+
+  @Override
+  public void runStart() {
+    // nothing to do here
+  }
+
+  @Override
+  public void handleMutationResult(ClassMutationResults results) {
+    totals.addFiles(1);
+    totals.addMutations(results.getMutations().size());
+    totals.addMutationsDetetcted(results.getMutations().stream().filter(mutation -> mutation.getStatus().isDetected()).count());
+    totals.addMutationsWithCoverage(results.getMutations().stream().filter(it -> it.getStatus().hasCoverage()).count());
+  }
+
+  @Override
+  public void runEnd() {
+    // nothing to do here
+  }
+
+  public AggregationResult result() {
+    return new AggregationResult(totals.getNumberOfMutations(), totals.getNumberOfMutations() - totals.getNumberOfMutationsDetected(),
+        totals.getMutationCoverage(), totals.getTestStrength());
+  }
+}

--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -253,7 +253,7 @@ public class PitMojoIT {
 
     assertTrue("coverage included",
             projectReportsHtmlContents
-                    .contains("89%"));
+                    .contains("85%"));
   }
 
   /*

--- a/pitest-maven-verification/src/test/resources/pit-sub-module/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-sub-module/pom.xml
@@ -41,6 +41,9 @@
 						</outputFormats>
 						<!-- exportLineCoverage is used by the report aggregate -->
 						<exportLineCoverage>true</exportLineCoverage>
+						<aggregatedTestStrengthThreshold>26</aggregatedTestStrengthThreshold>
+						<aggregatedMutationThreshold>20</aggregatedMutationThreshold>
+						<aggregatedMaxSurviving>6</aggregatedMaxSurviving>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/pitest-maven-verification/src/test/resources/pit-sub-module/sub-module-2/src/main/java/org/example2/SystemUnderTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-sub-module/sub-module-2/src/main/java/org/example2/SystemUnderTest.java
@@ -15,10 +15,16 @@ public class SystemUnderTest {
       aNumber = -25;
     }
   }
+
+  public int getNumber() {
+    return aNumber;
+  }
   
   public String toString() {
     return "SystemUnderTest";
   }
   
-  
+  public boolean isActive() {
+    return false;
+  }
 }

--- a/pitest-maven-verification/src/test/resources/pit-sub-module/sub-module-2/src/test/java/org/example2/SystemUnderTestTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-sub-module/sub-module-2/src/test/java/org/example2/SystemUnderTestTest.java
@@ -1,0 +1,19 @@
+package org.example2;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class SystemUnderTestTest {
+
+  @Test
+  public void testGetNumber() {
+    SystemUnderTest sut = new SystemUnderTest();
+
+    int result = sut.getNumber();
+    assertTrue(result == -25);
+  }
+  
+  
+}

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -1,10 +1,12 @@
 package org.pitest.maven.report;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.util.FileUtils;
+import org.pitest.aggregate.AggregationResult;
 import org.pitest.aggregate.ReportAggregator;
 import org.pitest.functional.FCollection;
 import org.pitest.maven.DependencyFilter;
@@ -35,6 +37,24 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
    */
   @Parameter(property = "reactorProjects", readonly = true)
   List<MavenProject> reactorProjects;
+
+  /**
+   * Mutation score threshold at which to fail build
+   */
+  @Parameter(defaultValue = "0", property = "aggregatedMutationThreshold")
+  private int aggregatedMutationThreshold;
+
+  /**
+   * Test strength score threshold at which to fail build
+   */
+  @Parameter(defaultValue = "0", property = "aggregatedTestStrengthThreshold")
+  private int aggregatedTestStrengthThreshold;
+
+  /**
+   * Maximum surviving mutants to allow
+   */
+  @Parameter(defaultValue = "-1", property = "aggregatedMaxSurviving")
+  private int aggregatedMaxSurviving = -1;
 
   private final ReportSourceLocator reportSourceLocator = new ReportSourceLocator();
 
@@ -69,7 +89,12 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
               new UndatedReportDirCreationStrategy()))
           .build();
 
-      reportAggregator.aggregateReport();
+      AggregationResult result = reportAggregator.aggregateReport();
+
+      throwErrorIfTestStrengthBelowThreshold(result.getTestStrength());
+      throwErrorIfScoreBelowThreshold(result.getMutationCoverage());
+      throwErrorIfMoreThanMaximumSurvivors(result.getMutationsSurvived());
+
     } catch (final Exception e) {
       throw new MavenReportException(e.getMessage(), e);
     }
@@ -137,5 +162,35 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
         Arrays.asList(project.getBuild().getOutputDirectory(),
             project.getBuild().getTestOutputDirectory()),
         sourceRoots);
+  }
+
+  private void throwErrorIfScoreBelowThreshold(final int mutationCoverage)
+      throws MojoFailureException {
+    if ((this.aggregatedMutationThreshold != 0)
+        && (mutationCoverage < this.aggregatedMutationThreshold)) {
+      throw new MojoFailureException("Mutation score of "
+          + mutationCoverage + " is below threshold of "
+          + this.aggregatedMutationThreshold);
+    }
+  }
+
+  private void throwErrorIfTestStrengthBelowThreshold(final int testStrength)
+      throws MojoFailureException {
+    if ((this.aggregatedTestStrengthThreshold != 0)
+        && (testStrength < this.aggregatedTestStrengthThreshold)) {
+      throw new MojoFailureException("Test strength score of "
+          + testStrength + " is below threshold of "
+          + this.aggregatedTestStrengthThreshold);
+    }
+  }
+
+  private void throwErrorIfMoreThanMaximumSurvivors(final long mutationsSurvived)
+      throws MojoFailureException {
+    if ((this.aggregatedMaxSurviving >= 0)
+        && (mutationsSurvived > this.aggregatedMaxSurviving)) {
+      throw new MojoFailureException("Had "
+          + mutationsSurvived + " surviving mutants, but only "
+          + this.aggregatedMaxSurviving + " survivors allowed");
+    }
   }
 }


### PR DESCRIPTION
Fixes #1068 .

Adds support for thresholds for aggregated mutation coverage, test strength and max. surviving mutants in multi module projects:

```xml
<plugin>
	<groupId>org.pitest</groupId>
	<artifactId>pitest-maven</artifactId>
	<version>${pit.version}</version>
	<configuration>
		//...
		<aggregatedTestStrengthThreshold>26</aggregatedTestStrengthThreshold>
		<aggregatedMutationThreshold>20</aggregatedMutationThreshold>
		<aggregatedMaxSurviving>6</aggregatedMaxSurviving>
	</configuration>
</plugin>
```

As this is added as a result of `ReportAggregator#aggregateReport` this can also be used in the pitest gradle plugins to configure thresholds for the aggregated metrics in the next step.