### PR TITLE
Auto add standard kotlin source dirs if present

### DIFF
--- a/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-1/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-1/pom.xml
@@ -39,24 +39,6 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
-				<executions>
-					<execution>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>src/main/kotlin</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-2/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-2/pom.xml
@@ -39,24 +39,6 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
-				<executions>
-					<execution>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>src/main/kotlin</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-3/pom.xml
+++ b/pitest-maven-verification/src/test/resources/pit-kotlin-multi-module/sub-module-3/pom.xml
@@ -39,24 +39,6 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
-				<executions>
-					<execution>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>src/main/kotlin</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -34,7 +34,6 @@ import org.pitest.util.Verbosity;
 
 import java.io.File;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -50,7 +49,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.pitest.functional.Streams.asStream;
 
@@ -220,7 +218,6 @@ public class MojoToReportOptionsConverter {
     final List<String> sourceRoots = new ArrayList<>();
     sourceRoots.addAll(this.mojo.getProject().getCompileSourceRoots());
     sourceRoots.addAll(this.mojo.getProject().getTestCompileSourceRoots());
-    sourceRoots.addAll(kotlinIfPresent());
 
     data.setSourceDirs(stringsToPaths(sourceRoots));
 
@@ -254,17 +251,6 @@ public class MojoToReportOptionsConverter {
     checkForObsoleteOptions(this.mojo);
 
     return data;
-  }
-
-  // Many maven projects will not have the kotlin sources dirs configured within the maven
-  // model. To work around this, the horrible hack below adds them if they are present
-  private Collection<String> kotlinIfPresent() {
-    Path test = Paths.get(this.mojo.getProject().getBasedir().getAbsolutePath(),"src","test","kotlin" );
-    Path main = Paths.get(this.mojo.getProject().getBasedir().getAbsolutePath(),"src","main","kotlin" );
-    return Stream.of(test, main)
-            .filter(Files::exists)
-            .map(p -> p.toFile().getAbsolutePath())
-            .collect(Collectors.toList());
   }
 
   private void configureVerbosity(ReportOptions data) {

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -470,28 +470,6 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     assertThat(actual.getArgLine()).isEqualTo("fooValue barValue");
   }
 
-  public void testAutoAddsKotlinSourceDirsWhenPresent() throws IOException {
-    // we're stuck in junit 3 land but can
-    // use junit 4's temporary folder rule programatically
-    TemporaryFolder t = new TemporaryFolder();
-    try {
-      t.create();
-      File base = t.getRoot();
-      when(project.getBasedir()).thenReturn(base);
-
-      Path main = base.toPath().resolve("src").resolve("main").resolve("kotlin");
-      Path test = base.toPath().resolve("src").resolve("test").resolve("kotlin");
-      Files.createDirectories(main);
-      Files.createDirectories(test);
-
-      ReportOptions actual = parseConfig("");
-      assertThat(actual.getSourcePaths()).contains(main);
-    } finally {
-      t.delete();
-    }
-
-  }
-
   private ReportOptions parseConfig(final String xml) {
     try {
       final String pom = createPomWithConfiguration(xml);

--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -38,7 +38,7 @@ public class PitMojoTest extends BasePitMojoTest {
     when(this.executionProject.getBasedir()).thenReturn(new File("BASEDIR"));
   }
 
-  public void testRunsAMutationReportWhenMutationCoverageGoalTrigered()
+  public void testRunsAMutationReportWhenMutationCoverageGoalTriggered()
       throws Exception {
     this.testee = createPITMojo(createPomWithConfiguration(""));
     final Build build = new Build();


### PR DESCRIPTION
src/main/kotlin and src/test/kotlin are now auto added to the a maven project by the mojo if present.

This is necessary as, for maven builds, these directories are often added at runtime by the build helper or kotlin plugins. If they pitest goal is run directly (as is common) these plugins will not fire and the config will be missing causing confusing failures.

This replaces an earlier hack where there directories were aded at a lower level.