### PR TITLE
Add "Covered by tests" list for every survived mutation in HTML report

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/MutationResultDataLoader.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/MutationResultDataLoader.java
@@ -4,6 +4,7 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -51,10 +52,12 @@ class MutationResultDataLoader extends DataLoader<MutationResult> {
     Location location = new Location(ClassName.fromString(xml.mutatedClass),
             xml.mutatedMethod, xml.methodDescription);
     MutationIdentifier id = new MutationIdentifier(location, xml.indexes, xml.mutator);
+    String[] killingTests = xml.killingTest == null ? new String[0] : new String[] { xml.killingTest };
+    String[] succeedingTests = xml.succeedingTests == null ? new String[0] : xml.succeedingTests.split(",");
     return new MutationResult(new MutationDetails(id,
             xml.sourceFile, xml.description,
             xml.lineNumber, xml.blocks),
-            new MutationStatusTestPair(xml.numberOfTestsRun, DetectionStatus.valueOf(xml.status), xml.killingTest));
+            new MutationStatusTestPair(xml.numberOfTestsRun, DetectionStatus.valueOf(xml.status), Arrays.asList(killingTests), Arrays.asList(succeedingTests)));
   }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/MutationResult.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/MutationResult.java
@@ -66,6 +66,10 @@ public final class MutationResult {
     return getKillingTest().orElse("none");
   }
 
+  public Boolean getSurvived() {
+    return this.status.getStatus() == DetectionStatus.SURVIVED;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(details, status);

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/MutationStatusMap.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/MutationStatusMap.java
@@ -15,18 +15,21 @@
 package org.pitest.mutationtest;
 
 import static org.pitest.functional.prelude.Prelude.putToMap;
+import static org.pitest.mutationtest.DetectionStatus.SURVIVED;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.pitest.coverage.TestInfo;
 import org.pitest.functional.FCollection;
 import org.pitest.mutationtest.engine.MutationDetails;
 
@@ -41,8 +44,23 @@ public class MutationStatusMap {
 
   public void setStatusForMutation(final MutationDetails mutation,
       final MutationStatusTestPair status) {
-    this.mutationMap.put(mutation, status);
+    MutationStatusTestPair finalStatus = status;
+    if (status.getStatus().equals(SURVIVED)) {
+
+      List<TestInfo> testsInOrder = mutation.getTestsInOrder();
+      List<String> passingTests = new ArrayList<>();
+      for (TestInfo test : testsInOrder) {
+          passingTests.add(test.getName());
+      }
+      finalStatus = new MutationStatusTestPair(status.getNumberOfTestsRun(),
+              status.getStatus(),
+              status.getKillingTests(),
+              passingTests);
+
+    }
+    this.mutationMap.put(mutation, finalStatus);
   }
+
 
   public void setStatusForMutations(
       final Collection<MutationDetails> mutations, final DetectionStatus status) {

--- a/pitest-html-report/src/main/resources/templates/mutation/mutation_report.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/mutation_report.st
@@ -11,7 +11,7 @@
 
 <table class="src">
 
-$sourceFile.lines:{ line | 
+$sourceFile.lines:{ line |
 
 <tr>
 <td class='$line.styles.lineCoverage$'>
@@ -42,7 +42,14 @@ $sourceFile.groups:{ group |
 
 <a name='group$sourceFile$_$group.id$'/> 
 
-$group.mutations: { mutation | <p class='$mutation.status$'><span class='pop'>$i$.<span><b>$i$</b><br/><b>Location : </b>$mutation.details.location$<br/><b>Killed by : </b>$mutation.killingTestDescription$</span></span> $mutation.details.htmlSafeDescription$ &rarr; $mutation.statusDescription$</p> }$
+$group.mutations: { mutation | <p class='$mutation.status$'><span class='pop'>$i$.<span><b>$i$</b><br/><b>Location : </b>$mutation.details.location$<br/><b>Killed by : </b>$mutation.killingTestDescription$</span></span> $mutation.details.htmlSafeDescription$ &rarr; $mutation.statusDescription$</span>
+$if(mutation.survived)$
+<p>Covered by  tests: </p>
+<ul>
+$mutation.succeedingTests: { test | <li>$test$</li> }$
+</ul>
+$endif$
+</p> }$
 </td>
 </tr>
 }$


### PR DESCRIPTION
Right now, when a mutation survives, the tests that cover that mutation are not readily available to the user.

If we provide the list of tests that cover the survived mutation, it would pin-point the places where the user can make improvements.

This PR adds this information to the HTML report.

![image](https://github.com/user-attachments/assets/ed87bdd0-7367-4e70-bafe-64789ce97c93)
