### PR TITLE
Use unified percentage calculation logic

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
@@ -1,5 +1,7 @@
 package org.pitest.coverage;
 
+import static org.pitest.util.PercentageCalculator.getPercentage;
+
 /**
  * Basic summary of line coverage data
  */
@@ -22,8 +24,7 @@ public final class CoverageSummary {
   }
 
   public int getCoverage() {
-    return this.numberOfLines == 0 ? 100 : Math
-        .round((100f * this.numberOfCoveredLines) / this.numberOfLines);
+    return getPercentage(numberOfLines, numberOfCoveredLines);
   }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
@@ -22,6 +22,8 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import java.util.Set;
 
+import static org.pitest.util.PercentageCalculator.getPercentage;
+
 public final class MutationStatistics {
   private final Iterable<Score> scores;
   private final long totalMutations;
@@ -73,21 +75,8 @@ public final class MutationStatistics {
     return mutatedClasses;
   }
 
-  public long getPercentageDetected() {
-    if (getTotalMutations() == 0) {
-      return 100;
-    }
-
-    if (getTotalDetectedMutations() == 0) {
-      return 0;
-    }
-
-    if (getTotalMutations() == getTotalDetectedMutations()) {
-      return 100;
-    }
-
-    return Math.min(99, Math.round((100f / getTotalMutations())
-        * getTotalDetectedMutations()));
+  public int getPercentageDetected() {
+    return getPercentage(getTotalMutations(), getTotalDetectedMutations());
   }
 
   public void report(final PrintStream out) {
@@ -98,7 +87,7 @@ public final class MutationStatistics {
             + ". Test strength " + this.getTestStrength() + "%");
     out.println(">> Ran " + this.numberOfTestsRun + " tests ("
         + getTestsPerMutation() + " tests per mutation)");
-    
+
     out.println("Enhanced functionality available at https://www.arcmutate.com/");
   }
 
@@ -113,16 +102,7 @@ public final class MutationStatistics {
         .format(testsPerMutation);
   }
 
-  public long getTestStrength() {
-    if (getTotalMutations() == 0) {
-      return 100;
-    }
-
-    if (getTotalMutationsWithCoverage() == 0) {
-      return 0;
-    }
-
-    return Math.round((100f / getTotalMutationsWithCoverage())
-            * getTotalDetectedMutations());
+  public int getTestStrength() {
+    return getPercentage(getTotalMutationsWithCoverage(), getTotalDetectedMutations());
   }
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
@@ -16,6 +16,8 @@ package org.pitest.mutationtest.statistics;
 
 import java.io.PrintStream;
 
+import static org.pitest.util.PercentageCalculator.getPercentage;
+
 public final class Score {
 
   private final String                mutatorName;
@@ -67,16 +69,7 @@ public final class Score {
   }
 
   public int getPercentageDetected() {
-    if (getTotalMutations() == 0) {
-      return 100;
-    }
-
-    if (getTotalDetectedMutations() == 0) {
-      return 0;
-    }
-
-    return Math.round((100f / getTotalMutations())
-        * getTotalDetectedMutations());
+    return getPercentage(getTotalMutations(), getTotalDetectedMutations());
   }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/util/PercentageCalculator.java
+++ b/pitest-entry/src/main/java/org/pitest/util/PercentageCalculator.java
@@ -1,0 +1,19 @@
+package org.pitest.util;
+
+public class PercentageCalculator {
+  public static int getPercentage(long total, long actual) {
+    if (total == 0) {
+      return 100;
+    }
+
+    if (actual == 0) {
+      return 0;
+    }
+
+    if (total == actual) {
+      return 100;
+    }
+
+    return Math.min(99, Math.round((100f / total) * actual));
+  }
+}

--- a/pitest-entry/src/test/java/org/pitest/util/PercentageCalculatorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/util/PercentageCalculatorTest.java
@@ -1,0 +1,23 @@
+package org.pitest.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.pitest.util.PercentageCalculator.getPercentage;
+
+public class PercentageCalculatorTest {
+  @Test
+  public void shouldNotHaveHundredPercentIfNotAll() {
+    assertEquals(99, getPercentage(2000, 1999));
+  }
+
+  @Test
+  public void shouldHaveHundredPercentIfAll() {
+    assertEquals(100, getPercentage(2000, 2000));
+  }
+
+  @Test
+  public void shouldHaveHundredPercentIfNoTotal() {
+    assertEquals(100, getPercentage(0, 0));
+  }
+}

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -1,5 +1,7 @@
 package org.pitest.mutationtest.report.html;
 
+import static org.pitest.util.PercentageCalculator.getPercentage;
+
 public class MutationTotals {
 
   private long numberOfFiles                 = 0;
@@ -50,14 +52,11 @@ public class MutationTotals {
   }
 
   public int getLineCoverage() {
-    return this.numberOfLines == 0 ? 100 : Math
-        .round((100f * this.numberOfLinesCovered) / this.numberOfLines);
+    return getPercentage(numberOfLines, numberOfLinesCovered);
   }
 
   public int getMutationCoverage() {
-    return this.numberOfMutations == 0 ? 100
-        : Math.round((100f * this.numberOfMutationsDetected)
-            / this.numberOfMutations);
+    return getPercentage(numberOfMutations, numberOfMutationsDetected);
   }
 
   public void addMutationsWithCoverage(final long mutationsWithCoverage) {
@@ -65,9 +64,7 @@ public class MutationTotals {
   }
 
   public int getTestStrength() {
-    return this.numberOfMutationsWithCoverage == 0 ? 0
-            : Math.round((100f * this.numberOfMutationsDetected)
-            / this.numberOfMutationsWithCoverage);
+    return getPercentage(numberOfMutationsWithCoverage, numberOfMutationsDetected);
   }
 
   public long getNumberOfMutationsWithCoverage() {

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
@@ -66,19 +66,13 @@ public class MutationTotalsTest {
 
   @Test
   public void shouldCorrectlyCalculateTestStrengthWhenNoMutationsPresent() {
-    assertEquals(0, this.testee.getTestStrength());
+    assertEquals(100, this.testee.getTestStrength());
   }
 
   @Test
   public void shouldCorrectlyCalculateTestStrengthWhenNoMutationsDetected() {
     this.testee.addMutations(100);
-    assertEquals(0, this.testee.getTestStrength());
-  }
-
-  @Test
-  public void shouldCorrectlyCalculateTestStrengthWhenAllMutationsWithNoCoverage() {
-    this.testee.addMutations(100);
-    assertEquals(0, this.testee.getTestStrength());
+    assertEquals(100, this.testee.getTestStrength());
   }
 
   @Test


### PR DESCRIPTION
Fixes #375
Supersedes #776

With this PR hopefully all percentage calculation uses the common logic introcuded in #638.
This should avoid everywhere showing 100% if not the full total is reached.

As a positive side-effect it also fixes a potential arithmetic exception in `getTestStrength()`
as it was not the divisor that was checked for zero to avoid it, probably by bad copy & paste.