### PR TITLE
New extension points

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Read all about it at http://pitest.org
 
 ## Releases
 
-## 1.10.5 (unreleased)
+## 1.11.0 (unreleased)
 
 * #1138 Do not mutate redundant fall through to default switch cases
+* #1150 New extension points
+
+Note that #1150 includes breaking interface changes which may require updates to third party plugins.
 
 ## 1.10.4
 

--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/CodeSourceAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/CodeSourceAggregator.java
@@ -12,6 +12,7 @@ import org.pitest.classpath.ClassFilter;
 import org.pitest.classpath.ClassPath;
 import org.pitest.classpath.ClassPathRoot;
 import org.pitest.classpath.CodeSource;
+import org.pitest.classpath.DefaultCodeSource;
 import org.pitest.classpath.DirectoryClassPathRoot;
 import org.pitest.classpath.PathFilter;
 import org.pitest.classpath.ProjectClassPaths;
@@ -30,7 +31,7 @@ class CodeSourceAggregator {
   }
 
   public CodeSource createCodeSource() {
-    return new CodeSource(createProjectClassPaths());
+    return new DefaultCodeSource(createProjectClassPaths());
   }
 
   private ProjectClassPaths createProjectClassPaths() {

--- a/pitest-entry/src/main/java/org/pitest/classpath/CodeSourceFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/classpath/CodeSourceFactory.java
@@ -1,0 +1,7 @@
+package org.pitest.classpath;
+
+import org.pitest.plugin.ToolClasspathPlugin;
+
+public interface CodeSourceFactory extends ToolClasspathPlugin {
+    CodeSource createCodeSource(ProjectClassPaths classPath);
+}

--- a/pitest-entry/src/main/java/org/pitest/classpath/DefaultCodeSource.java
+++ b/pitest-entry/src/main/java/org/pitest/classpath/DefaultCodeSource.java
@@ -1,0 +1,85 @@
+package org.pitest.classpath;
+
+import org.pitest.bytecode.analysis.ClassTree;
+import org.pitest.classinfo.ClassInfo;
+import org.pitest.classinfo.ClassName;
+import org.pitest.classinfo.NameToClassInfo;
+import org.pitest.classinfo.Repository;
+import org.pitest.classinfo.TestToClassMapper;
+import org.pitest.functional.Streams;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DefaultCodeSource implements CodeSource {
+    private final ProjectClassPaths   classPath;
+    private final Repository classRepository;
+
+    public DefaultCodeSource(final ProjectClassPaths classPath) {
+        this(classPath, new Repository(new ClassPathByteArraySource(
+                classPath.getClassPath())));
+    }
+
+    DefaultCodeSource(final ProjectClassPaths classPath,
+               final Repository classRepository) {
+        this.classPath = classPath;
+        this.classRepository = classRepository;
+    }
+
+    public Stream<ClassTree> codeTrees() {
+        return this.classPath.code().stream()
+                .map(c -> this.getBytes(c.asJavaName()))
+                .filter(Optional::isPresent)
+                .map(maybe -> ClassTree.fromBytes(maybe.get()));
+    }
+
+    public Set<ClassName> getCodeUnderTestNames() {
+        return this.classPath.code().stream().collect(Collectors.toSet());
+    }
+
+    public Stream<ClassTree> testTrees() {
+        return this.classPath.test().stream()
+                .map(c -> this.getBytes(c.asJavaName()))
+                .filter(Optional::isPresent)
+                .map(maybe -> ClassTree.fromBytes(maybe.get()))
+                .filter(t -> !t.isAbstract());
+    }
+
+    public ClassPath getClassPath() {
+        return this.classPath.getClassPath();
+    }
+
+    public Optional<ClassName> findTestee(final String className) {
+        final TestToClassMapper mapper = new TestToClassMapper(this.classRepository);
+        return mapper.findTestee(className);
+    }
+
+    public Collection<ClassInfo> getClassInfo(final Collection<ClassName> classes) {
+        return classes.stream()
+                .flatMap(nameToClassInfo())
+                .collect(Collectors.toList());
+    }
+
+    public Optional<byte[]> fetchClassBytes(final ClassName clazz) {
+        return this.classRepository.querySource(clazz);
+    }
+
+    @Override
+    public Optional<ClassInfo> fetchClass(final ClassName clazz) {
+        return this.classRepository.fetchClass(clazz);
+    }
+
+    private Function<ClassName, Stream<ClassInfo>> nameToClassInfo() {
+        return new NameToClassInfo(this.classRepository)
+                .andThen(Streams::fromOptional);
+    }
+
+    @Override
+    public Optional<byte[]> getBytes(String clazz) {
+        return fetchClassBytes(ClassName.fromString(clazz));
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/coverage/ClassLines.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/ClassLines.java
@@ -3,8 +3,11 @@ package org.pitest.coverage;
 import org.pitest.bytecode.analysis.ClassTree;
 import org.pitest.classinfo.ClassName;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 public final class ClassLines {
     private final ClassName name;
@@ -21,6 +24,16 @@ public final class ClassLines {
 
     public ClassName name() {
         return name;
+    }
+
+    public ClassLines relocate(ClassName name) {
+        return new ClassLines(name, codeLines);
+    }
+
+    public List<ClassLine> asList() {
+        return codeLines.stream()
+                .map(l -> new ClassLine(name, l))
+                .collect(Collectors.toList());
     }
 
     public int getNumberOfCodeLines() {
@@ -46,5 +59,13 @@ public final class ClassLines {
     @Override
     public int hashCode() {
         return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ClassLines.class.getSimpleName() + "[", "]")
+                .add("name=" + name)
+                .add("codeLines=" + codeLines)
+                .toString();
     }
 }

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
@@ -15,7 +15,6 @@
 
 package org.pitest.coverage;
 
-import org.pitest.bytecode.analysis.ClassTree;
 import org.pitest.classinfo.ClassInfo;
 import org.pitest.classinfo.ClassName;
 import org.pitest.classpath.CodeSource;
@@ -78,11 +77,6 @@ public class CoverageData implements CoverageDatabase {
     return this.blockCoverage.getOrDefault(location, Collections.emptySet());
   }
 
-  @Override
-  public Collection<TestInfo> getTestsForClassLine(final ClassLine classLine) {
-    return legacyClassCoverage.getTestsForClassLine(classLine);
-  }
-
   public boolean allTestsGreen() {
     return this.failingTestDescriptions.isEmpty();
   }
@@ -96,13 +90,13 @@ public class CoverageData implements CoverageDatabase {
   }
 
   @Override
-  public Optional<ClassLines> getCoveredLinesForClass(ClassName clazz) {
-    return legacyClassCoverage.getCoveredLinesForClass(clazz);
+  public ClassLines getCodeLinesForClass(ClassName clazz) {
+    return legacyClassCoverage.getCodeLinesForClass(clazz);
   }
 
   @Override
-  public int getNumberOfCoveredLines(final Collection<ClassName> mutatedClass) {
-    return legacyClassCoverage.getNumberOfCoveredLines(mutatedClass);
+  public Set<ClassLine> getCoveredLines(ClassName clazz) {
+    return legacyClassCoverage.getCoveredLines(clazz);
   }
 
   @Override
@@ -144,11 +138,6 @@ public class CoverageData implements CoverageDatabase {
     return legacyClassCoverage.getClassesForFile(sourceFile, packageName);
   }
 
-  @Override
-  public CoverageSummary createSummary() {
-    return new CoverageSummary(numberOfLines(), coveredLines());
-  }
-
   private BigInteger generateCoverageNumber(Collection<TestInfo> coverage) {
     BigInteger coverageNumber = BigInteger.ZERO;
     Set<ClassName> testClasses = coverage.stream()
@@ -160,20 +149,6 @@ public class CoverageData implements CoverageDatabase {
     }
 
     return coverageNumber;
-  }
-
-  private Collection<ClassName> allClasses() {
-    return this.code.getCodeUnderTestNames();
-  }
-
-  private int numberOfLines() {
-    return this.code.codeTrees()
-            .map(ClassTree::numberOfCodeLines)
-            .reduce(0, Integer::sum);
-  }
-
-  private int coveredLines() {
-    return getNumberOfCoveredLines(allClasses());
   }
 
   private void checkForFailedTest(final CoverageResult cr) {

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
@@ -13,6 +13,4 @@ public interface CoverageDatabase extends ReportCoverage {
 
   BigInteger getCoverageIdForClass(ClassName clazz);
 
-  CoverageSummary createSummary();
-
 }

--- a/pitest-entry/src/main/java/org/pitest/coverage/NoCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/NoCoverage.java
@@ -5,17 +5,17 @@ import org.pitest.classinfo.ClassName;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
+import java.util.Set;
 
 public class NoCoverage implements CoverageDatabase {
     @Override
-    public Optional<ClassLines> getCoveredLinesForClass(ClassName clazz) {
-        return Optional.empty();
+    public ClassLines getCodeLinesForClass(ClassName clazz) {
+        return new ClassLines(clazz, Collections.emptySet());
     }
 
     @Override
-    public int getNumberOfCoveredLines(Collection<ClassName> clazz) {
-        return 0;
+    public Set<ClassLine> getCoveredLines(ClassName clazz) {
+        return Collections.emptySet();
     }
 
     @Override
@@ -29,11 +29,6 @@ public class NoCoverage implements CoverageDatabase {
     }
 
     @Override
-    public Collection<TestInfo> getTestsForClassLine(ClassLine classLine) {
-        return Collections.emptyList();
-    }
-
-    @Override
     public BigInteger getCoverageIdForClass(ClassName clazz) {
         return BigInteger.ZERO;
     }
@@ -41,11 +36,6 @@ public class NoCoverage implements CoverageDatabase {
     @Override
     public Collection<ClassLines> getClassesForFile(String sourceFile, String packageName) {
         return Collections.emptyList();
-    }
-
-    @Override
-    public CoverageSummary createSummary() {
-        return new CoverageSummary(0,0);
     }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/coverage/ReportCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/ReportCoverage.java
@@ -3,17 +3,15 @@ package org.pitest.coverage;
 import org.pitest.classinfo.ClassName;
 
 import java.util.Collection;
-import java.util.Optional;
+import java.util.Set;
 
 /**
  * Subset of coverage interface used by legacy html report
  */
 public interface ReportCoverage {
-    Optional<ClassLines> getCoveredLinesForClass(ClassName clazz);
+    ClassLines getCodeLinesForClass(ClassName clazz);
 
-    int getNumberOfCoveredLines(Collection<ClassName> clazz);
-
-    Collection<TestInfo> getTestsForClassLine(ClassLine classLine);
+    Set<ClassLine> getCoveredLines(ClassName clazz);
 
     Collection<ClassLines> getClassesForFile(String sourceFile, String packageName);
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/CompoundMutationResultInterceptor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/CompoundMutationResultInterceptor.java
@@ -1,0 +1,35 @@
+package org.pitest.mutationtest;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CompoundMutationResultInterceptor implements MutationResultInterceptor {
+
+    private final List<MutationResultInterceptor> interceptors;
+
+    public CompoundMutationResultInterceptor(List<MutationResultInterceptor> interceptors) {
+        this.interceptors = interceptors;
+    }
+
+    @Override
+    public Collection<ClassMutationResults> modify(Collection<ClassMutationResults> in) {
+        Collection<ClassMutationResults> result = in;
+        for (MutationResultInterceptor each : interceptors) {
+            result = each.modify(result);
+        }
+        return result;
+    }
+
+    @Override
+    public Collection<ClassMutationResults> remaining() {
+        return interceptors.stream()
+                .flatMap(i -> i.remaining().stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String description() {
+        return "Composite interceptor";
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/ListenerArguments.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/ListenerArguments.java
@@ -1,6 +1,6 @@
 package org.pitest.mutationtest;
 
-import org.pitest.coverage.CoverageDatabase;
+import org.pitest.coverage.ReportCoverage;
 import org.pitest.mutationtest.config.ReportOptions;
 import org.pitest.mutationtest.engine.MutationEngine;
 import org.pitest.plugin.FeatureSetting;
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class ListenerArguments {
 
   private final ResultOutputStrategy outputStrategy;
-  private final CoverageDatabase     coverage;
+  private final ReportCoverage       coverage;
   private final long                 startTime;
   private final SourceLocator        locator;
   private final MutationEngine       engine;
@@ -24,7 +24,7 @@ public class ListenerArguments {
   private final FeatureSetting       setting;
 
   public ListenerArguments(ResultOutputStrategy outputStrategy,
-                           CoverageDatabase coverage,
+                           ReportCoverage coverage,
                            SourceLocator locator,
                            MutationEngine engine,
                            long startTime,
@@ -34,7 +34,7 @@ public class ListenerArguments {
   }
 
   ListenerArguments(ResultOutputStrategy outputStrategy,
-                           CoverageDatabase coverage,
+                           ReportCoverage coverage,
                            SourceLocator locator,
                            MutationEngine engine,
                            long startTime,
@@ -55,7 +55,7 @@ public class ListenerArguments {
     return this.outputStrategy;
   }
 
-  public CoverageDatabase getCoverage() {
+  public ReportCoverage getCoverage() {
     return this.coverage;
   }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/MutationResultInterceptor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/MutationResultInterceptor.java
@@ -1,0 +1,32 @@
+package org.pitest.mutationtest;
+
+import org.pitest.plugin.ToolClasspathPlugin;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Allows modification of results before reporting
+ */
+public interface MutationResultInterceptor extends ToolClasspathPlugin {
+    /**
+     * Modify results for a class
+     * @param results Results
+     * @return Results with modifications
+     */
+    Collection<ClassMutationResults> modify(Collection<ClassMutationResults> results);
+
+    /**
+     * Called at end of run to provide any results that could not be determined
+     * until all processing was complete
+     * @return Collection of results
+     */
+    default Collection<ClassMutationResults> remaining() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    default String description() {
+        return "";
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/CoverageTransformer.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/CoverageTransformer.java
@@ -1,0 +1,10 @@
+package org.pitest.mutationtest.build;
+
+import org.pitest.coverage.ReportCoverage;
+
+/**
+ * Allows modification of coverage prior to reporting
+ */
+public interface CoverageTransformer {
+    ReportCoverage transform(ReportCoverage in);
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/CoverageTransformerFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/CoverageTransformerFactory.java
@@ -1,0 +1,9 @@
+package org.pitest.mutationtest.build;
+
+import org.pitest.classpath.CodeSource;
+import org.pitest.plugin.ToolClasspathPlugin;
+
+public interface CoverageTransformerFactory extends ToolClasspathPlugin {
+
+    CoverageTransformer create(CodeSource source);
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
@@ -1,6 +1,9 @@
 package org.pitest.mutationtest.config;
 
+import org.pitest.classpath.CodeSourceFactory;
+import org.pitest.mutationtest.build.CoverageTransformerFactory;
 import org.pitest.mutationtest.MutationEngineFactory;
+import org.pitest.mutationtest.MutationResultInterceptor;
 import org.pitest.mutationtest.MutationResultListenerFactory;
 import org.pitest.mutationtest.build.MutationGrouperFactory;
 import org.pitest.mutationtest.build.MutationInterceptorFactory;
@@ -48,7 +51,10 @@ public class PluginServices {
     l.addAll(findTestPrioritisers());
     l.addAll(findInterceptors());
     l.addAll(findConfigurationUpdaters());
+    l.addAll(findMutationResultInterceptor());
+    l.addAll(findCoverageTransformers());
     l.addAll(findVerifiers());
+    l.addAll(findCodeSources());
     return l;
   }
 
@@ -103,6 +109,18 @@ public class PluginServices {
 
   public List<BuildVerifierFactory> findVerifiers() {
     return new ArrayList<>(load(BuildVerifierFactory.class));
+  }
+
+  public List<MutationResultInterceptor> findMutationResultInterceptor() {
+    return new ArrayList<>(load(MutationResultInterceptor.class));
+  }
+
+  public List<CoverageTransformerFactory> findCoverageTransformers() {
+    return new ArrayList<>(load(CoverageTransformerFactory.class));
+  }
+
+  public List<CodeSourceFactory> findCodeSources() {
+    return new ArrayList<>(load(CodeSourceFactory.class));
   }
 
   public Collection<ProvidesFeature> findFeatures() {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/EntryPoint.java
@@ -106,21 +106,21 @@ public class EntryPoint {
         .usingClassPathJar(data.useClasspathJar());
     final ProjectClassPaths cps = data.getMutationClassPaths();
 
-    final CodeSource code = new CodeSource(cps);
+    final CodeSource code = settings.createCodeSource(cps);
 
     final Timings timings = new Timings();
     final CoverageGenerator coverageDatabase = new DefaultCoverageGenerator(
         baseDir, coverageOptions, launchOptions, code,
         settings.createCoverageExporter(), timings, data.getVerbosity());
 
-
     final Optional<WriterFactory> maybeWriter = data.createHistoryWriter();
     WriterFactory historyWriter = maybeWriter.orElse(new NullWriterFactory());
     final HistoryStore history = makeHistoryStore(data, maybeWriter);
 
     final MutationStrategies strategies = new MutationStrategies(
-        settings.createEngine(), history, coverageDatabase, reportFactory,
-        reportOutput, settings.createVerifier().create(code));
+        settings.createEngine(), history, coverageDatabase, reportFactory, settings.getResultInterceptor(),
+        settings.createCoverageTransformer(code),
+            reportOutput, settings.createVerifier().create(code));
 
     final MutationCoverage report = new MutationCoverage(strategies, baseDir,
         code, data, settings, timings);

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationStrategies.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationStrategies.java
@@ -1,8 +1,10 @@
 package org.pitest.mutationtest.tooling;
 
 import org.pitest.coverage.CoverageGenerator;
+import org.pitest.mutationtest.build.CoverageTransformer;
 import org.pitest.mutationtest.HistoryStore;
 import org.pitest.mutationtest.MutationEngineFactory;
+import org.pitest.mutationtest.MutationResultInterceptor;
 import org.pitest.mutationtest.MutationResultListenerFactory;
 import org.pitest.mutationtest.verify.BuildVerifier;
 import org.pitest.util.ResultOutputStrategy;
@@ -12,6 +14,9 @@ public class MutationStrategies {
   private final HistoryStore                  history;
   private final CoverageGenerator             coverage;
   private final MutationResultListenerFactory listenerFactory;
+  private final MutationResultInterceptor     resultsInterceptor;
+
+  private final CoverageTransformer           coverageTransformer;
   private final BuildVerifier                 buildVerifier;
   private final MutationEngineFactory         factory;
   private final ResultOutputStrategy          output;
@@ -19,10 +24,14 @@ public class MutationStrategies {
   public MutationStrategies(final MutationEngineFactory factory,
       final HistoryStore history, final CoverageGenerator coverage,
       final MutationResultListenerFactory listenerFactory,
+      final MutationResultInterceptor resultsInterceptor,
+      final CoverageTransformer coverageTransformer,
       final ResultOutputStrategy output, final BuildVerifier buildVerifier) {
     this.history = history;
     this.coverage = coverage;
     this.listenerFactory = listenerFactory;
+    this.resultsInterceptor = resultsInterceptor;
+    this.coverageTransformer = coverageTransformer;
     this.buildVerifier = buildVerifier;
     this.factory = factory;
     this.output = output;
@@ -40,6 +49,10 @@ public class MutationStrategies {
     return this.listenerFactory;
   }
 
+  public MutationResultInterceptor resultInterceptor() {
+    return this.resultsInterceptor;
+  }
+
   public BuildVerifier buildVerifier() {
     return this.buildVerifier;
   }
@@ -54,12 +67,15 @@ public class MutationStrategies {
 
   public MutationStrategies with(final MutationEngineFactory factory) {
     return new MutationStrategies(factory, this.history, this.coverage,
-        this.listenerFactory, this.output, this.buildVerifier);
+        this.listenerFactory, this.resultsInterceptor, this.coverageTransformer, this.output, this.buildVerifier);
   }
 
   public MutationStrategies with(final BuildVerifier verifier) {
     return new MutationStrategies(this.factory, this.history, this.coverage,
-        this.listenerFactory, this.output, verifier);
+        this.listenerFactory, this.resultsInterceptor, this.coverageTransformer, this.output, verifier);
   }
 
+  public CoverageTransformer coverageTransformer() {
+    return this.coverageTransformer;
+  }
 }

--- a/pitest-entry/src/test/java/org/pitest/classpath/DefaultCodeSourceTest.java
+++ b/pitest-entry/src/test/java/org/pitest/classpath/DefaultCodeSourceTest.java
@@ -17,7 +17,7 @@ import org.pitest.classinfo.ClassName;
 import org.pitest.classinfo.Repository;
 import java.util.Optional;
 
-public class CodeSourceTest {
+public class DefaultCodeSourceTest {
 
   private CodeSource          testee;
 
@@ -34,7 +34,7 @@ public class CodeSourceTest {
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
-    this.testee = new CodeSource(this.classPath, this.repository);
+    this.testee = new DefaultCodeSource(this.classPath, this.repository);
     this.foo = makeClassInfo("Foo");
     this.bar = makeClassInfo("Bar");
   }

--- a/pitest-entry/src/test/java/org/pitest/coverage/ClassLinesTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/ClassLinesTest.java
@@ -3,6 +3,13 @@ package org.pitest.coverage;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
+import org.pitest.classinfo.ClassName;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.Arrays.asList;
 
 public class ClassLinesTest {
 
@@ -12,5 +19,29 @@ public class ClassLinesTest {
                 .withNonnullFields("name")
                 .withIgnoredFields("codeLines")
                 .verify();
+    }
+
+    @Test
+    public void relocateModifiesClassname() {
+        // note relocate is used within external plugins
+        ClassName bar = ClassName.fromString("bar");
+        ClassLines underTest = new ClassLines(ClassName.fromString("foo"), Collections.emptySet());
+        assertThat(underTest.relocate(bar)).isEqualTo(new ClassLines(bar, Collections.emptySet()));
+    }
+
+    @Test
+    public void convertsToClassLines() {
+        ClassName foo = ClassName.fromString("foo");
+        ClassLines underTest = new ClassLines(foo, new HashSet<>(asList(1,2)));
+
+        assertThat(underTest.asList()).containsExactly(new ClassLine(foo,1), new ClassLine(foo,2));
+    }
+
+    @Test
+    public void reportsNumberOfCodeLines() {
+        ClassName foo = ClassName.fromString("foo");
+        ClassLines underTest = new ClassLines(foo, new HashSet<>(asList(1,2)));
+
+        assertThat(underTest.getNumberOfCodeLines()).isEqualTo(2);
     }
 }

--- a/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
@@ -77,35 +77,12 @@ public class CoverageDataTest {
   public void shouldReturnNoTestsWhenNoTestsCoverALine() {
     when(this.lm.mapLines(any(ClassName.class))).thenReturn(
         new HashMap<>());
-    final ClassLine line = new ClassLine("foo", 1);
-    assertEquals(Collections.emptyList(),
-        this.testee.getTestsForClassLine(line));
-  }
-
-  @Test
-  public void shouldStoreExecutionTimesOfTests() {
-
-    final int line = 1;
-    final int time = 42;
-
-    final BlockLocationBuilder block = aBlockLocation().withLocation(
-        aLocation().withClass(this.foo));
-    when(this.lm.mapLines(any(ClassName.class))).thenReturn(
-        makeCoverageMapForBlock(block, line));
-
-    final CoverageResultBuilder cr = aCoverageResult().withVisitedBlocks(
-        block.build(1)).withExecutionTime(time);
-
-    this.testee.calculateClassCoverage(cr.build());
-
-    assertEquals(Arrays.asList(42), FCollection.map(
-        this.testee.getTestsForClassLine(new ClassLine(this.foo, line)), TestInfo::getTime));
+    assertThat(this.testee.getCoveredLines(ClassName.fromString("foo"))).isEmpty();
   }
 
   @Test
   public void shouldReportNumberOfCoveredLinesWhenNoneCovered() {
-    assertEquals(0, this.testee.getNumberOfCoveredLines(Collections
-        .singletonList(ClassName.fromString("foo"))));
+    assertThat(this.testee.getCoveredLines(ClassName.fromString("foo"))).isEmpty();
   }
 
   @Test
@@ -121,8 +98,7 @@ public class CoverageDataTest {
 
     this.testee.calculateClassCoverage(cr.build());
 
-    assertEquals(2, this.testee.getNumberOfCoveredLines(Collections
-        .singletonList(this.foo)));
+    assertThat(this.testee.getCoveredLines(this.foo)).hasSize(2);
   }
 
   @Test
@@ -236,24 +212,6 @@ public class CoverageDataTest {
     assertThat(this.testee.getClassesForFile("Foo.java", "com.example.a.b.c"))
             .containsExactly(new ClassLines(foo1Class.name(), Collections.emptySet()));
 
-  }
-
-  @Test
-  public void shouldIncludeAllCoveredLinesInCoverageSummary() {
-
-    final BlockLocationBuilder block = aBlockLocation();
-    when(this.code.getCodeUnderTestNames()).thenReturn(
-        Collections.singleton(block.build().getLocation().getClassName()));
-    when(this.lm.mapLines(any(ClassName.class))).thenReturn(
-        makeCoverageMapForBlock(block, 1, 2, 3, 4));
-
-    final CoverageResultBuilder cr = aCoverageResult().withVisitedBlocks(
-        block.build(1));
-
-    this.testee.calculateClassCoverage(cr.build());
-
-    final CoverageSummary actual = this.testee.createSummary();
-    assertThat(actual.getNumberOfCoveredLines()).isEqualTo(4);
   }
 
   private CoverageResult makeCoverageResult(final String clazz,

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/CompoundMutationResultInterceptorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/CompoundMutationResultInterceptorTest.java
@@ -1,0 +1,78 @@
+package org.pitest.mutationtest;
+
+import org.junit.Test;
+import org.pitest.mutationtest.report.MutationTestResultMother;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pitest.mutationtest.engine.MutationDetailsMother.aMutationDetail;
+import static org.pitest.mutationtest.report.MutationTestResultMother.aMutationTestResult;
+
+public class CompoundMutationResultInterceptorTest {
+
+    @Test
+    public void chainsChildCallsToModify() {
+        MutationResultInterceptor a = appendToDesc("foo");
+        MutationResultInterceptor b = appendToDesc("bar");
+
+        CompoundMutationResultInterceptor underTest = new CompoundMutationResultInterceptor(asList(a,b));
+
+        Collection<ClassMutationResults> actual = underTest.modify(someClassResults());
+
+        assertThat(actual.stream().flatMap(c -> c.getMutations().stream()))
+                .allMatch(m -> m.getDetails().getDescription().endsWith("foobar"));
+    }
+
+    @Test
+    public void combinesRemainingResults() {
+        MutationResultInterceptor a = hasResult(aMutationTestResult().withMutationDetails(aMutationDetail().withDescription("a")));
+        MutationResultInterceptor b = hasResult(aMutationTestResult().withMutationDetails(aMutationDetail().withDescription("b")));
+
+        CompoundMutationResultInterceptor underTest = new CompoundMutationResultInterceptor(asList(a,b));
+
+        Collection<ClassMutationResults> actual = underTest.remaining();
+
+        assertThat(actual.stream().flatMap(c -> c.getMutations().stream().map(m -> m.getDetails().getDescription())))
+                .containsExactly("a", "b");
+    }
+
+    private MutationResultInterceptor hasResult(MutationTestResultMother.MutationTestResultBuilder b) {
+        return new MutationResultInterceptor() {
+            @Override
+            public Collection<ClassMutationResults> modify(Collection<ClassMutationResults> results) {
+                return null;
+            }
+
+            @Override
+            public Collection<ClassMutationResults> remaining() {
+                return asList(new ClassMutationResults(asList(b.build())));
+            }
+        };
+    }
+
+    private static List<ClassMutationResults> someClassResults() {
+        return asList(MutationTestResultMother.createClassResults(aMutationTestResult().build(2)));
+    }
+
+    private MutationResultInterceptor appendToDesc(final String foo) {
+        return new MutationResultInterceptor() {
+            @Override
+            public Collection<ClassMutationResults> modify(Collection<ClassMutationResults> results) {
+                return results.stream()
+                        .map(r -> new ClassMutationResults(r.getMutations().stream().map(m -> appendToDesc(m, foo)).collect(Collectors.toList())))
+                        .collect(Collectors.toList());
+            }
+
+            private MutationResult appendToDesc(MutationResult result, String toAppend) {
+                return new MutationResult(result.getDetails().withDescription(result.getDetails().getDescription() + toAppend)
+                        , result.getStatusTestPair());
+            }
+        };
+    }
+
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/ReportTestBase.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 
 import org.junit.Before;
 import org.pitest.classpath.CodeSource;
+import org.pitest.classpath.DefaultCodeSource;
 import org.pitest.classpath.PathFilter;
 import org.pitest.classpath.ProjectClassPaths;
 import org.pitest.coverage.CoverageGenerator;
@@ -114,7 +115,7 @@ public abstract class ReportTestBase {
           this.data.getClassPath(), this.data.createClassesFilter(), pf);
 
       final Timings timings = new Timings();
-      final CodeSource code = new CodeSource(cps);
+      final CodeSource code = new DefaultCodeSource(cps);
 
       final CoverageGenerator coverageDatabase = new DefaultCoverageGenerator(
           null, coverageOptions, launchOptions, code,
@@ -124,7 +125,7 @@ public abstract class ReportTestBase {
 
       final MutationStrategies strategies = new MutationStrategies(
           new GregorEngineFactory(), history, coverageDatabase,
-          listenerFactory(), null, new NoVerification());
+          listenerFactory(), result -> result, cov -> cov, null, new NoVerification());
 
       final MutationCoverage testee = new MutationCoverage(strategies, null,
           code, this.data, new SettingsFactory(this.data, this.plugins),

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/TestMutationTesting.java
@@ -45,12 +45,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.MockitoAnnotations;
 import org.pitest.SystemTest;
-import org.pitest.classinfo.ClassInfo;
 import org.pitest.classinfo.ClassName;
 import org.pitest.classpath.ClassloaderByteArraySource;
 import org.pitest.classpath.CodeSource;
+import org.pitest.classpath.DefaultCodeSource;
 import org.pitest.classpath.PathFilter;
 import org.pitest.classpath.ProjectClassPaths;
 import org.pitest.coverage.CoverageDatabase;
@@ -58,7 +57,6 @@ import org.pitest.coverage.CoverageGenerator;
 import org.pitest.coverage.execute.CoverageOptions;
 import org.pitest.coverage.execute.DefaultCoverageGenerator;
 import org.pitest.coverage.export.NullCoverageExporter;
-import org.pitest.functional.FCollection;
 import org.pitest.functional.prelude.Prelude;
 import org.pitest.mutationtest.build.CompoundMutationInterceptor;
 import org.pitest.mutationtest.build.DefaultGrouper;
@@ -79,7 +77,6 @@ import org.pitest.mutationtest.tooling.JarCreatingJarFinder;
 import org.pitest.process.DefaultJavaExecutableLocator;
 import org.pitest.process.JavaAgent;
 import org.pitest.process.LaunchOptions;
-import org.pitest.simpletest.SimpleTestPlugin;
 import org.pitest.simpletest.TestAnnotationForTesting;
 import org.pitest.util.IsolationUtils;
 import org.pitest.util.Timings;
@@ -98,10 +95,9 @@ public class TestMutationTesting {
 
   @Before
   public void setUp() {
-    MockitoAnnotations.openMocks(this);
-    this.config = TestPluginArguments.defaults().withTestPlugin(SimpleTestPlugin.NAME);
+    this.config = TestPluginArguments.defaults();
     this.metaDataExtractor = new MetaDataExtractor();
-    this.mae = new MutationAnalysisExecutor(1,
+    this.mae = new MutationAnalysisExecutor(1, result -> result,
         Collections
             .<MutationResultListener> singletonList(this.metaDataExtractor));
   }
@@ -245,7 +241,7 @@ public class TestMutationTesting {
         data.createClassesFilter(), pf);
 
     final Timings timings = new Timings();
-    final CodeSource code = new CodeSource(cps);
+    final CodeSource code = new DefaultCodeSource(cps);
 
     final CoverageGenerator coverageGenerator = new DefaultCoverageGenerator(
         null, coverageOptions, launchOptions, code, new NullCoverageExporter(),

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/MutationTestResultMother.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/MutationTestResultMother.java
@@ -15,14 +15,43 @@
 package org.pitest.mutationtest.report;
 
 import static org.pitest.mutationtest.LocationMother.aMutationId;
+import static org.pitest.mutationtest.engine.MutationDetailsMother.aMutationDetail;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
+import org.pitest.coverage.TestInfo;
 import org.pitest.mutationtest.ClassMutationResults;
+import org.pitest.mutationtest.DetectionStatus;
 import org.pitest.mutationtest.MutationResult;
+import org.pitest.mutationtest.MutationStatusTestPair;
 import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.MutationDetailsMother;
+import org.pitest.quickbuilder.Builder;
+import org.pitest.quickbuilder.Generator;
+import org.pitest.quickbuilder.SequenceBuilder;
+import org.pitest.quickbuilder.builders.QB;
 
 public class MutationTestResultMother {
+
+  public interface MutationTestResultBuilder extends SequenceBuilder<MutationResult> {
+    MutationTestResultBuilder withMutationDetails(Builder<MutationDetails> details);
+    MutationTestResultBuilder withStatusTestPair(MutationStatusTestPair status);
+
+    MutationDetails _MutationDetails();
+    MutationStatusTestPair _StatusTestPair();
+  }
+
+  public static MutationTestResultBuilder aMutationTestResult() {
+    return QB.builder(MutationTestResultBuilder.class, seed())
+            .withMutationDetails(aMutationDetail())
+            .withStatusTestPair(MutationStatusTestPair.notAnalysed(0, DetectionStatus.SURVIVED));
+  }
+
+  private static Generator<MutationTestResultBuilder, MutationResult> seed() {
+    return b -> new MutationResult(b._MutationDetails(), b._StatusTestPair());
+  }
 
   public static MutationDetails createDetails() {
     return createDetails("file");
@@ -34,7 +63,11 @@ public class MutationTestResultMother {
 
   public static ClassMutationResults createClassResults(
       final MutationResult... mrs) {
-    return new ClassMutationResults(Arrays.asList(mrs));
+    return createClassResults(Arrays.asList(mrs));
+  }
+
+  public static ClassMutationResults createClassResults(List<MutationResult> mrs) {
+    return new ClassMutationResults(mrs);
   }
 
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/tooling/MutationCoverageReportTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/tooling/MutationCoverageReportTest.java
@@ -215,7 +215,7 @@ public class MutationCoverageReportTest {
   private CombinedStatistics createAndRunTestee() {
     final MutationStrategies strategies = new MutationStrategies(
         new GregorEngineFactory(), this.history, this.coverage,
-        this.listenerFactory, this.output, this.verifier).with(this.mutationFactory);
+        this.listenerFactory, result -> result, cov -> cov, this.output, this.verifier).with(this.mutationFactory);
 
     this.testee = new MutationCoverage(strategies, null, this.code, this.data,
         new SettingsFactory(this.data, PluginServices.makeForContextLoader()),

--- a/pitest-entry/src/test/java/org/pitest/verifier/interceptors/BuildVerifierVerifier.java
+++ b/pitest-entry/src/test/java/org/pitest/verifier/interceptors/BuildVerifierVerifier.java
@@ -9,6 +9,7 @@ import org.pitest.classpath.ClassPath;
 import org.pitest.classpath.ClassPathRoot;
 import org.pitest.classpath.ClassloaderByteArraySource;
 import org.pitest.classpath.CodeSource;
+import org.pitest.classpath.DefaultCodeSource;
 import org.pitest.classpath.PathFilter;
 import org.pitest.classpath.ProjectClassPaths;
 import org.pitest.mutationtest.config.PluginServices;
@@ -88,7 +89,7 @@ public class BuildVerifierVerifier {
         final PathFilter pf = new PathFilter(p -> true, p -> true);
         final ProjectClassPaths pcp = new ProjectClassPaths(
                 new ClassPath(root), new ClassFilter(c -> true, c -> true), pf);
-        return new CodeSource(pcp);
+        return new DefaultCodeSource(pcp);
     }
 
     public static ClassTree aValidClass() {
@@ -100,7 +101,7 @@ public class BuildVerifierVerifier {
         final PathFilter pf = new PathFilter(p -> true, p -> true);
         final ProjectClassPaths pcp = new ProjectClassPaths(
                 new ClassPath(), new ClassFilter(c -> true, c -> true), pf);
-        return new CodeSource(pcp);
+        return new DefaultCodeSource(pcp);
     }
 }
 

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -33,7 +33,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -42,6 +41,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
+
+import static java.util.Arrays.asList;
 
 public class MutationHtmlReportListener implements MutationResultListener {
 
@@ -62,7 +63,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
     this.outputCharset = outputCharset;
     this.coverage = coverage;
     this.outputStrategy = outputStrategy;
-    this.sourceRoots = new HashSet<>(Arrays.asList(locators));
+    this.sourceRoots = new HashSet<>(asList(locators));
     this.mutatorNames = new HashSet<>(mutatorNames);
     this.css = loadCss();
   }
@@ -120,14 +121,10 @@ public class MutationHtmlReportListener implements MutationResultListener {
   public MutationTestSummaryData createSummaryData(
       final ReportCoverage coverage, final ClassMutationResults data) {
 
-    final List<ClassLines> lines = this.coverage.getCoveredLinesForClass(data
-                    .getMutatedClass())
-            .map(l -> Collections.singletonList(l))
-            .orElse(Collections.emptyList());
+    final List<ClassLines> lines = asList(this.coverage.getCodeLinesForClass(data.getMutatedClass()));
 
     return new MutationTestSummaryData(data.getFileName(), data.getMutations(),
-        this.mutatorNames, lines, coverage.getNumberOfCoveredLines(Collections
-            .singleton(data.getMutatedClass())));
+        this.mutatorNames, lines, coverage.getCoveredLines(data.getMutatedClass()).size());
   }
 
   private SourceFile createAnnotatedSourceFile(

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
@@ -65,8 +65,8 @@ public class MutationHtmlReportListenerTest {
     when(this.outputStrategy.createWriterForFile(any(String.class)))
         .thenReturn(this.writer);
 
-    when(this.coverageDb.getCoveredLinesForClass(any(ClassName.class))).thenReturn(
-        Optional.of(this.classInfo));
+    when(this.coverageDb.getCodeLinesForClass(any(ClassName.class))).thenReturn(
+        this.classInfo);
 
     this.testee = new MutationHtmlReportListener(StandardCharsets.UTF_8, this.coverageDb,
         this.outputStrategy, Collections.<String>emptyList(), this.sourceLocator);

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTestSummaryDataTest.java
@@ -6,6 +6,7 @@ import org.pitest.coverage.ClassLines;
 import org.pitest.mutationtest.DetectionStatus;
 import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.MutationStatusTestPair;
+import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.gregor.MethodMutatorFactory;
 import org.pitest.mutationtest.engine.gregor.config.Mutator;
 
@@ -18,6 +19,8 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.pitest.mutationtest.LocationMother.aMutationId;
+import static org.pitest.mutationtest.engine.MutationDetailsMother.aMutationDetail;
 
 public class MutationTestSummaryDataTest {
 
@@ -100,9 +103,9 @@ public class MutationTestSummaryDataTest {
   @Test
   public void shouldReturnCorrectTestStrengthWhenAnalysedInOneUnit() {
     this.testee = buildSummaryDataWithMutationResults(makeClass(),
-            aMutationResult(DetectionStatus.NO_COVERAGE),
-            aMutationResult(DetectionStatus.KILLED),
-            aMutationResult(DetectionStatus.SURVIVED)
+            aMutationResult(DetectionStatus.NO_COVERAGE, "a"),
+            aMutationResult(DetectionStatus.KILLED, "b"),
+            aMutationResult(DetectionStatus.SURVIVED, "c")
     );
     assertEquals(50, this.testee.getTotals().getTestStrength());
   }
@@ -111,13 +114,13 @@ public class MutationTestSummaryDataTest {
   public void shouldReturnCorrectTestStrengthWhenAnalysedInTwoUnits() {
     ClassLines clazz = makeClass();
     this.testee = buildSummaryDataWithMutationResults(clazz,
-            aMutationResult(DetectionStatus.NO_COVERAGE),
-            aMutationResult(DetectionStatus.KILLED),
-            aMutationResult(DetectionStatus.SURVIVED)
+            aMutationResult(DetectionStatus.NO_COVERAGE, "a"),
+            aMutationResult(DetectionStatus.KILLED, "b"),
+            aMutationResult(DetectionStatus.SURVIVED, "c")
     );
     final MutationTestSummaryData additionalData = buildSummaryDataWithMutationResults(clazz,
-            aMutationResult(DetectionStatus.KILLED),
-            aMutationResult(DetectionStatus.KILLED)
+            aMutationResult(DetectionStatus.KILLED, "d"),
+            aMutationResult(DetectionStatus.KILLED, "e")
     );
     this.testee.add(additionalData);
     assertEquals(75, this.testee.getTotals().getTestStrength());
@@ -126,13 +129,13 @@ public class MutationTestSummaryDataTest {
   @Test
   public void shouldReturnCorrectTestStrengthWhenWhenCombiningResultsForDifferentClasses() {
     this.testee = buildSummaryDataWithMutationResults(makeClass(100),
-            aMutationResult(DetectionStatus.NO_COVERAGE),
-            aMutationResult(DetectionStatus.KILLED),
-            aMutationResult(DetectionStatus.SURVIVED)
+            aMutationResult(DetectionStatus.NO_COVERAGE, "a"),
+            aMutationResult(DetectionStatus.KILLED, "b"),
+            aMutationResult(DetectionStatus.SURVIVED, "c")
     );
     final MutationTestSummaryData additionalData = buildSummaryDataWithMutationResults(makeClass(200),
-            aMutationResult(DetectionStatus.KILLED),
-            aMutationResult(DetectionStatus.KILLED)
+            aMutationResult(DetectionStatus.KILLED, "d"),
+            aMutationResult(DetectionStatus.KILLED, "e")
     );
     this.testee.add(additionalData);
     assertEquals(75, this.testee.getTotals().getTestStrength());
@@ -182,7 +185,11 @@ public class MutationTestSummaryDataTest {
   }
 
   private MutationResult aMutationResult(DetectionStatus status) {
-    return new MutationResult(null, new MutationStatusTestPair(1, status, "A test"));
+    return new MutationResult(aMutationDetail().build(), new MutationStatusTestPair(1, status, "A test"));
+  }
+
+  private MutationResult aMutationResult(DetectionStatus status, String mutator) {
+    return new MutationResult(aMutationDetail().withId(aMutationId().withMutator(mutator)).build(), new MutationStatusTestPair(1, status, "A test"));
   }
 
   private MutationTestSummaryData buildSummaryDataMutators() {

--- a/pitest/src/main/java/org/pitest/mutationtest/DetectionStatus.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/DetectionStatus.java
@@ -67,6 +67,7 @@ public enum DetectionStatus {
    */
   NO_COVERAGE(false);
 
+
   private final boolean detected;
 
   DetectionStatus(final boolean detected) {

--- a/pitest/src/main/java/org/pitest/mutationtest/config/TestPluginArguments.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/config/TestPluginArguments.java
@@ -33,10 +33,6 @@ public class TestPluginArguments implements Serializable {
             Collections.emptyList(), false);
   }
 
-  public TestPluginArguments withTestPlugin(String plugin) {
-    return new TestPluginArguments(this.groupConfig, this.excludedRunners, this.includedTestMethods, this.skipFailingTests);
-  }
-
   public TestGroupConfig getGroupConfig() {
     return this.groupConfig;
   }


### PR DESCRIPTION
Adds new extension points to allow post analysis modification of coverage and mutation analysis results.

Extensions points have multiple potential uses, but first use case is supporting the 'un-inlining' of inlined kotlin functions.

Change requires alteration of existing interfaces which may be incompatible with some third party plugins.