### PR TITLE
extra features param for maven

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -136,10 +136,18 @@ public class AbstractPitMojo extends AbstractMojo {
   private ArrayList<String>           mutators;
   
   /**
-   * Mutation operators to apply
+   * Features to activate/deactivate
    */
   @Parameter(property = "features")
   private ArrayList<String>           features;
+
+  /**
+   * Additional features activate/deactivate, use to
+   * avoid overwriting features set in the build script when
+   * specifying features from the command line
+   */
+  @Parameter(property = "extraFeatures")
+  private ArrayList<String>           extraFeatures;
 
 
   /**
@@ -739,7 +747,9 @@ public class AbstractPitMojo extends AbstractMojo {
   }
   
   public ArrayList<String> getFeatures() {
-    return withoutNulls(features);
+    ArrayList<String> consolidated = emptyWithoutNulls(features);
+    consolidated.addAll(emptyWithoutNulls(extraFeatures));
+    return consolidated;
   }
 
   public boolean isUseClasspathJar() {
@@ -776,6 +786,14 @@ public class AbstractPitMojo extends AbstractMojo {
     public List<String> getReasons() {
       return Collections.unmodifiableList(reasons);
     }
+  }
+
+  private <X> ArrayList<X> emptyWithoutNulls(List<X> originalList) {
+    if (originalList == null) {
+      return new ArrayList<>();
+    }
+
+    return withoutNulls(originalList);
   }
 
   private <X> ArrayList<X> withoutNulls(List<X> originalList) {

--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -394,6 +394,23 @@ public class PitMojoTest extends BasePitMojoTest {
         mojo.getFeatures());
   }
 
+  public void testCombinesFeaturesAndExtraFeatures() throws Exception {
+
+    AbstractPitMojo mojo = createPITMojo(createPomWithConfiguration("\n"
+            + "  <features>\n"
+            + "    <feature>FEATURE</feature>\n"
+            + "  </features>\n"
+            + "  <extraFeatures>\n"
+            + "    <feature>ALSO_A_FEATURE</feature>\n"
+            + "    <feature>MORE</feature>\n"
+            + "  </extraFeatures>\n"
+    ));
+
+    assertEquals(
+            asList("FEATURE", "ALSO_A_FEATURE", "MORE"),
+            mojo.getFeatures());
+  }
+
   private void setupCoverage(long mutationScore, int lines, int linesCovered)
       throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();


### PR DESCRIPTION
Additional parameter extraFeatures allowed features to be added from the commandline without overwriting/needing to respecify features set within the pom.xml