### PR TITLE
Relax source file attribute check

### DIFF
--- a/pitest-entry/src/test/java/org/pitest/mutationtest/verify/DefaultBuildVerifierTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/verify/DefaultBuildVerifierTest.java
@@ -15,6 +15,7 @@
 
 package org.pitest.mutationtest.verify;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -103,6 +104,12 @@ public class DefaultBuildVerifierTest {
     } catch (final PitHelpError e) {
       fail();
     }
+  }
+
+  @Test
+  public void doesNotErrorWhenNoClassesProvided() {
+    when(this.code.getCode()).thenReturn(Collections.emptyList());
+    assertThatCode(() -> this.testee.verify(this.code)).doesNotThrowAnyException();
   }
 
   private void setupClassPath(final Class<?> clazz) {


### PR DESCRIPTION
The purpose of the check is to alert users that they must configure the compiler to include source file debug info.

Previously all classes were checked to ensure the source file was present, however it appears there may be some scenarios in which the source file is omitted when compiling kotlin.

To allow analysis of the remaining classes, the check has been relaxed so that the info must be present in at least one file, rather than all files.