### PR TITLE
replace standard maven properties imported from surefire

### DIFF
--- a/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
+++ b/pitest-maven-verification/src/test/java/org/pitest/PitMojoIT.java
@@ -321,6 +321,8 @@ public class PitMojoIT {
 
   @Test
   public void shouldReadExclusionsFromSurefireConfig() throws Exception {
+    // Note this test also tests the argline parsing concern
+
     File testDir = prepare("/pit-surefire-excludes");
     verifier.executeGoal("test");
     verifier.executeGoal("org.pitest:pitest-maven:mutationCoverage");

--- a/pitest-maven-verification/src/test/resources/pit-surefire-excludes/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-surefire-excludes/pom.xml
@@ -15,6 +15,8 @@
             </dependency>
 	</dependencies>
 	<properties>
+		<a.value>isSet</a.value>
+		<b.value>alsoSet</b.value>
 		<argLine/>
 	</properties>
 	<build>
@@ -37,7 +39,7 @@
 			    <exclude>**/FailingTest.java</exclude>
 			    <exclude>**/BadTest.java</exclude>
 			  </excludes>
-				<argLine>@{argLine} -DnotNeeded=avalue</argLine>
+				<argLine>${argLine} -DMUST_BE_SET=${a.value} -DMUST_ALSO_BE_SET=@{b.value}</argLine>
 			</configuration>
 		        </plugin>
 			<plugin>

--- a/pitest-maven-verification/src/test/resources/pit-surefire-excludes/src/test/java/com/example/AnotherTest.java
+++ b/pitest-maven-verification/src/test/resources/pit-surefire-excludes/src/test/java/com/example/AnotherTest.java
@@ -18,4 +18,10 @@ public class AnotherTest {
     assertEquals(1, Covered.someCode(1));
   }
 
+  @Test
+  public void dependsOnArgLine() {
+    assertEquals("isSet", System.getProperty("MUST_BE_SET"));
+    assertEquals("alsoSet", System.getProperty("MUST_ALSO_BE_SET"));
+  }
+
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -320,6 +320,13 @@ public class AbstractPitMojo extends AbstractMojo {
   private boolean                     parseSurefireConfig;
 
   /**
+   * When set will try and set the argLine based on surefire configuration. This
+   * may not give the desired result in some circumstances
+   */
+  @Parameter(defaultValue = "true")
+  private boolean                     parseSurefireArgLine;
+
+  /**
    * honours common skipTests flag in a maven run
    */
   @Parameter(property = "skipTests", defaultValue = "false")
@@ -515,7 +522,7 @@ public class AbstractPitMojo extends AbstractMojo {
 
   protected Optional<CombinedStatistics> analyse() throws MojoExecutionException {
     final ReportOptions data = new MojoToReportOptionsConverter(this,
-        new SurefireConfigConverter(), this.filter).convert();
+        new SurefireConfigConverter(this.isParseSurefireArgLine()), this.filter).convert();
     return Optional.ofNullable(this.goalStrategy.execute(detectBaseDir(), data,
         this.plugins, this.environmentVariables));
   }
@@ -724,6 +731,10 @@ public class AbstractPitMojo extends AbstractMojo {
 
   public boolean isParseSurefireConfig() {
     return this.parseSurefireConfig;
+  }
+
+  public boolean isParseSurefireArgLine() {
+    return this.parseSurefireArgLine;
   }
 
   public boolean skipFailingTests() {

--- a/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/ScmMojo.java
@@ -135,7 +135,7 @@ public class ScmMojo extends AbstractPitMojo {
     logClassNames();
     defaultTargetTestsIfNoValueSet();
     final ReportOptions data = new MojoToReportOptionsConverter(this,
-        new SurefireConfigConverter(), getFilter()).convert();
+        new SurefireConfigConverter(this.isParseSurefireArgLine()), getFilter()).convert();
     data.setFailWhenNoMutations(false);
 
     return Optional.ofNullable(this.getGoalStrategy().execute(detectBaseDir(), data,

--- a/pitest-maven/src/main/java/org/pitest/maven/SurefireConfigConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/SurefireConfigConverter.java
@@ -22,14 +22,22 @@ import org.pitest.util.Glob;
  */
 public class SurefireConfigConverter {
 
-  public ReportOptions update(ReportOptions option, Xpp3Dom configuration) {
+  private final boolean parseArgLine;
+
+    public SurefireConfigConverter(boolean parseArgLine) {
+        this.parseArgLine = parseArgLine;
+    }
+
+    public ReportOptions update(ReportOptions option, Xpp3Dom configuration) {
     if (configuration == null) {
       return option;
     }
     convertExcludes(option, configuration);
     convertGroups(option, configuration);
     convertTestFailureIgnore(option, configuration);
-    convertArgLine(option, configuration);
+    if (parseArgLine) {
+      convertArgLine(option, configuration);
+    }
     return option;
   }
 
@@ -70,13 +78,10 @@ public class SurefireConfigConverter {
   }
 
   private void convertArgLine(ReportOptions option, Xpp3Dom configuration) {
-    if (option.getArgLine() != null) {
-      return;
-    }
-
     Xpp3Dom argLine = configuration.getChild("argLine");
     if (argLine != null) {
-      option.setArgLine(argLine.getValue());
+      String existing = option.getArgLine() != null ? option.getArgLine() + " " : "";
+      option.setArgLine(existing + argLine.getValue());
     }
   }
 

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -441,11 +441,21 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     assertThat(actual.getArgLine()).isEqualTo("foo");
   }
 
-  public void testEvaluatesArgLineProperties() {
+  public void testEvaluatesSureFireLateEvalArgLineProperties() {
     properties.setProperty("FOO", "fooValue");
     properties.setProperty("BAR", "barValue");
     properties.setProperty("UNUSED", "unusedValue");
     ReportOptions actual = parseConfig("<argLine>@{FOO} @{BAR}</argLine>");
+    assertThat(actual.getArgLine()).isEqualTo("fooValue barValue");
+  }
+
+  public void testEvaluatesNormalPropertiesInArgLines() {
+    properties.setProperty("FOO", "fooValue");
+    properties.setProperty("BAR", "barValue");
+    properties.setProperty("UNUSED", "unusedValue");
+    // these are normally auto resolved by maven, but if we pull
+    // in an argline from surefire it will not have been escaped.
+    ReportOptions actual = parseConfig("<argLine>${FOO} ${BAR}</argLine>");
     assertThat(actual.getArgLine()).isEqualTo("fooValue barValue");
   }
 

--- a/pitest-maven/src/test/java/org/pitest/maven/SurefireConfigConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/SurefireConfigConverterTest.java
@@ -17,7 +17,7 @@ import org.pitest.util.Glob;
 
 public class SurefireConfigConverterTest {
 
-  SurefireConfigConverter testee  = new SurefireConfigConverter();
+  SurefireConfigConverter testee  = new SurefireConfigConverter(true);
   ReportOptions           options = new ReportOptions();
   Xpp3Dom                 surefireConfig;
 
@@ -166,16 +166,28 @@ public class SurefireConfigConverterTest {
 
   @Test
   public void convertsArgline() throws Exception {
-    this.surefireConfig = makeConfig("<argLine>-Xmx1024m</argLine>");
+    this.surefireConfig = makeConfig("<argLine>-Xmx1024m -Dfoo=${BAR} -Dfoo=$@BAR}</argLine>");
 
     ReportOptions actual = this.testee
         .update(this.options, this.surefireConfig);
 
-    assertThat(actual.getArgLine()).isEqualTo("-Xmx1024m");
+    assertThat(actual.getArgLine()).isEqualTo("-Xmx1024m -Dfoo=${BAR} -Dfoo=$@BAR}");
   }
 
   @Test
-  public void doesNotConvertArglineWhenAlreadySetInPitestConfig() throws Exception {
+  public void appendsToExistingArgLine() throws Exception {
+    this.surefireConfig = makeConfig("<argLine>-Xmx1024m -Dfoo=${BAR} -Dfoo=$@BAR}</argLine>");
+    this.options.setArgLine("alreadyHere");
+
+    ReportOptions actual = this.testee
+            .update(this.options, this.surefireConfig);
+
+    assertThat(actual.getArgLine()).isEqualTo("alreadyHere -Xmx1024m -Dfoo=${BAR} -Dfoo=$@BAR}");
+  }
+
+  @Test
+  public void doesNotConvertArglineWhenFlagNotSet() throws Exception {
+    this.testee = new SurefireConfigConverter(false);
     this.surefireConfig = makeConfig("<argLine>-Xmx1024m</argLine>");
 
     this.options.setArgLine("-foo");


### PR DESCRIPTION
In the last release pitest was updated to read argLine arguments from the surefire config, including support for surefire's late parsing of fields using the '@' symbol.

Unfortunately standard fields using the maven '$' syntax were being brought through unreplaced when read from surefire, causing errors when launching processes.

This change resolves this issues, and also moves the parsing of surefire arglines under the control of a new `parseSurefireArgLine` parameter. This is enabled by default, but can be set to false if attempting to read the surefire argline causes an issue for a particular project.