### PR TITLE
Prevent double instantiation of features

### DIFF
--- a/pitest/src/main/java/org/pitest/plugin/FeatureSelector.java
+++ b/pitest/src/main/java/org/pitest/plugin/FeatureSelector.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -34,15 +35,15 @@ public class FeatureSelector<T extends ProvidesFeature> {
   }
 
   private List<T> selectFeatures(List<FeatureSetting> features, Collection<T> filters) {
-    final List<T> factories = new ArrayList<>(filters);
-    final Map<String, Collection<T>> featureMap = FCollection.bucket(factories, byFeatureName());
+    List<T> factories = new ArrayList<>(filters);
+    Map<String, Collection<T>> featureMap = FCollection.bucket(factories, byFeatureName());
 
-    final List<T> active = factories.stream()
+    Set<T> active = factories.stream()
             .filter(isOnByDefault())
-            .collect(Collectors.toCollection(ArrayList::new));
+            .collect(Collectors.toSet());
 
-    for ( final FeatureSetting each : features ) {
-      final Collection<T> providers = featureMap.get(each.feature().toLowerCase());
+    for (FeatureSetting each : features) {
+      Collection<T> providers = featureMap.get(each.feature().toLowerCase());
       if ((providers == null) || providers.isEmpty()) {
         continue;
       }
@@ -59,7 +60,8 @@ public class FeatureSelector<T extends ProvidesFeature> {
       }
     }
 
-    return active;
+    return active.stream()
+            .collect(Collectors.toList());
   }
 
   private Predicate<T> isOnByDefault() {

--- a/pitest/src/test/java/org/pitest/plugin/FeatureSelectorTest.java
+++ b/pitest/src/test/java/org/pitest/plugin/FeatureSelectorTest.java
@@ -78,6 +78,14 @@ public class FeatureSelectorTest {
     assertThat(this.testee.getSettingForFeature("FOO")).isEqualTo(fooConfig);
   }
 
+  @Test
+  public void doesNotDuplicateFeatures() {
+    final FeatureSetting fooConfig = new FeatureSetting("foo", ToggleStatus.ACTIVATE,  new HashMap<>());
+    this.testee = new FeatureSelector<>(Arrays.asList(fooConfig), features(this.onByDefault));
+
+    assertThat(this.testee.getActiveFeatures()).hasSize(1);
+  }
+
   private List<FeatureSetting> noSettings() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
Configuring an on by default feature caused a 2nd instance to be created.