### PR TITLE
temporarily remove dynamic call tracking

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptor.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptor.java
@@ -90,8 +90,11 @@ class StaticInitializerInterceptor implements MutationInterceptor {
   }
 
   private List<Location> allCallsFor(ClassTree tree, MethodTree m) {
-    return Stream.concat(callsFor(tree,m), invokeDynamicCallsFor(tree,m))
-            .collect(Collectors.toList());
+    // temporarily disable dynamic calls as they are more likely to be involved
+    // in storing delayed execution code within static fields.
+    return callsFor(tree,m).collect(Collectors.toList());
+  //  return Stream.concat(callsFor(tree,m), invokeDynamicCallsFor(tree,m))
+  //          .collect(Collectors.toList());
   }
 
   private Stream<Location> callsFor(ClassTree tree, MethodTree m) {

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/build/intercept/staticinitializers/StaticInitializerInterceptorTest.java
@@ -7,6 +7,7 @@ import com.example.staticinitializers.NestedEnumWithLambdaInStaticInitializer;
 import com.example.staticinitializers.SecondLevelPrivateMethods;
 import com.example.staticinitializers.SingletonWithWorkInInitializer;
 import com.example.staticinitializers.ThirdLevelPrivateMethods;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.gregor.mutators.NullMutateEverything;
@@ -145,6 +146,7 @@ public class StaticInitializerInterceptorTest {
     }
 
     @Test
+    @Ignore("temporally disabled while filtering reworked")
     public void filtersMutantsInEnumPrivateMethodsCalledViaMethodRef() {
         v.forClass(EnumWithLambdaInConstructor.class)
                 .forMutantsMatching(inMethodStartingWith("doStuff"))
@@ -154,6 +156,7 @@ public class StaticInitializerInterceptorTest {
     }
 
     @Test
+    @Ignore("temporally disabled while filtering reworked")
     public void filtersMutantsInLambdaCalledFromStaticInitializerInNestedEnum() {
         v.forClass(NestedEnumWithLambdaInStaticInitializer.TOYS.class)
                 .forMutantsMatching(inMethodStartingWith("lambda"))


### PR DESCRIPTION
Temporarily #1274 until additional logic added to handle increased likelihood of filtering mutants to delayed execution code reported in #1291 is implemented.