### PR TITLE
 Bump Quarkus from 2.8 to 3.4 and add usual Quarkus test from generated application 

### DIFF
--- a/pitest-maven-verification/src/test/resources/pit-quarkus/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/pom.xml
@@ -3,18 +3,17 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.example</groupId>
-  <artifactId>pitest-quarlus</artifactId>
+  <artifactId>pitest-quarkus</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
-    <failsafe.useModulePath>false</failsafe.useModulePath>
+    <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.8.3.Final</quarkus.platform.version>
-    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <quarkus.platform.version>3.4.3</quarkus.platform.version>
+    <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <pitest.junit5.version>1.0.0</pitest.junit5.version>
   </properties>
   <dependencyManagement>
@@ -40,13 +39,7 @@
     </dependency>
    <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-mockito</artifactId>
-      <version>2.8.1.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -90,6 +83,25 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemPropertyVariables>
+                <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.pitest</groupId>
@@ -113,4 +125,18 @@
 
     </plugins>
   </build>
+<profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <skipITs>false</skipITs>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/pom.xml
@@ -43,6 +43,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/GreetingResource.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/GreetingResource.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hello")
+public class GreetingResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from RESTEasy Reactive";
+    }
+}

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/controller/ExampleController.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/controller/ExampleController.java
@@ -2,10 +2,10 @@ package com.example.controller;
 
 import com.example.service.ExampleService;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/example")
 @ApplicationScoped

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/service/ExampleService.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/main/java/com/example/service/ExampleService.java
@@ -1,7 +1,7 @@
 package com.example.service;
 
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class ExampleService {

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/ExampleControllerTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/ExampleControllerTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.example.service.ExampleService;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import io.quarkus.test.junit.mockito.InjectMock;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/ExampleServiceTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/ExampleServiceTest.java
@@ -4,7 +4,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import com.example.service.ExampleService;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/GreetingResourceTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-quarkus/src/test/java/com/example/GreetingResourceTest.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class GreetingResourceTest {
+
+    @Test
+    public void testHelloEndpoint() {
+        given()
+          .when().get("/hello")
+          .then()
+             .statusCode(200)
+             .body(is("Hello from RESTEasy Reactive"));
+    }
+
+}


### PR DESCRIPTION
 - Bump Quarkus from 2.8 to 3.4
 - Add usual Quarkus test from generated application (https://code.quarkus.io/ for example)

Update of test coverage added in https://github.com/hcoles/pitest/pull/1022

Checks:
Executed `mvn clean test org.pitest:pitest-maven:mutationCoverage -Dpit.version=1.15.1` from `pitest-maven-verification/src/test/resources/pit-quarkus` directory
Also executed `mvn clean verify -Dit.test=PitMojoIT#shouldWorkWithQuarkus` from `pitest-maven-verification`