### PR TITLE
delay test class identification

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/MutationTestBuilder.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/MutationTestBuilder.java
@@ -15,7 +15,6 @@
 package org.pitest.mutationtest.build;
 
 import org.pitest.classinfo.ClassName;
-import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import org.pitest.functional.prelude.Prelude;
 import org.pitest.mutationtest.DetectionStatus;
@@ -25,10 +24,7 @@ import org.pitest.mutationtest.engine.MutationDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -96,22 +92,11 @@ public class MutationTestBuilder {
 
   private MutationAnalysisUnit makeUnanalysedUnit(
       final Collection<MutationDetails> needAnalysis) {
-    final Set<ClassName> uniqueTestClasses = new HashSet<>();
-    FCollection.flatMapTo(needAnalysis, mutationDetailsToTestClass(),
-        uniqueTestClasses);
-
-    return new MutationTestUnit(needAnalysis, uniqueTestClasses,
-        this.workerFactory);
+    return new MutationTestUnit(needAnalysis, this.workerFactory);
   }
 
   private static Predicate<MutationResult> statusNotKnown() {
     return a -> a.getStatus() == DetectionStatus.NOT_STARTED;
-  }
-
-  private static Function<MutationDetails, Iterable<ClassName>> mutationDetailsToTestClass() {
-    return a -> a.getTestsInOrder().stream()
-            .map(TestInfo.toDefiningClassName())
-            .collect(Collectors.toList());
   }
 
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/MutationTestUnitTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/MutationTestUnitTest.java
@@ -25,7 +25,6 @@ import org.pitest.mutationtest.engine.MutationDetailsMother;
 import org.pitest.mutationtest.engine.MutationEngine;
 import org.pitest.process.JavaAgent;
 import org.pitest.process.LaunchOptions;
-import org.pitest.testapi.Configuration;
 import org.pitest.util.Verbosity;
 
 public class MutationTestUnitTest {
@@ -33,9 +32,6 @@ public class MutationTestUnitTest {
   private MutationTestUnit      testee;
   private List<MutationDetails> mutations;
   private Collection<ClassName> tests;
-
-  @Mock
-  private Configuration         config;
 
   private MutationConfig        mutationConfig;
 
@@ -55,7 +51,7 @@ public class MutationTestUnitTest {
         this.javaAgent));
     this.mutations = new ArrayList<>();
     this.tests = new ArrayList<>();
-    this.testee = new MutationTestUnit(this.mutations, this.tests,
+    this.testee = new MutationTestUnit(this.mutations,
         new WorkerFactory(null, TestPluginArguments.defaults(), this.mutationConfig, EngineArguments.arguments(), this.timeout,
             Verbosity.DEFAULT, false, null));
 
@@ -75,7 +71,7 @@ public class MutationTestUnitTest {
   public void shouldReportPriorityBasedOnNumberOfMutations() {
     this.mutations.add(MutationDetailsMother.aMutationDetail().build());
     this.testee = new MutationTestUnit(MutationDetailsMother.aMutationDetail()
-        .build(42), this.tests, null);
+        .build(42), null);
     assertThat(this.testee.priority()).isEqualTo(42);
   }
 


### PR DESCRIPTION
Test classes to be sent to the minion are now calculated from the list of remaning mutations. In the event of a timeout, this list may be shorter than the initial list, and the scanning of the test classes within the minion thereby avoided.