### PR TITLE
report test count

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -138,7 +138,7 @@ public final class ReportAggregator {
       Collection<BlockLocation> coverageData = this.blockCoverageLoader.loadData().stream()
               .map(BlockCoverage::getBlock)
               .collect(Collectors.toList());
-      CoverageData cd = new CoverageData(codeSource, new LineMapper(codeSource));
+      CoverageData cd = new CoverageData(codeSource, new LineMapper(codeSource), 0);
       cd.loadBlockDataOnly(coverageData);
 
       return transformCoverage(cd);

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageData.java
@@ -42,14 +42,15 @@ public class CoverageData implements CoverageDatabase {
 
   private final Map<BlockLocation, Set<TestInfo>> blockCoverage = new LinkedHashMap<>();
   private final LegacyClassCoverage legacyClassCoverage;
-
   private final CodeSource code;
+  private final int testCount;
 
   private final List<Description> failingTestDescriptions = new ArrayList<>();
 
-  public CoverageData(final CodeSource code, final LineMap lm) {
+  public CoverageData(CodeSource code, LineMap lm, int testCount) {
     this.code = code;
     this.legacyClassCoverage = new LegacyClassCoverage(code, lm);
+    this.testCount = testCount;
   }
 
   public void calculateClassCoverage(final CoverageResult cr) {
@@ -74,6 +75,11 @@ public class CoverageData implements CoverageDatabase {
   @Override
   public Collection<TestInfo> getTestsForBlockLocation(BlockLocation location) {
     return this.blockCoverage.getOrDefault(location, Collections.emptySet());
+  }
+
+  @Override
+  public int testCount() {
+    return testCount;
   }
 
   public boolean allTestsGreen() {

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageDatabase.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 
 public interface CoverageDatabase extends ReportCoverage {
 
+  int testCount();
+
   Collection<TestInfo> getTestsForClass(ClassName clazz);
 
   Collection<TestInfo> getTestsForBlockLocation(BlockLocation location);

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
@@ -7,12 +7,18 @@ import static org.pitest.util.PercentageCalculator.getPercentage;
  */
 public final class CoverageSummary {
 
+  private final int numberOfTests;
   private final int numberOfLines;
   private final int numberOfCoveredLines;
 
-  public CoverageSummary(final int numberOfLines, final int numberOfCoveredLines) {
+  public CoverageSummary(int numberOfLines, int numberOfCoveredLines, int numberOfTests) {
     this.numberOfLines = numberOfLines;
     this.numberOfCoveredLines = numberOfCoveredLines;
+    this.numberOfTests = numberOfTests;
+  }
+
+  public int getNumberOfTests() {
+    return this.numberOfTests;
   }
 
   public int getNumberOfLines() {

--- a/pitest-entry/src/main/java/org/pitest/coverage/NoCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/NoCoverage.java
@@ -19,6 +19,11 @@ public class NoCoverage implements CoverageDatabase {
     }
 
     @Override
+    public int testCount() {
+        return 0;
+    }
+
+    @Override
     public Collection<TestInfo> getTestsForClass(ClassName clazz) {
         return Collections.emptyList();
     }

--- a/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/execute/DefaultCoverageGenerator.java
@@ -90,7 +90,7 @@ public class DefaultCoverageGenerator implements CoverageGenerator {
       this.timings.registerEnd(Timings.Stage.SCAN_CLASS_PATH);
 
       final CoverageData coverage = new CoverageData(this.code, new LineMapper(
-          this.code));
+          this.code), tests.size());
 
       this.timings.registerStart(Timings.Stage.COVERAGE);
       if (tests.isEmpty()) {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -148,7 +148,7 @@ public class MutationCoverage {
 
   private CombinedStatistics emptyStatistics() {
     MutationStatistics mutationStatistics = new MutationStatistics(emptyList(),0,0,0,0, emptySet());
-    return new CombinedStatistics(mutationStatistics, new CoverageSummary(0,0), Collections.emptyList());
+    return new CombinedStatistics(mutationStatistics, new CoverageSummary(0,0, 0), Collections.emptyList());
   }
 
   private CombinedStatistics runAnalysis(Runtime runtime, long t0, EngineArguments args, MutationEngine engine, List<BuildMessage> issues, List<MutationDetails> unfilteredMutants) {
@@ -191,7 +191,7 @@ public class MutationCoverage {
 
     MutationStatistics mutationStats = stats.getStatistics();
     CombinedStatistics combined = new CombinedStatistics(mutationStats,
-            createSummary(modifiedCoverage, mutationStats.mutatedClasses()), issues);
+            createSummary(coverageData.testCount(), modifiedCoverage, mutationStats.mutatedClasses()), issues);
 
     printStats(combined);
 
@@ -204,7 +204,7 @@ public class MutationCoverage {
     return strategies.coverageTransformer().transform(coverageData);
   }
 
-  private CoverageSummary createSummary(ReportCoverage modifiedCoverage, Set<ClassName> mutatedClasses) {
+  private CoverageSummary createSummary(int numberOfTests, ReportCoverage modifiedCoverage, Set<ClassName> mutatedClasses) {
     List<ClassName> examinedClasses = this.code.getCodeUnderTestNames().stream()
             .filter(mutatedClasses::contains)
             .collect(Collectors.toList());
@@ -218,7 +218,7 @@ public class MutationCoverage {
             .mapToInt(c -> modifiedCoverage.getCoveredLines(c).size())
             .sum();
 
-    return new CoverageSummary(numberOfCodeLines, coveredLines);
+    return new CoverageSummary(numberOfCodeLines, coveredLines, numberOfTests);
   }
 
   private Predicate<MutationInterceptor> allInterceptors() {
@@ -318,6 +318,7 @@ public class MutationCoverage {
     if (coverage != null) {
       ps.println(String.format(">> Line Coverage (for mutated classes only): %d/%d (%d%%)", coverage.getNumberOfCoveredLines(),
               coverage.getNumberOfLines(), coverage.getCoverage()));
+      ps.println(String.format(">> %d tests examined", coverage.getNumberOfTests()));
     }
 
     stats.report(ps);

--- a/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/CoverageDataTest.java
@@ -70,7 +70,7 @@ public class CoverageDataTest {
     when(this.lm.mapLines(any(ClassName.class))).thenReturn(
         new HashMap<>());
     when(this.code.findTestee(any())).thenReturn(Optional.empty());
-    this.testee = new CoverageData(this.code, this.lm);
+    this.testee = new CoverageData(this.code, this.lm, 42);
   }
 
   @Test
@@ -195,7 +195,7 @@ public class CoverageDataTest {
     ClassTree barClass = treeFor(com.example.a.b.c.Bar.class);
     when(this.code.codeTrees()).thenReturn(Stream.of(fooClass, barClass));
 
-    this.testee = new CoverageData(this.code, this.lm);
+    this.testee = new CoverageData(this.code, this.lm, 0);
 
     assertThat(this.testee.getClassesForFile("Bar.java", "com.example.a.b.c"))
             .containsExactly(new ClassLines(barClass.name(), Collections.emptySet()));
@@ -209,11 +209,16 @@ public class CoverageDataTest {
 
     when(this.code.codeTrees()).thenReturn(classes.stream());
 
-    this.testee = new CoverageData(this.code, this.lm);
+    this.testee = new CoverageData(this.code, this.lm, 0);
 
     assertThat(this.testee.getClassesForFile("Foo.java", "com.example.a.b.c"))
             .containsExactly(new ClassLines(foo1Class.name(), Collections.emptySet()));
 
+  }
+
+  @Test
+  public void reportsTestCount() {
+    assertThat(testee.testCount()).isEqualTo(42);
   }
 
   private CoverageResult makeCoverageResult(final String clazz,

--- a/pitest-entry/src/test/java/org/pitest/coverage/CoverageSummaryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/CoverageSummaryTest.java
@@ -8,22 +8,22 @@ public class CoverageSummaryTest {
 
   @Test
   public void shouldCorrectlyCalculateLineCoverageWhenNoLinesPresent() {
-    assertEquals(100, new CoverageSummary(0, 0).getCoverage());
+    assertEquals(100, new CoverageSummary(0, 0, 0).getCoverage());
   }
 
   @Test
   public void shouldCorrectlyCalculateLineCoverageWhenNoLinesCovered() {
-    assertEquals(0, new CoverageSummary(100, 0).getCoverage());
+    assertEquals(0, new CoverageSummary(100, 0, 0).getCoverage());
   }
 
   @Test
   public void shouldCorrectlyCalculateLineCoverageWhenAllLinesCovered() {
-    assertEquals(100, new CoverageSummary(100, 100).getCoverage());
+    assertEquals(100, new CoverageSummary(100, 100, 0).getCoverage());
   }
 
   @Test
   public void shouldCorrectlyCalculateLineCoverageWhenPartiallyCovered() {
-    assertEquals(50, new CoverageSummary(100, 50).getCoverage());
+    assertEquals(50, new CoverageSummary(100, 50, 0).getCoverage());
   }
 
 }

--- a/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/PitMojoTest.java
@@ -415,7 +415,7 @@ public class PitMojoTest extends BasePitMojoTest {
       throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();
     final MutationStatistics stats = new MutationStatistics(scores, 100, mutationScore, 100, 0, Collections.emptySet());
-    CoverageSummary sum = new CoverageSummary(lines, linesCovered);
+    CoverageSummary sum = new CoverageSummary(lines, linesCovered, 0);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(
         this.executionStrategy.execute(any(File.class),
@@ -427,7 +427,7 @@ public class PitMojoTest extends BasePitMojoTest {
           throws MojoExecutionException {
     Iterable<Score> scores = Collections.<Score>emptyList();
     final MutationStatistics stats = new MutationStatistics(scores, totalMutations, mutationDetected, mutationsWithCoverage, 0, Collections.emptySet());
-    CoverageSummary sum = new CoverageSummary(0, 0);
+    CoverageSummary sum = new CoverageSummary(0, 0, 0);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(
             this.executionStrategy.execute(any(File.class),
@@ -440,7 +440,7 @@ public class PitMojoTest extends BasePitMojoTest {
     Iterable<Score> scores = Collections.<Score>emptyList();
     int detected = 100;
     final MutationStatistics stats = new MutationStatistics(scores, detected + survivors, detected, detected + survivors, 0, Collections.emptySet());
-    CoverageSummary sum = new CoverageSummary(0, 0);
+    CoverageSummary sum = new CoverageSummary(0, 0, 0);
     final CombinedStatistics cs = new CombinedStatistics(stats, sum, Collections.emptyList());
     when(
         this.executionStrategy.execute(any(File.class),


### PR DESCRIPTION
Report number of examined tests on console. Of some interest to end users, but reporting in a structured way via the AnalysisResult is mainly of use for tests. Making the number of internally examined tests available externally allows tests to ensure that optimisation measures are working.