### PR TITLE
log the history file locations when set explicitly

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -289,7 +289,9 @@ public class MojoToReportOptionsConverter {
       useHistoryFileInTempDir(data);
     } else {
       data.setHistoryInputLocation(this.mojo.getHistoryInputFile());
+      log.info("Will read history at " + data.getHistoryInputLocation());
       data.setHistoryOutputLocation(this.mojo.getHistoryOutputFile());
+      log.info("Will write history at " + data.getHistoryOutputLocation());
     }
   }
 


### PR DESCRIPTION
Right now, the history file locations are logged only when the `withHistory` option is enabled.  If they are set explicitly, the locations are not logged.

Logging the history file locations even when set explicitly can make the developer's life easy when integrated into a CI/Nightly build server.  They know exactly which file to archive between builds.  

This also saves time for the developer when debugging the history storage file config for the CI/Nightly build server.