### PR TITLE
use classpath jar when classpath file provided

### DIFF
--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -534,6 +534,7 @@ public class OptionsParser {
         LOG.warning("Unable to read class path file:" + userArgs.valueOf(this.classPathFile).getAbsolutePath() + " - "
                 + ioe.getMessage());
       }
+      data.setUseClasspathJar(true);
     }
     elements.addAll(userArgs.valuesOf(this.additionalClassPathSpec));
     data.setClassPathElements(elements);

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -326,6 +326,15 @@ public class OptionsParserTest {
   }
 
   @Test
+  public void alsoSetsUseClasspathJarWhenClasspathFileProvided() {
+    final ClassLoader classLoader = getClass().getClassLoader();
+    final File classPathFile = new File(classLoader.getResource("testClassPathFile.txt").getFile());
+    final ReportOptions ro = parseAddingRequiredArgs("--classPathFile",
+            classPathFile.getAbsolutePath());
+    assertThat(ro.useClasspathJar()).isTrue();
+  }
+
+  @Test
   public void shouldDetermineIfFailWhenNoMutationsFlagIsSet() {
     assertTrue(parseAddingRequiredArgs("--failWhenNoMutations", "true")
         .shouldFailWhenNoMutations());


### PR DESCRIPTION
The gradle plugin uses a classpath file to communicate with pitest when the user classpath is too large to pass on the commandline line. In this scenario the same issue is highly likely to be encountered when pitest launches processes.

This change auto sets the classpath jar flag when a classpath file is supplied to avoid the user having to set two parameters.