### PR TITLE
Auto add junit-platform-launcher to classpath

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
@@ -3,6 +3,9 @@ package org.pitest.maven;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.aether.RepositorySystem;
+
+import javax.inject.Inject;
 
 /**
  * Goal which runs a coverage mutation report
@@ -13,4 +16,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
       threadSafe = true)
 public class PitMojo extends AbstractPitMojo {
 
+    @Inject
+    public PitMojo(RepositorySystem repositorySystem) {
+        super(repositorySystem);
+    }
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
@@ -33,10 +33,13 @@ import org.apache.maven.scm.command.status.StatusScmResult;
 import org.apache.maven.scm.manager.ScmManager;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.RepositorySystem;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.config.PluginServices;
 import org.pitest.mutationtest.config.ReportOptions;
 import org.pitest.mutationtest.tooling.CombinedStatistics;
+
+import javax.inject.Inject;
 
 /**
  * Goal which runs a coverage mutation report only for files that have been
@@ -96,16 +99,20 @@ public class ScmMojo extends AbstractPitMojo {
   @Parameter(property = "scmRootDir", defaultValue = "${project.parent.basedir}")
   private File            scmRootDir;
 
-  public ScmMojo(final RunPitStrategy executionStrategy,
-                 final ScmManager manager, Predicate<Artifact> filter,
-                 PluginServices plugins, boolean analyseLastCommit, Predicate<MavenProject> nonEmptyProjectCheck) {
-    super(executionStrategy, filter, plugins, nonEmptyProjectCheck);
+  public ScmMojo(RunPitStrategy executionStrategy,
+                 ScmManager manager, Predicate<Artifact> filter,
+                 PluginServices plugins,
+                 boolean analyseLastCommit,
+                 Predicate<MavenProject> nonEmptyProjectCheck,
+                 RepositorySystem repositorySystem) {
+    super(executionStrategy, filter, plugins, nonEmptyProjectCheck, repositorySystem);
     this.manager = manager;
     this.analyseLastCommit = analyseLastCommit;
   }
 
-  public ScmMojo() {
-
+  @Inject
+  public ScmMojo(RepositorySystem repositorySystem) {
+    super(repositorySystem);
   }
 
   @Override

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -97,7 +97,7 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
   protected AbstractPitMojo createPITMojo(final String config) throws Exception {
     final AbstractPitMojo pitMojo = new AbstractPitMojo(this.executionStrategy, this.filter,
-        this.plugins, p -> true);
+        this.plugins, p -> true, null);
     configurePitMojo(pitMojo, config);
     return pitMojo;
   }

--- a/pitest-maven/src/test/java/org/pitest/maven/ScmMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/ScmMojoTest.java
@@ -53,7 +53,7 @@ public class ScmMojoTest extends BasePitMojoTest {
   public void setUp() throws Exception {
     super.setUp();
     this.testee = new ScmMojo(this.executionStrategy, this.manager,
-        this.filter, this.plugins, false,  i -> true);
+        this.filter, this.plugins, false,  i -> true, null);
     this.testee.setScmRootDir(new File("foo"));
     when(this.project.getBuild()).thenReturn(this.build);
     when(this.project.getParent()).thenReturn(null);


### PR DESCRIPTION
The pitest minions require a version of the junit-platform-launcher which matches the version of junit 5 used by the SUT. Previously this was provided by the cludge of shading it into the junit5 plugin, but this causes constant headaches with version mismatched.

This change pulls in a matching version of platform-launcher in the same manner that surefire does. It also allows junit dependencies to be explicitly included pitest config should this resolution give the wrong results.