### PR TITLE
Pluggable coverage

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/coverage/CompoundCoverageExporterFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CompoundCoverageExporterFactory.java
@@ -1,0 +1,38 @@
+package org.pitest.coverage;
+
+import org.pitest.plugin.Feature;
+import org.pitest.plugin.FeatureSelector;
+import org.pitest.plugin.FeatureSetting;
+import org.pitest.util.ResultOutputStrategy;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CompoundCoverageExporterFactory implements CoverageExporterFactory {
+
+    private final FeatureSelector<CoverageExporterFactory> features;
+
+    public CompoundCoverageExporterFactory(List<FeatureSetting> features, Collection<CoverageExporterFactory> children) {
+        this.features = new FeatureSelector<>(features, children);
+    }
+
+    @Override
+    public CoverageExporter create(ResultOutputStrategy source) {
+        List<CoverageExporter> exporters = this.features.getActiveFeatures().stream()
+                .map(f -> f.create(source))
+                .collect(Collectors.toList());
+        return c -> exporters.stream().forEach(exporter -> exporter.recordCoverage(c));
+    }
+
+    @Override
+    public String description() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Feature provides() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageExporterFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageExporterFactory.java
@@ -1,0 +1,9 @@
+package org.pitest.coverage;
+
+import org.pitest.plugin.ProvidesFeature;
+import org.pitest.plugin.ToolClasspathPlugin;
+import org.pitest.util.ResultOutputStrategy;
+
+public interface CoverageExporterFactory extends ToolClasspathPlugin, ProvidesFeature {
+    CoverageExporter create(ResultOutputStrategy source);
+}

--- a/pitest-entry/src/main/java/org/pitest/coverage/DefaultCoverageExporterFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/DefaultCoverageExporterFactory.java
@@ -1,0 +1,24 @@
+package org.pitest.coverage;
+
+import org.pitest.coverage.export.DefaultCoverageExporter;
+import org.pitest.plugin.Feature;
+import org.pitest.util.ResultOutputStrategy;
+
+public class DefaultCoverageExporterFactory implements CoverageExporterFactory {
+    @Override
+    public CoverageExporter create(ResultOutputStrategy source) {
+        return new DefaultCoverageExporter(source);
+    }
+
+    @Override
+    public Feature provides() {
+        return Feature.named("defaultCoverage")
+                .withDescription(description())
+                .withOnByDefault(true);
+    }
+
+    @Override
+    public String description() {
+        return "Default coverage exporter";
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/PluginServices.java
@@ -1,6 +1,7 @@
 package org.pitest.mutationtest.config;
 
 import org.pitest.classpath.CodeSourceFactory;
+import org.pitest.coverage.CoverageExporterFactory;
 import org.pitest.mutationtest.HistoryFactory;
 import org.pitest.mutationtest.build.CoverageTransformerFactory;
 import org.pitest.mutationtest.MutationEngineFactory;
@@ -59,6 +60,7 @@ public class PluginServices {
     l.addAll(findVerifiers());
     l.addAll(findCodeSources());
     l.addAll(findHistory());
+    l.addAll(findCoverageExport());
     return l;
   }
 
@@ -133,6 +135,10 @@ public class PluginServices {
     return new ArrayList<>(load(HistoryFactory.class));
   }
 
+
+  public List<CoverageExporterFactory> findCoverageExport() {
+    return new ArrayList<>(load(CoverageExporterFactory.class));
+  }
   public Collection<ProvidesFeature> findFeatures() {
     return findToolClasspathPlugins().stream()
             .filter(p -> p instanceof ProvidesFeature)

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
@@ -4,12 +4,12 @@ import org.pitest.classpath.CodeSource;
 import org.pitest.classpath.CodeSourceFactory;
 import org.pitest.classpath.DefaultCodeSource;
 import org.pitest.classpath.ProjectClassPaths;
+import org.pitest.coverage.CompoundCoverageExporterFactory;
 import org.pitest.coverage.CoverageExporter;
 import org.pitest.mutationtest.HistoryFactory;
 import org.pitest.mutationtest.build.CoverageTransformer;
 import org.pitest.mutationtest.build.CoverageTransformerFactory;
 import org.pitest.coverage.execute.CoverageOptions;
-import org.pitest.coverage.export.DefaultCoverageExporter;
 import org.pitest.coverage.export.NullCoverageExporter;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.CompoundMutationResultInterceptor;
@@ -63,7 +63,9 @@ public class SettingsFactory {
 
   public CoverageExporter createCoverageExporter() {
     if (this.options.shouldExportLineCoverage()) {
-      return new DefaultCoverageExporter(getOutputStrategy());
+      final FeatureParser parser = new FeatureParser();
+      return new CompoundCoverageExporterFactory(parser.parseFeatures(this.options.getFeatures()), this.plugins.findCoverageExport())
+                .create(this.options.getReportDirectoryStrategy());
     } else {
       return new NullCoverageExporter();
     }

--- a/pitest-entry/src/main/resources/META-INF/services/org.pitest.coverage.CoverageExporterFactory
+++ b/pitest-entry/src/main/resources/META-INF/services/org.pitest.coverage.CoverageExporterFactory
@@ -1,0 +1,1 @@
+org.pitest.coverage.DefaultCoverageExporterFactory

--- a/pitest-entry/src/test/java/org/pitest/process/ArgLineParserTest.java
+++ b/pitest-entry/src/test/java/org/pitest/process/ArgLineParserTest.java
@@ -136,4 +136,5 @@ public class ArgLineParserTest {
                 "--add-opens=java.base/java.lang=ALL-UNNAMED",
                 "--add-opens=java.base/java.math=ALL-UNNAMED");
     }
+
 }


### PR DESCRIPTION
Additional coverage exporters can now be used.

Exporting coverage is still controlled by the `exportLineCoverage` parameter, but additional exporters can be provided by plugins and enabled/disabled using feature strings.

To disable the default exporter pass `-defaultCoverage` as a feature string.