### PR TITLE
feat: ignore absent ReportAggregatorBuilder files

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -159,7 +159,11 @@ public final class ReportAggregator {
 
     public Builder addLineCoverageFile(final File lineCoverageFile) {
       validateFile(lineCoverageFile);
-      this.lineCoverageFiles.add(lineCoverageFile);
+      if (lineCoverageFile.exists()) {
+        this.lineCoverageFiles.add(lineCoverageFile);
+      } else {
+        LOG.info("ignoring absent line coverage file " + lineCoverageFile.getAbsolutePath());
+      }
       return this;
     }
 
@@ -173,7 +177,11 @@ public final class ReportAggregator {
 
     public Builder addMutationResultsFile(final File mutationResultsFile) {
       validateFile(mutationResultsFile);
-      this.mutationResultsFiles.add(mutationResultsFile);
+      if (mutationResultsFile.exists()) {
+        this.mutationResultsFiles.add(mutationResultsFile);
+      } else {
+        LOG.info("ignoring absent mutation results file " + mutationResultsFile.getAbsolutePath());
+      }
       return this;
     }
 
@@ -273,8 +281,9 @@ public final class ReportAggregator {
       if (file == null) {
         throw new IllegalArgumentException("file is null");
       }
-      if (!file.exists() || !file.isFile()) {
-        throw new IllegalArgumentException(file.getAbsolutePath() + " does not exist or is not a file");
+      // a non existent file shouldn't prevent the aggregator from being built
+      if (file.exists() && !file.isFile()) {
+        throw new IllegalArgumentException(file.getAbsolutePath() + "is not a file");
       }
     }
 

--- a/pitest-aggregator/src/test/java/org/pitest/aggregate/ReportAggregatorBuilderTest.java
+++ b/pitest-aggregator/src/test/java/org/pitest/aggregate/ReportAggregatorBuilderTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.ExpectedException;
 
 public class ReportAggregatorBuilderTest {
 
-  private static final String NOT_A_FILE = "does not exist or is not a file";
+  private static final String NOT_A_FILE = "is not a file";
   private static final String NOT_A_DIR  = "is not a directory";
   private static final String IS_NULL    = "is null";
   @Rule
@@ -38,10 +38,10 @@ public class ReportAggregatorBuilderTest {
 
   @Test
   public void testLineCoverageFiles_withFake() {
-    this.expected.expect(IllegalArgumentException.class);
-    this.expected.expectMessage(Matchers.containsString(NOT_A_FILE));
+    ReportAggregator.Builder builder = ReportAggregator.builder()
+        .lineCoverageFiles(Arrays.asList(new File("doesnotexist.xml")));
 
-    ReportAggregator.builder().lineCoverageFiles(Arrays.asList(new File("doesnotexist.xml")));
+    assertTrue(builder.getMutationResultsFiles().isEmpty());
   }
 
   @Test
@@ -62,10 +62,10 @@ public class ReportAggregatorBuilderTest {
 
   @Test
   public void testMutationResultsFiles_withFake() {
-    this.expected.expect(IllegalArgumentException.class);
-    this.expected.expectMessage(Matchers.containsString(NOT_A_FILE));
+    ReportAggregator.Builder builder = ReportAggregator.builder()
+        .mutationResultsFiles(Arrays.asList(new File("doesnotexist.xml")));
 
-    ReportAggregator.builder().mutationResultsFiles(Arrays.asList(new File("doesnotexist.xml")));
+    assertTrue(builder.getMutationResultsFiles().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### Summary
Similar to #466, when using the gradle-pitest-plugin it is possible to end up in a scenario where `linecoverage.xml` and `mutations.xml` file paths are sent to the `ReportAggregatorBuilder` but they do not actually exist.

An example of this would be where you have a multi module project with some nested sub modules:

```
sub-module/
    nested-module-a/
        src/
            main/
                ...
            test/
                ...
        build.gradle
    nested-module-b/
        src/
            main/
                ...
            test/
                ...
        build.gradle
build.gradle
```

The sub-module does not have a build.gradle, code, or tests, yet the plugin passes the file paths to the builder as if they did exist.
       
### Proposed Solution
I am proposing that the ReportAggregatorBuilder could log the missing files instead of raising an error. This would allow the aggregation to continue in cases such as the above, but still inform users of the missing output in case it was unexpected. 

I would welcome your thoughts on the above in case it has any unintended side effects.
