### PR TITLE
shade jackson

### DIFF
--- a/pitest-aggregator/pom.xml
+++ b/pitest-aggregator/pom.xml
@@ -13,6 +13,39 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>com.fasterxml.jackson.dataformat:*</include>
+									<include>com.fasterxml.jackson.core:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>pitest.fasterxml.jackson</shadedPattern>
+								</relocation>
+							</relocations>
+							<!-- gradle scans the multi release jar includes with a potentially old version of ASM. Easiest to exclude.
+							This works for jackson, should be rechecked when including any off multi release dependencies-->
+							<exclude>META-INF/versions/**</exclude>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- must run after shade -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
@@ -29,7 +62,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-xml</artifactId>
-			<version>2.16.2</version>
+			<version>2.17.0</version>
 		</dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -75,6 +75,10 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
     try {
       final Collection<MavenProject> allProjects = findDependencies();
 
+      if (allProjects.isEmpty()) {
+        throw new IllegalStateException("No projects found. Did you call the aggregate goal directly? It must be bound to a lifecycle phase");
+      }
+
       final ReportAggregator.Builder reportAggregationBuilder = ReportAggregator
           .builder();
 

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.2.1</version>
+					<version>3.5.3</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Version mismatches between jackson used on plugins can cause errors, so we are forced to shade it.