### PR TITLE
improve for each filter performance

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
@@ -191,11 +191,6 @@ public class ForEachLoopFilter implements MutationInterceptor {
       final int instruction = a.getInstructionIndex();
       final MethodTree method = currentClass.method(a.getId().getLocation()).get();
 
-      //performance hack
-      if (!mightContainForLoop(method.instructions())) {
-        return false;
-      }
-
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);
 
       Set<AbstractInsnNode> toAvoid = cache.computeIfAbsent(method, this::findLoopInstructions);
@@ -209,11 +204,6 @@ public class ForEachLoopFilter implements MutationInterceptor {
     return ITERATOR_LOOP.contextMatches(method.instructions(), context).stream()
             .flatMap(c -> c.retrieve(LOOP_INSTRUCTIONS.read()).get().stream())
             .collect(Collectors.toSet());
-  }
-
-  private boolean mightContainForLoop(List<AbstractInsnNode> instructions) {
-    return instructions.stream()
-            .anyMatch(hasNextMethodCall().or(ARRAYLENGTH).asPredicate());
   }
 
   @Override


### PR DESCRIPTION
Hack to avoid nfa degraded performance when large methods were present as it prevented use of the cache.