### PR TITLE
remove use of reflection based toString generator

### DIFF
--- a/pitest-entry/pom.xml
+++ b/pitest-entry/pom.xml
@@ -133,7 +133,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.10.0</version>
+			<version>1.12.0</version>
 		</dependency>
 
 		<dependency>

--- a/pitest-maven/src/main/java/org/pitest/maven/report/generator/ReportGenerationContext.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/generator/ReportGenerationContext.java
@@ -18,8 +18,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.logging.Log;
 
@@ -97,8 +95,11 @@ public class ReportGenerationContext {
 
   @Override
   public String toString() {
-    return ToStringBuilder.reflectionToString(this,
-        ToStringStyle.MULTI_LINE_STYLE);
+    return "ReportGenerationContext{"
+            + "locale=" + locale
+            + ", reportsDataDirectory=" + reportsDataDirectory
+            + ", siteDirectory=" + siteDirectory
+            + ", sourceDataFormats=" + sourceDataFormats
+            + '}';
   }
-
 }


### PR DESCRIPTION
The reflection based toString generator fails on some modern jvms as apache commons tries to parse out the version of Java, but fails due to outdated assumptions.

Not clear why it's inmportant to have a toString method here, but replacing with an autogenerated one should solve #1358. Implementation excludes logger and sink form toString as it's unclear how they would be useful.