### PR TITLE
make excludedRunners parameter available via commandline and Ant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Read all about it at http://pitest.org
 
 ## Releases
 
+## 1.10.4 (unreleased)
+
+* #1134 Add `excludedRunners` parameter to command line interface and Ant
+
 ## 1.10.3
 
 * #1128 Bug fix - lines with repeated debug entries double counted

--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -212,6 +212,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
     this.setOption(ConfigOption.EXCLUDED_GROUPS, value);
   }
 
+  public void setExcludedRunners(final String value) {
+    this.setOption(ConfigOption.EXCLUDED_RUNNERS, value);
+  }
+
   public void setIncludedTestMethods(final String value) {
     this.setOption(ConfigOption.INCLUDED_TEST_METHODS, value);
   }

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -233,6 +233,13 @@ public class PitestTaskTest {
   }
 
   @Test
+  public void shouldPassExcludedRunnersToJavaTask() {
+    this.pitestTask.setExcludedRunners("foo");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--excludedRunners=foo");
+  }
+  
+  @Test
   public void shouldPassIncludedTestMethodsOptionToJavaTask() {
     this.pitestTask.setIncludedTestMethods("footest");
     this.pitestTask.execute(this.java);

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -56,6 +56,7 @@ import static org.pitest.mutationtest.config.ConfigOption.COVERAGE_THRESHOLD;
 import static org.pitest.mutationtest.config.ConfigOption.EXCLUDED_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.EXCLUDED_GROUPS;
 import static org.pitest.mutationtest.config.ConfigOption.EXCLUDED_METHOD;
+import static org.pitest.mutationtest.config.ConfigOption.EXCLUDED_RUNNERS;
 import static org.pitest.mutationtest.config.ConfigOption.EXCLUDED_TEST_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.EXPORT_LINE_COVERAGE;
 import static org.pitest.mutationtest.config.ConfigOption.FAIL_WHEN_NOT_MUTATIONS;
@@ -127,6 +128,8 @@ public class OptionsParser {
   private final ArgumentAcceptingOptionSpec<Boolean> failWhenNoMutations;
   private final ArgumentAcceptingOptionSpec<Boolean> skipFailingTests;
   private final ArgumentAcceptingOptionSpec<String>  codePaths;
+
+  private final OptionSpec<String>                   excludedRunnersSpec;
   private final OptionSpec<String>                   excludedGroupsSpec;
   private final OptionSpec<String>                   includedGroupsSpec;
   private final OptionSpec<String>                   includedTestMethodsSpec;
@@ -311,6 +314,10 @@ public class OptionsParser {
         .describedAs(
             "Globs identifying classpath roots containing mutable code");
 
+    this.excludedRunnersSpec = parserAccepts(EXCLUDED_RUNNERS).withRequiredArg()
+            .ofType(String.class).withValuesSeparatedBy(',')
+            .describedAs("JUnit4 runners to exclude");
+
     this.includedGroupsSpec = parserAccepts(INCLUDED_GROUPS).withRequiredArg()
         .ofType(String.class).withValuesSeparatedBy(',')
         .describedAs("TestNG groups/JUnit categories to include");
@@ -473,6 +480,8 @@ public class OptionsParser {
     setClassPath(userArgs, data);
 
     setTestGroups(userArgs, data);
+
+    data.setExcludedRunners(this.excludedRunnersSpec.values(userArgs));
 
     data.setIncludedTestMethods(this.includedTestMethodsSpec.values(userArgs));
     data.setJavaExecutable(this.javaExecutable.value(userArgs));

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -383,6 +383,13 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void shouldParseCommaSeparatedListOfExcludedTestRunners() {
+    final ReportOptions actual = parseAddingRequiredArgs("--excludedRunners",
+            "foo,bar");
+    assertThat(actual.getExcludedRunners()).containsExactly("foo", "bar");
+  }
+
+  @Test
   public void shouldParseMutationUnitSize() {
     final ReportOptions actual = parseAddingRequiredArgs("--mutationUnitSize",
         "50");

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -153,9 +153,14 @@ public enum ConfigOption {
    */
   INCLUDED_TEST_METHODS("includedTestMethods"),
   /**
-   * TestNG groupsJUnit categories to exclude
+   * TestNG groups / JUnit categories to exclude
    */
   EXCLUDED_GROUPS("excludedGroups"),
+
+  /**
+   * JUnit4 runners to exclude
+   */
+  EXCLUDED_RUNNERS("excludedRunners"),
 
   /**
    * Whether to compute a full mutation matrix.


### PR DESCRIPTION
The excludedRunners parameter added by #283 was only made available for the maven plugin. This change adds the parameter to the commandline interface and other build tools.