### PR TITLE
suppress reporting of coverage stats

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -132,6 +132,8 @@ public class ReportOptions {
 
   private boolean                        includeLaunchClasspath         = true;
 
+  private boolean                        reportCoverage                 = true;
+
   private Properties                     properties;
 
   private int maxSurvivors;
@@ -647,6 +649,13 @@ public class ReportOptions {
     this.outputEncoding = outputEncoding;
   }
 
+  public boolean shouldReportCoverage() {
+    return reportCoverage;
+  }
+
+  public void setReportCoverage(boolean reportCoverage) {
+    this.reportCoverage = reportCoverage;
+  }
 
   @Override
   public String toString() {
@@ -695,6 +704,7 @@ public class ReportOptions {
             .add("projectBase=" + projectBase)
             .add("inputEncoding=" + inputEncoding)
             .add("outputEncoding=" + outputEncoding)
+            .add("reportCoverage=" + reportCoverage)
             .toString();
   }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/xml/XMLReportFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/xml/XMLReportFactory.java
@@ -25,7 +25,7 @@ public class XMLReportFactory implements MutationResultListenerFactory {
   @Override
   public MutationResultListener getListener(Properties props,
       final ListenerArguments args) {
-    return new XMLReportListener(args.getOutputStrategy(), args.isFullMutationMatrix());
+    return new XMLReportListener(args.getOutputStrategy(), args.isFullMutationMatrix(), args.data().shouldReportCoverage());
   }
 
   @Override

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/xml/XMLReportListener.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/xml/XMLReportListener.java
@@ -55,13 +55,16 @@ public class XMLReportListener implements MutationResultListener {
   private final Writer out;
   private final boolean fullMutationMatrix;
 
-  public XMLReportListener(final ResultOutputStrategy outputStrategy, boolean fullMutationMatrix) {
-    this(outputStrategy.createWriterForFile("mutations.xml"), fullMutationMatrix);
+  private final boolean partialCoverage;
+
+  public XMLReportListener(final ResultOutputStrategy outputStrategy, boolean fullMutationMatrix, boolean partialCoverage) {
+    this(outputStrategy.createWriterForFile("mutations.xml"), fullMutationMatrix, partialCoverage);
   }
 
-  public XMLReportListener(final Writer out, boolean fullMutationMatrix) {
+  public XMLReportListener(final Writer out, boolean fullMutationMatrix, boolean partialCoverage) {
     this.out = out;
     this.fullMutationMatrix = fullMutationMatrix;
+    this.partialCoverage = partialCoverage;
   }
 
   private void writeResult(final ClassMutationResults metaData) {
@@ -176,7 +179,7 @@ public class XMLReportListener implements MutationResultListener {
   @Override
   public void runStart() {
     write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    write("<mutations>\n");
+    write("<mutations partial=\"" + this.partialCoverage + "\">\n");
   }
 
   @Override

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/xml/XMLReportListenerTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/xml/XMLReportListenerTest.java
@@ -37,14 +37,14 @@ public class XMLReportListenerTest {
   @Before
   public void setup() {
     this.out = new StringWriter();
-    this.testee = new XMLReportListener(this.out, false);
+    this.testee = new XMLReportListener(this.out, false, false);
   }
 
   @Test
   public void shouldCreateAValidXmlDocumentWhenNoResults() {
     this.testee.runStart();
     this.testee.runEnd();
-    final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mutations>\n</mutations>\n";
+    final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mutations partial=\"false\">\n</mutations>\n";
     assertThat(expected).isEqualTo(this.out.toString());
   }
 
@@ -61,7 +61,7 @@ public class XMLReportListenerTest {
 
   @Test
   public void shouldOutputFullMutationMatrixWhenEnabled() {
-    this.testee = new XMLReportListener(this.out, true);
+    this.testee = new XMLReportListener(this.out, true, false);
     final MutationResult mr = new MutationResult(
             MutationTestResultMother.createDetails(),
             new MutationStatusTestPair(3, DetectionStatus.KILLED, Arrays.asList("foo", "foo2"), Arrays.asList("bar")));

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/AnnotatedLineFactory.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/AnnotatedLineFactory.java
@@ -32,19 +32,20 @@ import java.util.stream.StreamSupport;
 
 public class AnnotatedLineFactory {
 
-  private final Collection<MutationResult>         mutations;
-  private final ReportCoverage                     coverage;
-  private final Collection<ClassLines>             classesInFile;
-
-  private final Set<Integer>                       coveredLines;
+  private final Collection<MutationResult> mutations;
+  private final Collection<ClassLines> classesInFile;
+  private final Set<Integer>  coveredLines;
+  private final boolean reportCoverage;
 
   public AnnotatedLineFactory(
           final Collection<MutationResult> mutations,
-          final ReportCoverage coverage, final Collection<ClassLines> classes) {
+          final ReportCoverage coverage,
+          final Collection<ClassLines> classes,
+          boolean reportCoverage) {
     this.mutations = mutations;
-    this.coverage = coverage;
     this.classesInFile = classes;
     this.coveredLines = findCoveredLines(classes,coverage);
+    this.reportCoverage = reportCoverage;
   }
 
   private Set<Integer> findCoveredLines(Collection<ClassLines> classes, ReportCoverage coverage) {
@@ -93,7 +94,7 @@ public class AnnotatedLineFactory {
 
   private LineStatus lineCovered(final int line) {
 
-    if (!isCodeLine(line)) {
+    if (!isCodeLine(line) || !reportCoverage) {
       return LineStatus.NotApplicable;
     } else {
       if (isLineCovered(line)) {

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/HtmlReportFactory.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/HtmlReportFactory.java
@@ -27,7 +27,7 @@ public class HtmlReportFactory implements MutationResultListenerFactory {
   public MutationResultListener getListener(Properties props,
       ListenerArguments args) {
     return new MutationHtmlReportListener(args.data().getOutputEncoding(), args.getCoverage(),
-        args.getOutputStrategy(), args.getEngine().getMutatorNames(),
+        args.getOutputStrategy(), args.getEngine().getMutatorNames(), args.data().shouldReportCoverage(),
         args.getLocator());
   }
 

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -56,16 +56,21 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
   private final String                    css;
   private final Charset                   outputCharset;
+  private final boolean reportCoverage;
 
-  public MutationHtmlReportListener(Charset outputCharset, final ReportCoverage coverage,
-                                    final ResultOutputStrategy outputStrategy,
-                                    Collection<String> mutatorNames, final SourceLocator... locators) {
+  public MutationHtmlReportListener(Charset outputCharset,
+                                    ReportCoverage coverage,
+                                    ResultOutputStrategy outputStrategy,
+                                    Collection<String> mutatorNames,
+                                    boolean reportCoverage,
+                                    SourceLocator... locators) {
     this.outputCharset = outputCharset;
     this.coverage = coverage;
     this.outputStrategy = outputStrategy;
     this.sourceRoots = new HashSet<>(asList(locators));
     this.mutatorNames = new HashSet<>(mutatorNames);
     this.css = loadCss();
+    this.reportCoverage = reportCoverage;
   }
 
   private String loadCss() {
@@ -101,7 +106,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
       st.setAttribute("sourceFile", sourceFile);
       st.setAttribute("mutatedClasses", mutationMetaData.getMutatedClasses());
       st.setAttribute("outputCharset", this.outputCharset);
-
+      st.setAttribute("showCoverage", this.reportCoverage);
       writer.write(st.toString());
 
 
@@ -153,7 +158,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
         sourceFile);
     if (reader.isPresent()) {
       final AnnotatedLineFactory alf = new AnnotatedLineFactory(
-          mutationsForThisFile.list(), this.coverage, classes);
+          mutationsForThisFile.list(), this.coverage, classes, this.reportCoverage);
       return alf.convert(reader.get());
     }
     return Collections.emptyList();
@@ -215,6 +220,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
     st.setAttribute("totals", totals);
     st.setAttribute("packageSummaries", psd);
     st.setAttribute("outputCharset", this.outputCharset);
+    st.setAttribute("showCoverage", this.reportCoverage);
     try {
       writer.write(st.toString());
       writer.close();
@@ -233,6 +239,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
         .getPackageDirectory() + File.separator + "index.html");
     st.setAttribute("packageData", psData);
     st.setAttribute("outputCharset", this.outputCharset);
+    st.setAttribute("showCoverage", this.reportCoverage);
     try {
       writer.write(st.toString());
       writer.close();

--- a/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
@@ -21,7 +21,9 @@
     <tbody>
         <tr>
             <td>$totals.numberOfFiles$</td>
-            <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$ <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
+            $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
+            $endif$
             <td>$totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.mutationCoverage$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
             <td>$totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$totals.testStrength$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
@@ -45,7 +47,9 @@ $packageSummaries:{ summary |
         <tr>
             <td><a href="./$summary.packageDirectory$/index.html">$summary.packageName$</a></td>
             <td>$summary.totals.numberOfFiles$</td>
-            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$ <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
+            $endif$
             <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>

--- a/pitest-html-report/src/main/resources/templates/mutation/package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/package_index.st
@@ -21,7 +21,9 @@
     <tbody>
         <tr>
             <td>$packageData.totals.numberOfFiles$</td>
-            <td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$<td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
+            $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
+            $endif$
             <td>$packageData.totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.mutationCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
             <td>$packageData.totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.testStrength$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
@@ -43,7 +45,9 @@
 $packageData.summaryData:{ summary | 
         <tr>
             <td><a href="./$summary.fileName$.html">$summary.fileName$</a></td>
-            <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$<td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
+            $endif$
             <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
             <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
@@ -69,7 +69,7 @@ public class MutationHtmlReportListenerTest {
         this.classInfo);
 
     this.testee = new MutationHtmlReportListener(StandardCharsets.UTF_8, this.coverageDb,
-        this.outputStrategy, Collections.<String>emptyList(), this.sourceLocator);
+        this.outputStrategy, Collections.<String>emptyList(), true, this.sourceLocator);
   }
 
   @Test

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -157,8 +157,7 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
   }
 
   @SuppressWarnings("unchecked")
-  private List<File> getCompiledDirs(final MavenProject project)
-      throws Exception {
+  private List<File> getCompiledDirs(final MavenProject project) {
     final List<String> sourceRoots = new ArrayList<>();
     for (final Object artifactObj : FCollection
         .filter(project.getPluginArtifactMap().values(), new DependencyFilter(


### PR DESCRIPTION
Arcmutates advanced incremental processing includes the option to avoid gathering coverage for tests which cannot kill an in scope mutant. Although this speeds up processing the html report shows most lines as uncovered when this feature is activated. Reporting of line coverage it therefore disabled when this feature is activated.