### PR TITLE
Non jdk classes picked up by filter

### DIFF
--- a/pitest/src/main/java/org/pitest/coverage/execute/CoverageOptions.java
+++ b/pitest/src/main/java/org/pitest/coverage/execute/CoverageOptions.java
@@ -64,8 +64,8 @@ public class CoverageOptions implements Serializable {
             glob("org.pitest.*"),
             glob("java.*"),
             glob("javax.*"),
-            glob("com.sun*"),
-            glob("org.junit*"),
+            glob("com.sun.*"),
+            glob("org.junit.*"),
             glob("sun.*"));
   }
 

--- a/pitest/src/test/java/org/pitest/coverage/execute/CoverageOptionsTest.java
+++ b/pitest/src/test/java/org/pitest/coverage/execute/CoverageOptionsTest.java
@@ -40,8 +40,18 @@ public class CoverageOptionsTest {
   }
 
   @Test
+  public void shouldNotCoverDotSun() {
+    assertThat(this.testee.getFilter().test("com.sun.dance")).isFalse();
+  }
+
+  @Test
+  public void shouldCoverSunDance() {
+    assertThat(this.testee.getFilter().test("com.sundance")).isTrue();
+  }
+
+  @Test
   public void shouldNotCoverJUnitWhenFilterIsBroad() {
-    assertThat(this.testee.getFilter().test("sun.foo.Bar")).isFalse();
+    assertThat(this.testee.getFilter().test("org.junit.Bar")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
If code was packaged anywhere in com.sun* it was being picked up by the filter for legacy jdk classes in the com.sun.* package.