### PR TITLE
fixes hcoles/pitest#1333 Expand ${settings.localRepository} in <argLine>

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/AbstractPitMojo.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.eclipse.aether.RepositorySystem;
 import org.pitest.coverage.CoverageSummary;
 import org.pitest.mutationtest.config.PluginServices;
@@ -401,6 +402,9 @@ public class AbstractPitMojo extends AbstractMojo {
   @Parameter(property = "project", readonly = true, required = true)
   private MavenProject                project;
 
+  @Parameter(property = "settings", readonly = true, required = true)
+  private Settings                    settings;
+
   /**
    * <i>Internal</i>: Map of plugin artifacts.
    */
@@ -666,6 +670,10 @@ public class AbstractPitMojo extends AbstractMojo {
 
   public MavenProject getProject() {
     return this.project;
+  }
+
+  public Settings getSettings() {
+    return this.settings;
   }
 
   public Map<String, Artifact> getPluginArtifactMap() {

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -568,6 +568,8 @@ public class MojoToReportOptionsConverter {
       argLine = replaceFieldForSymbol('$', key, argLine);
     }
 
+    argLine = replaceSettingsField(argLine);
+
     return argLine;
   }
 
@@ -575,6 +577,14 @@ public class MojoToReportOptionsConverter {
     String field = symbol + "{" + key + "}";
     if (argLine.contains(field))  {
       return argLine.replace(field, mojo.getProject().getProperties().getProperty(key, ""));
+    }
+    return argLine;
+  }
+
+  private String replaceSettingsField(String argLine) {
+    String field = "${settings.localRepository}";
+    if (argLine.contains(field))  {
+      return argLine.replace(field, mojo.getSettings().getLocalRepository());
     }
     return argLine;
   }

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -31,6 +31,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
@@ -48,6 +49,9 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
   @Mock
   protected MavenSession        session;
+
+  @Mock
+  protected Settings            settings;
 
   @Mock
   protected RunPitStrategy      executionStrategy;
@@ -123,6 +127,7 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
     setVariableValueToObject(pitMojo, "project", this.project);
     setVariableValueToObject(pitMojo, "session", this.session);
+    setVariableValueToObject(pitMojo, "settings", this.settings);
 
     if (pitMojo.getAdditionalClasspathElements() == null) {
       ArrayList<String> elements = new ArrayList<>();

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -469,6 +469,12 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     assertThat(actual.getArgLine()).isEqualTo("fooValue barValue");
   }
 
+  public void testEvaluatesLocalRepositoryPropertyInArgLines() {
+    when(this.settings.getLocalRepository()).thenReturn("localRepoValue");
+    ReportOptions actual = parseConfig("<argLine>${settings.localRepository}/jar</argLine>");
+    assertThat(actual.getArgLine()).isEqualTo("localRepoValue/jar");
+  }
+
   public void testAddsModulesToMutationPathWhenCrossModule() {
     MavenProject dependedOn = project("com.example", "foo");
     MavenProject notDependedOn = project("com.example", "bar");


### PR DESCRIPTION
Added a lookup of `Settings#getLocalRepository()` to the expansion of variables referenced within `<argLine>`  elements.
fixes hcoles/pitest#1333