### PR TITLE
Support glob pattern **. to match zero or more packages

### DIFF
--- a/pitest/src/main/java/org/pitest/util/Glob.java
+++ b/pitest/src/main/java/org/pitest/util/Glob.java
@@ -25,6 +25,9 @@ public class Glob implements Predicate<String> {
 
   private final Pattern regex;
 
+  private static final String ZERO_OR_MORE_PACKAGES      = "(?:.*\\.)*";
+  private static final String DOUBLE_STAR_PACKAGE_MARKER = "#%#%#";
+
   public Glob(final String glob) {
     String rectifiedGlob;
     if (glob.startsWith("~")) {
@@ -50,9 +53,10 @@ public class Glob implements Predicate<String> {
   }
 
   private static String convertGlobToRegex(final String glob) {
+    final String preparedGlob = glob.replace("**.", DOUBLE_STAR_PACKAGE_MARKER);
     final StringBuilder out = new StringBuilder("^");
-    for (int i = 0; i < glob.length(); ++i) {
-      final char c = glob.charAt(i);
+    for (int i = 0; i < preparedGlob.length(); ++i) {
+      final char c = preparedGlob.charAt(i);
       switch (c) {
       case '$':
         out.append("\\$");
@@ -74,7 +78,8 @@ public class Glob implements Predicate<String> {
       }
     }
     out.append('$');
-    return out.toString();
+    return out.toString()
+        .replace(DOUBLE_STAR_PACKAGE_MARKER, ZERO_OR_MORE_PACKAGES);
   }
 
   @Override

--- a/pitest/src/test/java/org/pitest/util/GlobTest.java
+++ b/pitest/src/test/java/org/pitest/util/GlobTest.java
@@ -82,4 +82,17 @@ public class GlobTest {
     assertFalse(glob.matches("foo-Bar-car"));
   }
 
+  @Test
+  public void shouldSupportDoubleStarPackageMatcher() {
+    final Glob glob = new Glob("**.databinding.**.Foo");
+    assertTrue(glob.matches("databinding.Foo"));
+    assertTrue(glob.matches("databinding.bar.Foo"));
+    assertTrue(glob.matches("databinding.bar.car.Foo"));
+    assertTrue(glob.matches("foo.databinding.Foo"));
+    assertTrue(glob.matches("foo.car.databinding.bar.Foo"));
+    assertTrue(glob.matches(".databinding.Foo"));
+    assertFalse(glob.matches("databindingfoo.Foo"));
+    assertFalse(glob.matches("foodatabinding.Foo"));
+    assertFalse(glob.matches("databinding.fooFoo"));
+  }
 }


### PR DESCRIPTION
Fixes #1144

Currently it is not possible to write a glob that matches zero or more packages. This PR introduces the well-kown doube-star matcher to enable this:

`**.databinding.**.Foo` 
* matches `databinding.Foo`
* matches `foo.car.databinding.bar.Foo`
* NOT matches `databindingfoo.Foo`