### PR TITLE
Fix log output

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoverageMinion.java
@@ -91,7 +91,7 @@ public class CoverageMinion {
       List<TestUnit> toExecute = removeTestsExecutedDuringDiscovery(tus);
 
       if (!toExecute.isEmpty()) {
-        LOG.info(() -> tus.size() + "Executing " + toExecute.size() + " tests not run during discovery.");
+        LOG.info(() -> "Executing " + toExecute.size() + " tests not run during discovery.");
         CoverageWorker worker = new CoverageWorker(invokeQueue, toExecute);
         worker.run();
       } else {


### PR DESCRIPTION
The origin log output is like "100Executing 100 tests not run during discovery", and now the useless number at the very beginning is removed.