### PR TITLE
Extend transformation extension point

### DIFF
--- a/pitest/src/main/java/org/pitest/mutationtest/environment/TransformationPlugin.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/environment/TransformationPlugin.java
@@ -5,7 +5,7 @@ import org.pitest.plugin.ClientClasspathPlugin;
 import java.lang.instrument.ClassFileTransformer;
 
 public interface TransformationPlugin extends ClientClasspathPlugin {
-
-    ClassFileTransformer makeTransformer();
+    ClassFileTransformer makeCoverageTransformer();
+    ClassFileTransformer makeMutationTransformer();
 
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/execute/MutationTestWorker.java
@@ -21,7 +21,6 @@ import org.pitest.mutationtest.engine.Mutant;
 import org.pitest.mutationtest.engine.Mutater;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.mutationtest.engine.MutationIdentifier;
-import org.pitest.mutationtest.mocksupport.JavassistInterceptor;
 import org.pitest.testapi.Description;
 import org.pitest.testapi.TestResult;
 import org.pitest.testapi.TestUnit;
@@ -62,6 +61,7 @@ public class MutationTestWorker {
 
   private final ResetEnvironment                            reset;
 
+
   public MutationTestWorker(HotSwap hotswap,
                             Mutater mutater,
                             ClassLoader loader,
@@ -91,17 +91,13 @@ public class MutationTestWorker {
 
   }
 
-  private void processMutation(final Reporter r,
-      final TimeOutDecoratedTestSource testSource,
-      final MutationDetails mutationDetails) {
+  private void processMutation(Reporter r,
+                               TimeOutDecoratedTestSource testSource,
+                               MutationDetails mutationDetails) {
 
     final MutationIdentifier mutationId = mutationDetails.getId();
     final Mutant mutatedClass = this.mutater.getMutation(mutationId);
 
-    // For the benefit of mocking frameworks such as PowerMock
-    // mess with the internals of Javassist so our mutated class
-    // bytes are returned
-    JavassistInterceptor.setMutant(mutatedClass);
     reset.resetFor(mutatedClass);
 
     if (DEBUG) {
@@ -126,8 +122,8 @@ public class MutationTestWorker {
       final List<TestUnit> relevantTests) {
     final MutationStatusTestPair mutationDetected;
     if ((relevantTests == null) || relevantTests.isEmpty()) {
-      LOG.info(() -> "No test coverage for mutation " + mutationId + " in "
-          + mutatedClass.getDetails().getMethod());
+      LOG.log(Level.WARNING, "No test coverage for mutation " + mutationId + " in " + mutatedClass.getDetails().getMethod()
+              + ". This should have been detected in the outer process so treating as an error");
       mutationDetected =  MutationStatusTestPair.notAnalysed(0, DetectionStatus.RUN_ERROR, Collections.emptyList());
     } else {
       mutationDetected = handleCoveredMutation(mutationId, mutatedClass,
@@ -142,7 +138,7 @@ public class MutationTestWorker {
       final List<TestUnit> relevantTests) {
     final MutationStatusTestPair mutationDetected;
     if (DEBUG) {
-      LOG.fine("" + relevantTests.size() + " relevant test for "
+      LOG.fine(relevantTests.size() + " relevant test for "
           + mutatedClass.getDetails().getMethod());
     }
 

--- a/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistInputStreamInterceptorAdapter.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistInputStreamInterceptorAdapter.java
@@ -22,17 +22,17 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.pitest.bytecode.ASMVersion;
 
-public class JavassistInputStreamInterceptorAdapater extends ClassVisitor {
+public class JavassistInputStreamInterceptorAdapter extends ClassVisitor {
 
   private final String interceptorClass;
 
-  public JavassistInputStreamInterceptorAdapater(final ClassVisitor arg0, Class<?> interceptor) {
+  public JavassistInputStreamInterceptorAdapter(final ClassVisitor arg0, Class<?> interceptor) {
     super(ASMVersion.ASM_VERSION, arg0);
     this.interceptorClass = classToName(interceptor);
   }
 
   public static Function<ClassWriter, ClassVisitor> inputStreamAdapterSupplier(final Class<?> interceptor) {
-    return a -> new JavassistInputStreamInterceptorAdapater(a, interceptor);
+    return a -> new JavassistInputStreamInterceptorAdapter(a, interceptor);
   }
 
 
@@ -59,8 +59,8 @@ class JavassistInputStreamInterceptorMethodVisitor extends MethodVisitor {
   }
 
   @Override
-  public void visitMethodInsn(final int opcode, final String owner,
-      final String name, final String desc, boolean itf) {
+  public void visitMethodInsn(int opcode, String owner,
+      String name, String desc, boolean itf) {
     if ((opcode == Opcodes.INVOKEINTERFACE)
         && owner.equals("javassist/ClassPath") && name.equals("openClassfile")) {
       this.mv.visitMethodInsn(Opcodes.INVOKESTATIC, this.interceptorClass, name,

--- a/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistInterceptor.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistInterceptor.java
@@ -34,7 +34,7 @@ public final class JavassistInterceptor {
       final String name) {
 
     if (isMutatedClass(name)) {
-      return  new ByteArrayInputStream(
+      return new ByteArrayInputStream(
           mutant.getBytes());
     } else {
       return returnNormalBytes(classPath, name);
@@ -58,7 +58,7 @@ public final class JavassistInterceptor {
         .equals(ClassName.fromString(name));
   }
 
-  public static void setMutant(final Mutant newMutant) {
+  static void setMutant(final Mutant newMutant) {
     mutant = newMutant;
   }
 }

--- a/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistTransformation.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/mocksupport/JavassistTransformation.java
@@ -1,0 +1,30 @@
+package org.pitest.mutationtest.mocksupport;
+
+import org.pitest.coverage.execute.JavassistCoverageInterceptor;
+import org.pitest.functional.prelude.Prelude;
+import org.pitest.mutationtest.environment.TransformationPlugin;
+import org.pitest.util.Glob;
+
+import java.lang.instrument.ClassFileTransformer;
+
+public class JavassistTransformation implements TransformationPlugin {
+
+    @Override
+    public ClassFileTransformer makeCoverageTransformer() {
+        return new BendJavassistToMyWillTransformer(Prelude
+                .or(new Glob("javassist/*")),
+                JavassistInputStreamInterceptorAdapter.inputStreamAdapterSupplier(JavassistCoverageInterceptor.class));
+    }
+
+    @Override
+    public ClassFileTransformer makeMutationTransformer() {
+        return new BendJavassistToMyWillTransformer(Prelude
+                .or(new Glob("javassist/*")),
+                JavassistInputStreamInterceptorAdapter.inputStreamAdapterSupplier(JavassistInterceptor.class));
+    }
+
+    @Override
+    public String description() {
+        return "Support for mocking frameworks using javassist";
+    }
+}

--- a/pitest/src/main/java/org/pitest/mutationtest/mocksupport/ResetJavassistEnvironment.java
+++ b/pitest/src/main/java/org/pitest/mutationtest/mocksupport/ResetJavassistEnvironment.java
@@ -1,0 +1,16 @@
+package org.pitest.mutationtest.mocksupport;
+
+import org.pitest.mutationtest.environment.EnvironmentResetPlugin;
+import org.pitest.mutationtest.environment.ResetEnvironment;
+
+public class ResetJavassistEnvironment implements EnvironmentResetPlugin {
+    @Override
+    public ResetEnvironment make() {
+        return JavassistInterceptor::setMutant;
+    }
+
+    @Override
+    public String description() {
+        return "Reset environment for javassist";
+    }
+}

--- a/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.environment.EnvironmentResetPlugin
+++ b/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.environment.EnvironmentResetPlugin
@@ -1,0 +1,1 @@
+org.pitest.mutationtest.mocksupport.ResetJavassistEnvironment

--- a/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.environment.TransformationPlugin
+++ b/pitest/src/main/resources/META-INF/services/org.pitest.mutationtest.environment.TransformationPlugin
@@ -1,0 +1,1 @@
+org.pitest.mutationtest.mocksupport.JavassistTransformation

--- a/pitest/src/test/java/org/pitest/mutationtest/mocksupport/BendJavassistToMyWillTransformerTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/mocksupport/BendJavassistToMyWillTransformerTest.java
@@ -27,7 +27,7 @@ public class BendJavassistToMyWillTransformerTest {
   @Before
   public void setUp() {
     MockitoAnnotations.openMocks(this);
-    this.testee = new BendJavassistToMyWillTransformer(this.filter, JavassistInputStreamInterceptorAdapater.inputStreamAdapterSupplier(JavassistInterceptor.class));
+    this.testee = new BendJavassistToMyWillTransformer(this.filter, JavassistInputStreamInterceptorAdapter.inputStreamAdapterSupplier(JavassistInterceptor.class));
     final ClassloaderByteArraySource source = new ClassloaderByteArraySource(
         IsolationUtils.getContextClassLoader());
     this.bytes = source.getBytes("java.lang.String").get();

--- a/pitest/src/test/java/org/pitest/mutationtest/mocksupport/JavassistInputStreamInterceptorAdapterTest.java
+++ b/pitest/src/test/java/org/pitest/mutationtest/mocksupport/JavassistInputStreamInterceptorAdapterTest.java
@@ -9,7 +9,7 @@ import org.mockito.MockitoAnnotations;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
-public class JavassistInputStreamInterceptorAdapaterTest {
+public class JavassistInputStreamInterceptorAdapterTest {
 
   private JavassistInputStreamInterceptorMethodVisitor testee;
 


### PR DESCRIPTION
Extends the transformation plugin interface to allow separate transformations at the coverage and mutation testing phases.

Javassist implementation is moved into plugin using the new interface.