### PR TITLE
fix misleading path logging of history files

### DIFF
--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -335,6 +335,17 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     when(this.project.getVersion()).thenReturn("0.1-SNAPSHOT");      
     final ReportOptions actual = parseConfig("<withHistory>true</withHistory>");
     String expected = "com.example.foo.0.1-SNAPSHOT_pitest_history.bin";
+    assertThat(actual.getHistoryInputLocation()).isNotNull();
+    assertThat(actual.getHistoryInputLocation().getAbsolutePath()).endsWith(expected);
+  }
+
+  public void testOverridesExplicitPathsWhenWithHistoryFlagSet() {
+    when(this.project.getGroupId()).thenReturn("com.example");
+    when(this.project.getArtifactId()).thenReturn("foo");
+    when(this.project.getVersion()).thenReturn("0.1-SNAPSHOT");
+    final ReportOptions actual = parseConfig("<historyInputFile>foo.bin</historyInputFile><withHistory>true</withHistory>");
+    String expected = "com.example.foo.0.1-SNAPSHOT_pitest_history.bin";
+    assertThat(actual.getHistoryInputLocation()).isNotNull();
     assertThat(actual.getHistoryInputLocation().getAbsolutePath()).endsWith(expected);
   }
 


### PR DESCRIPTION
When both withHistory and explicit history paths are set, the log message is misleading.

This change ensures that withHistory overrides explicit paths and the correct file path is logged.