### PR TITLE
Limit line coverage to only mutated classes

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
@@ -14,10 +14,13 @@
  */
 package org.pitest.mutationtest.statistics;
 
+import org.pitest.classinfo.ClassName;
+
 import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
+import java.util.Set;
 
 public final class MutationStatistics {
   private final Iterable<Score> scores;
@@ -26,13 +29,20 @@ public final class MutationStatistics {
   private final long totalDetected;
   private final long totalWithCoverage;
 
-  public MutationStatistics(Iterable<Score> scores, long totalMutations,
-                            long totalDetected, long totalWithCoverage, long numberOfTestsRun) {
+  private final Set<ClassName> mutatedClasses;
+
+  public MutationStatistics(Iterable<Score> scores,
+                            long totalMutations,
+                            long totalDetected,
+                            long totalWithCoverage,
+                            long numberOfTestsRun,
+                            Set<ClassName> mutatedClasses) {
     this.scores = scores;
     this.totalMutations = totalMutations;
     this.totalDetected = totalDetected;
     this.numberOfTestsRun = numberOfTestsRun;
     this.totalWithCoverage = totalWithCoverage;
+    this.mutatedClasses = mutatedClasses;
   }
 
   public Iterable<Score> getScores() {
@@ -57,6 +67,10 @@ public final class MutationStatistics {
 
   public long getTotalSurvivingMutations() {
     return getTotalMutations() - getTotalDetectedMutations();
+  }
+
+  public Set<ClassName> mutatedClasses() {
+    return mutatedClasses;
   }
 
   public long getPercentageDetected() {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsListener.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsListener.java
@@ -43,6 +43,7 @@ MutationStatisticsSource {
   }
 
   private void processMetaData(final ClassMutationResults value) {
+    this.mutatorScores.registerClass(value.getMutatedClass());
     this.mutatorScores.registerResults(value.getMutations());
   }
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsPrecursor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatisticsPrecursor.java
@@ -2,19 +2,31 @@ package org.pitest.mutationtest.statistics;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import org.pitest.classinfo.ClassName;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.MutationResult;
 
 class MutationStatisticsPrecursor {
   private final Map<String, ScorePrecursor> mutatorTotalMap  = new HashMap<>();
+  private final Set<ClassName> mutatedClasses = new HashSet<>();
   private long                              numberOfTestsRun = 0;
 
   public void registerResults(final Collection<MutationResult> results) {
     results.forEach(register());
+  }
+
+  public void registerClass(ClassName mutatedClass) {
+    mutatedClasses.add(mutatedClass);
+  }
+
+  public Set<ClassName> mutatedClasses() {
+    return mutatedClasses;
   }
 
   private Consumer<MutationResult> register() {
@@ -39,7 +51,7 @@ class MutationStatisticsPrecursor {
         .fold(addDetectedTotals(), 0L, scores);
     final long totalWithCoverage = FCollection.fold(addCoveredTotals(), 0L, scores);
     return new MutationStatistics(scores, totalMutations, totalDetected, totalWithCoverage,
-        this.numberOfTestsRun);
+        this.numberOfTestsRun, mutatedClasses());
   }
 
   Iterable<Score> getScores() {
@@ -58,4 +70,6 @@ class MutationStatisticsPrecursor {
   private static BiFunction<Long, Score, Long> addCoveredTotals() {
     return (a, b) -> a + b.getTotalWithCoverage();
   }
+
+
 }

--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -396,7 +396,7 @@ public class PitMojoTest extends BasePitMojoTest {
   private void setupCoverage(long mutationScore, int lines, int linesCovered)
       throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();
-    final MutationStatistics stats = new MutationStatistics(scores, 100, mutationScore, 100, 0);
+    final MutationStatistics stats = new MutationStatistics(scores, 100, mutationScore, 100, 0, Collections.emptySet());
     CoverageSummary sum = new CoverageSummary(lines, linesCovered);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(
@@ -408,7 +408,7 @@ public class PitMojoTest extends BasePitMojoTest {
   private void setupTestStrength(long totalMutations, long mutationDetected, long mutationsWithCoverage)
           throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();
-    final MutationStatistics stats = new MutationStatistics(scores, totalMutations, mutationDetected, mutationsWithCoverage, 0);
+    final MutationStatistics stats = new MutationStatistics(scores, totalMutations, mutationDetected, mutationsWithCoverage, 0, Collections.emptySet());
     CoverageSummary sum = new CoverageSummary(0, 0);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(
@@ -421,7 +421,7 @@ public class PitMojoTest extends BasePitMojoTest {
       throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();
     int detected = 100;
-    final MutationStatistics stats = new MutationStatistics(scores, detected + survivors, detected, detected + survivors, 0);
+    final MutationStatistics stats = new MutationStatistics(scores, detected + survivors, detected, detected + survivors, 0, Collections.emptySet());
     CoverageSummary sum = new CoverageSummary(0, 0);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(


### PR DESCRIPTION
The line coverage data displayed on the console includes all targetted code, while the figures shown in the report are implicitly limited to mutated classes. These causes constant confusion.

This change limits the console coverage to also include only mutated classes.