### PR TITLE
report only target code lines

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -14,7 +14,6 @@
  */
 package org.pitest.mutationtest.tooling;
 
-import org.pitest.bytecode.analysis.ClassTree;
 import org.pitest.classinfo.CachingByteArraySource;
 import org.pitest.classinfo.ClassByteArraySource;
 import org.pitest.classinfo.ClassInfo;
@@ -201,8 +200,8 @@ public class MutationCoverage {
   }
 
   private CoverageSummary createSummary(ReportCoverage modifiedCoverage) {
-    int numberOfCodeLines = this.code.codeTrees()
-            .map(ClassTree::numberOfCodeLines)
+    int numberOfCodeLines = this.code.getCodeUnderTestNames().stream()
+            .map(c -> modifiedCoverage.getCodeLinesForClass(c).getNumberOfCodeLines())
             .reduce(0, Integer::sum);
 
     int coveredLines = this.code.getCodeUnderTestNames().stream()

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/tooling/MutationCoverageReportTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/tooling/MutationCoverageReportTest.java
@@ -41,6 +41,7 @@ import org.pitest.classinfo.ClassInfoMother;
 import org.pitest.classinfo.ClassName;
 import org.pitest.classinfo.HierarchicalClassId;
 import org.pitest.classpath.CodeSource;
+import org.pitest.coverage.ClassLines;
 import org.pitest.coverage.CoverageDatabase;
 import org.pitest.coverage.CoverageGenerator;
 import org.pitest.help.Help;
@@ -158,6 +159,7 @@ public class MutationCoverageReportTest {
         Collections.singleton(clazz));
     when(this.code.getClassInfo(anyCollection())).thenReturn(
         Collections.singletonList(foo));
+    when(this.coverageDb.getCodeLinesForClass(clazz)).thenReturn(new ClassLines(clazz, Collections.emptySet()));
 
     createAndRunTestee();
 
@@ -198,6 +200,7 @@ public class MutationCoverageReportTest {
     when(this.mutater.findMutations(foo)).thenReturn(aMutantIn(Foo.class));
     when(this.code.getCodeUnderTestNames()).thenReturn(
         Collections.singleton(foo));
+    when(this.coverageDb.getCodeLinesForClass(foo)).thenReturn(new ClassLines(foo, Collections.emptySet()));
     final CombinedStatistics actual = createAndRunTestee();
     assertEquals(1, actual.getMutationStatistics().getTotalMutations());
   }


### PR DESCRIPTION
Every line within a project was being treated as a codeline, resulting in very low coverage stats on the commandline when filters were applied.