### PR TITLE
Auto add kotlin source dirs when present

### DIFF
--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -34,6 +34,7 @@ public class PitMojoTest extends BasePitMojoTest {
     super.setUp();
 
     when(this.project.getExecutionProject()).thenReturn(executionProject);
+    when(this.project.getBasedir()).thenReturn(new File("BASEDIR"));
     when(this.executionProject.getBasedir()).thenReturn(new File("BASEDIR"));
   }
 


### PR DESCRIPTION
The jetbrains kotlin plugin doesn't seem to use the source dirs configured in the maven model. Many projects will therefore not have them properly configured. This hack ensures pitest picks them up if they are present.