### PR TITLE
fix: quote killingTest in CSV report

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/csv/CSVReportListener.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/csv/CSVReportListener.java
@@ -37,7 +37,7 @@ public class CSVReportListener implements MutationResultListener {
   }
 
   private String createKillingTestDesc(final Optional<String> killingTest) {
-    return killingTest.orElse("none");
+    return (killingTest.isPresent()) ? String.format("\"%s\"", killingTest.get()) : "none";
   }
 
   private String makeCsv(final Object... os) {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/csv/CSVReportListener.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/csv/CSVReportListener.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.Writer;
 
 import java.util.Optional;
+
+import org.apache.commons.text.StringEscapeUtils;
 import org.pitest.mutationtest.ClassMutationResults;
 import org.pitest.mutationtest.MutationResult;
 import org.pitest.mutationtest.MutationResultListener;
@@ -37,7 +39,7 @@ public class CSVReportListener implements MutationResultListener {
   }
 
   private String createKillingTestDesc(final Optional<String> killingTest) {
-    return (killingTest.isPresent()) ? String.format("\"%s\"", killingTest.get()) : "none";
+    return (killingTest.isPresent()) ? StringEscapeUtils.escapeCsv(killingTest.get()) : "none";
   }
 
   private String makeCsv(final Object... os) {

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/csv/CSVReportListenerTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/csv/CSVReportListenerTest.java
@@ -47,10 +47,10 @@ public class CSVReportListenerTest {
   public void shouldOutputKillingTestWhenOneFound() throws IOException {
     final MutationResult mr = new MutationResult(
         MutationTestResultMother.createDetails(), new MutationStatusTestPair(1,
-            DetectionStatus.KILLED, "foo"));
+            DetectionStatus.KILLED, "foo(java.lang.String, java.lang.String)"));
     this.testee.handleMutationResult(MutationTestResultMother
         .createClassResults(mr));
-    final String expected = "file,clazz,mutator,method,42,KILLED,foo"
+    final String expected = "file,clazz,mutator,method,42,KILLED,\"foo(java.lang.String, java.lang.String)\""
         + NEW_LINE;
     verify(this.out).write(expected);
   }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/csv/CSVReportListenerTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/csv/CSVReportListenerTest.java
@@ -47,11 +47,23 @@ public class CSVReportListenerTest {
   public void shouldOutputKillingTestWhenOneFound() throws IOException {
     final MutationResult mr = new MutationResult(
         MutationTestResultMother.createDetails(), new MutationStatusTestPair(1,
-            DetectionStatus.KILLED, "foo(java.lang.String, java.lang.String)"));
+            DetectionStatus.KILLED, "foo"));
     this.testee.handleMutationResult(MutationTestResultMother
         .createClassResults(mr));
-    final String expected = "file,clazz,mutator,method,42,KILLED,\"foo(java.lang.String, java.lang.String)\""
+    final String expected = "file,clazz,mutator,method,42,KILLED,foo"
         + NEW_LINE;
+    verify(this.out).write(expected);
+  }
+
+  @Test
+  public void shouldQuoteKillingTestWhenNeeded() throws IOException {
+    final MutationResult mr = new MutationResult(
+            MutationTestResultMother.createDetails(), new MutationStatusTestPair(1,
+            DetectionStatus.KILLED, "foo(java.lang.String, java.lang.String)"));
+    this.testee.handleMutationResult(MutationTestResultMother
+            .createClassResults(mr));
+    final String expected = "file,clazz,mutator,method,42,KILLED,\"foo(java.lang.String, java.lang.String)\""
+            + NEW_LINE;
     verify(this.out).write(expected);
   }
 


### PR DESCRIPTION
This is a possible solution for #1178.  
It quotes the `killingTest` before writing to CSV report.

Fixes #1178 