### PR TITLE
mutate delayed execution code stored in statics

### DIFF
--- a/pitest-entry/src/test/java/com/example/staticinitializers/StaticFunctionField.java
+++ b/pitest-entry/src/test/java/com/example/staticinitializers/StaticFunctionField.java
@@ -1,0 +1,14 @@
+package com.example.staticinitializers;
+
+import java.util.function.Function;
+
+public class StaticFunctionField {
+    private static final Function<String,String> FOO = canMutate();
+
+    private static Function<String, String> canMutate() {
+        // don't mutate
+        System.out.println("ideally would mutate me");
+
+        return s -> s + "foo";
+    }
+}

--- a/pitest-entry/src/test/java/com/example/staticinitializers/StaticSupplierField.java
+++ b/pitest-entry/src/test/java/com/example/staticinitializers/StaticSupplierField.java
@@ -1,0 +1,14 @@
+package com.example.staticinitializers;
+
+import java.util.function.Supplier;
+
+public class StaticSupplierField {
+    final static Supplier<String> SUPPLER = canMutate();
+
+    private static Supplier<String> canMutate() {
+        // don't mutate
+        System.out.println("ideally would mutate me");
+
+        return () -> "Do not mutate"; // mutate
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptorTest.java
@@ -6,6 +6,8 @@ import com.example.staticinitializers.MethodsCallsEachOtherInLoop;
 import com.example.staticinitializers.NestedEnumWithLambdaInStaticInitializer;
 import com.example.staticinitializers.SecondLevelPrivateMethods;
 import com.example.staticinitializers.SingletonWithWorkInInitializer;
+import com.example.staticinitializers.StaticFunctionField;
+import com.example.staticinitializers.StaticSupplierField;
 import com.example.staticinitializers.ThirdLevelPrivateMethods;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -146,7 +148,6 @@ public class StaticInitializerInterceptorTest {
     }
 
     @Test
-    @Ignore("temporally disabled while filtering reworked")
     public void filtersMutantsInEnumPrivateMethodsCalledViaMethodRef() {
         v.forClass(EnumWithLambdaInConstructor.class)
                 .forMutantsMatching(inMethodStartingWith("doStuff"))
@@ -156,12 +157,31 @@ public class StaticInitializerInterceptorTest {
     }
 
     @Test
-    @Ignore("temporally disabled while filtering reworked")
     public void filtersMutantsInLambdaCalledFromStaticInitializerInNestedEnum() {
         v.forClass(NestedEnumWithLambdaInStaticInitializer.TOYS.class)
                 .forMutantsMatching(inMethodStartingWith("lambda"))
                 .mutantsAreGenerated()
                 .allMutantsAreFiltered()
+                .verify();
+    }
+
+    @Test
+    public void doesNotSuppressDownStreamMutationsForCodeStoredInSuppliers() {
+        v.forClass(StaticSupplierField.class)
+                .forMethod("canMutate")
+                .forAnyCode()
+                .mutantsAreGenerated()
+                .noMutantsAreFiltered()
+                .verify();
+    }
+
+    @Test
+    public void doesNotSuppressDownStreamMutationsForCodeStoredInFunctions() {
+        v.forClass(StaticFunctionField.class)
+                .forMethod("canMutate")
+                .forAnyCode()
+                .mutantsAreGenerated()
+                .noMutantsAreFiltered()
                 .verify();
     }
 


### PR DESCRIPTION
We don't want to mutate code executed only during static initialization. Unfortunately the current filtering also picks up code that is executed after static initialization as lambdas.

This change implelements an imperfect comprimise where code stored as Suppliers, Functions etc will be considered for mutation.

This will fail to mutate delayed execution code stored in other types, and will incorrectly mutate code that is executed only during initialization if it is within a method that returns a Supplier etc.

Although imperfect, it is an improvement.