### PR TITLE
Enable annotation mutations

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/RegionInterceptor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/RegionInterceptor.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -44,9 +45,13 @@ public abstract class RegionInterceptor implements MutationInterceptor {
     private Predicate<MutationDetails> buildPredicate() {
         return a -> {
             final int instruction = a.getInstructionIndex();
-            final MethodTree method = this.currentClass.method(a.getId().getLocation()).get();
+            final Optional<MethodTree> method = this.currentClass.method(a.getId().getLocation());
 
-            List<RegionIndex> regions = cache.computeIfAbsent(method, this::computeRegionIndex);
+            if (!method.isPresent()) {
+                return false;
+            }
+
+            List<RegionIndex> regions = cache.computeIfAbsent(method.get(), this::computeRegionIndex);
             return regions.stream()
                     .anyMatch(r -> r.start() <= instruction && r.end() >= instruction);
         };

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
@@ -28,6 +28,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -189,7 +190,11 @@ public class ForEachLoopFilter implements MutationInterceptor {
   private Predicate<MutationDetails> mutatesIteratorLoopPlumbing() {
     return a -> {
       final int instruction = a.getInstructionIndex();
-      final MethodTree method = currentClass.method(a.getId().getLocation()).get();
+      final Optional<MethodTree> maybeMethod = currentClass.method(a.getId().getLocation());
+      if (!maybeMethod.isPresent()) {
+        return false;
+      }
+      MethodTree method = maybeMethod.get();
 
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/InlinedFinallyBlockFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/InlinedFinallyBlockFilter.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Logger;
@@ -170,7 +171,11 @@ public class InlinedFinallyBlockFilter implements MutationInterceptor {
 
 
   private boolean isInFinallyBlock(MutationDetails m) {
-    MethodTree method = currentClass.method(m.getId().getLocation()).get();
+    Optional<MethodTree> maybeMethod = currentClass.method(m.getId().getLocation());
+    if (!maybeMethod.isPresent()) {
+      return false;
+    }
+    MethodTree method = maybeMethod.get();
     List<LabelNode> handlers = method.rawNode().tryCatchBlocks.stream()
             .filter(t -> t.type == null)
             .map(t -> t.handler)

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
@@ -159,7 +159,12 @@ public class AvoidForLoopCounterFilter implements MutationInterceptor {
   private Predicate<MutationDetails> mutatesAForLoopCounter() {
     return a -> {
       final int instruction = a.getInstructionIndex();
-      final MethodTree method = AvoidForLoopCounterFilter.this.currentClass.method(a.getId().getLocation()).get();
+      Optional<MethodTree> maybeMethod = AvoidForLoopCounterFilter.this.currentClass.method(a.getId().getLocation());
+      if (!maybeMethod.isPresent()) {
+        return false;
+      }
+      MethodTree method = maybeMethod.get();
+
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);
 
       // performance hack

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
@@ -55,8 +55,11 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
   private Collection<MutationDetails> findTimeoutMutants(Location location,
       Collection<MutationDetails> mutations, Mutater m) {
 
-    final MethodTree method = this.currentClass.method(location)
-        .get();
+    final Optional<MethodTree> maybeMethod = this.currentClass.method(location);
+    if (!maybeMethod.isPresent()) {
+      return Collections.emptyList();
+    }
+    MethodTree method = maybeMethod.get();
 
     //  give up if our matcher thinks loop is already infinite
     if (infiniteLoopMatcher().matches(method.instructions())) {
@@ -64,7 +67,7 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
     }
 
     final List<MutationDetails> timeouts = new ArrayList<>();
-    for ( final MutationDetails each : mutations ) {
+    for (final MutationDetails each : mutations) {
       // avoid cost of static analysis by first checking mutant is on
       // on instruction that could affect looping
       if (couldCauseInfiniteLoop(method, each) && isInfiniteLoop(each,m) ) {

--- a/pitest/src/main/java/org/pitest/bytecode/ASMVersion.java
+++ b/pitest/src/main/java/org/pitest/bytecode/ASMVersion.java
@@ -4,4 +4,13 @@ import org.objectweb.asm.Opcodes;
 
 public class ASMVersion {
   public static final int ASM_VERSION = Opcodes.ASM9;
+
+  /**
+   * Provide the asm version via a method call so third party plugins built against pitest
+   * will receive the current asm version instead of one inlined at build time
+   * @return asm version
+   */
+  public static int asmVersion() {
+    return ASM_VERSION;
+  }
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AnnotationInfo.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/AnnotationInfo.java
@@ -1,0 +1,19 @@
+package org.pitest.mutationtest.engine.gregor;
+
+public class AnnotationInfo {
+    private final String descriptor;
+    private final boolean visible;
+
+    public AnnotationInfo(String descriptor, boolean visible) {
+        this.descriptor = descriptor;
+        this.visible = visible;
+    }
+
+    public String descriptor() {
+        return descriptor;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/BasicContext.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/BasicContext.java
@@ -1,0 +1,12 @@
+package org.pitest.mutationtest.engine.gregor;
+
+import org.pitest.mutationtest.engine.MutationIdentifier;
+
+public interface BasicContext {
+
+    ClassInfo getClassInfo();
+
+    void registerMutation(MutationIdentifier id, String description);
+
+    boolean shouldMutate(MutationIdentifier newId);
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/FieldInfo.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/FieldInfo.java
@@ -1,0 +1,37 @@
+package org.pitest.mutationtest.engine.gregor;
+
+public class FieldInfo {
+    private final int access;
+    private final String name;
+    private final String descriptor;
+    private final String signature;
+    private final Object value;
+
+    public FieldInfo(int access, String name, String descriptor, String signature, Object value) {
+        this.access = access;
+        this.name = name;
+        this.descriptor = descriptor;
+        this.signature = signature;
+        this.value = value;
+    }
+
+    public int access() {
+        return access;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String descriptor() {
+        return descriptor;
+    }
+
+    public String signature() {
+        return signature;
+    }
+
+    public Object value() {
+        return value;
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodInfo.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodInfo.java
@@ -48,6 +48,10 @@ public class MethodInfo {
     return this.methodDescriptor;
   }
 
+  public ClassInfo getOwningClass() {
+    return this.owningClass;
+  }
+
   public int getAccess() {
     return this.access;
   }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutatorFactory.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutatorFactory.java
@@ -14,16 +14,19 @@
  */
 package org.pitest.mutationtest.engine.gregor;
 
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.pitest.mutationtest.engine.MutationIdentifier;
 import org.pitest.plugin.ClientClasspathPlugin;
 
 /**
  * A <code>MethodMutatorFactory</code> is a factory creating method mutating
- * method visitors. Those method visitors will serve two purposes: finding new
+ * visitors. These visitors will serve two purposes: finding new
  * mutation points (locations in byte code where mutations can be applied) and
  * applying those mutations to the byte code.
  *
+ * Name of this class is misleading as it is capable of mutating both methods
+ * and field, but it is retained for historic reasons.
  *
  * <p>
  * A <code>MethodMutatorFactory</code> will have a globally unique id and must
@@ -36,8 +39,14 @@ import org.pitest.plugin.ClientClasspathPlugin;
  */
 public interface MethodMutatorFactory extends ClientClasspathPlugin {
 
-  MethodVisitor create(MutationContext context,
-      MethodInfo methodInfo, MethodVisitor methodVisitor);
+  default MethodVisitor create(MutationContext context,
+      MethodInfo methodInfo, MethodVisitor methodVisitor) {
+    return null;
+  }
+
+  default FieldVisitor createForField(ClassContext context, FieldInfo fieldInfo, FieldVisitor fieldVisitor) {
+    return null;
+  }
 
   String getGloballyUniqueId();
 

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutatorFactory.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MethodMutatorFactory.java
@@ -14,6 +14,7 @@
  */
 package org.pitest.mutationtest.engine.gregor;
 
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.pitest.mutationtest.engine.MutationIdentifier;
@@ -25,7 +26,7 @@ import org.pitest.plugin.ClientClasspathPlugin;
  * mutation points (locations in byte code where mutations can be applied) and
  * applying those mutations to the byte code.
  *
- * Name of this class is misleading as it is capable of mutating both methods
+ * Name of this class is misleading as it is capable of mutating methods, annotations
  * and field, but it is retained for historic reasons.
  *
  * <p>
@@ -44,7 +45,12 @@ public interface MethodMutatorFactory extends ClientClasspathPlugin {
     return null;
   }
 
-  default FieldVisitor createForField(ClassContext context, FieldInfo fieldInfo, FieldVisitor fieldVisitor) {
+
+  default AnnotationVisitor createForAnnotation(NoMethodContext context, AnnotationInfo annotationInfo, AnnotationVisitor next) {
+    return null;
+  }
+
+  default FieldVisitor createForField(NoMethodContext context, FieldInfo fieldInfo, FieldVisitor fieldVisitor) {
     return null;
   }
 

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutationContext.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/MutationContext.java
@@ -3,17 +3,10 @@ package org.pitest.mutationtest.engine.gregor;
 import org.pitest.mutationtest.engine.MutationIdentifier;
 import org.pitest.mutationtest.engine.gregor.blocks.BlockCounter;
 
-public interface MutationContext extends BlockCounter {
+public interface MutationContext extends BasicContext, BlockCounter {
 
   void registerCurrentLine(int line);
 
-  ClassInfo getClassInfo();
-
   MutationIdentifier registerMutation(MethodMutatorFactory factory,
       String description);
-
-  void registerMutation(MutationIdentifier id, String description);
-
-  boolean shouldMutate(MutationIdentifier newId);
-
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/NoMethodContext.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/engine/gregor/NoMethodContext.java
@@ -1,0 +1,32 @@
+package org.pitest.mutationtest.engine.gregor;
+
+import org.pitest.mutationtest.engine.MutationDetails;
+import org.pitest.mutationtest.engine.MutationIdentifier;
+
+public class NoMethodContext implements BasicContext {
+
+    private final ClassContext context;
+
+    public NoMethodContext(ClassContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public ClassInfo getClassInfo() {
+        return context.getClassInfo();
+    }
+
+    @Override
+    public void registerMutation(MutationIdentifier id, String description) {
+        registerMutation(new MutationDetails(id, context.getFileName(), description,0, 1));
+    }
+
+    @Override
+    public boolean shouldMutate(MutationIdentifier id) {
+        return this.context.shouldMutate(id);
+    }
+
+    private void registerMutation(MutationDetails details) {
+        this.context.addMutation(details);
+    }
+}


### PR DESCRIPTION
Introduces extensions points to make field mutation possible via third party plugins. Doing so remains challenging due to the need to understand and hook into the frameworks that read the modified annotations.