### PR TITLE
catch and log empty methods

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
@@ -26,6 +26,7 @@ import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.sequence.QueryParams;
 import org.pitest.sequence.QueryStart;
 import org.pitest.sequence.SequenceMatcher;
+import org.pitest.util.Log;
 
 public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
 
@@ -92,6 +93,11 @@ public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
   }
 
   private boolean shortCutEquals(MethodTree tree, MutationDetails a, Mutater m) {
+    if (tree.instructions().isEmpty()) {
+      Log.getLogger().warning(tree.asLocation() + " has no instructions");
+      return false;
+    }
+
     if (!mutatesAConditionalJump(tree, a.getInstructionIndex())) {
       return false;
     }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
@@ -49,6 +49,7 @@ import org.pitest.sequence.QueryStart;
 import org.pitest.sequence.SequenceMatcher;
 import org.pitest.sequence.SequenceQuery;
 import org.pitest.sequence.Slot;
+import org.pitest.util.Log;
 
 public class ForEachLoopFilter implements MutationInterceptor {
 
@@ -195,6 +196,11 @@ public class ForEachLoopFilter implements MutationInterceptor {
         return false;
       }
       MethodTree method = maybeMethod.get();
+
+      if (method.instructions().isEmpty()) {
+        Log.getLogger().warning(method.asLocation() + " has no instructions");
+        return false;
+      }
 
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
@@ -46,6 +46,7 @@ import org.pitest.sequence.SequenceMatcher;
 import org.pitest.sequence.SequenceQuery;
 import org.pitest.sequence.Slot;
 import org.pitest.sequence.SlotWrite;
+import org.pitest.util.Log;
 
 /**
  * Removes mutants that affect for loop counters as these have
@@ -164,6 +165,10 @@ public class AvoidForLoopCounterFilter implements MutationInterceptor {
         return false;
       }
       MethodTree method = maybeMethod.get();
+      if (method.instructions().isEmpty()) {
+        Log.getLogger().warning(method.asLocation() + " has no instructions");
+        return false;
+      }
 
       final AbstractInsnNode mutatedInstruction = method.instruction(instruction);
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
@@ -21,6 +21,7 @@ import org.pitest.mutationtest.engine.Location;
 import org.pitest.mutationtest.engine.Mutater;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.sequence.SequenceMatcher;
+import org.pitest.util.Log;
 
 public abstract class InfiniteLoopFilter implements MutationInterceptor {
 
@@ -60,6 +61,10 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
       return Collections.emptyList();
     }
     MethodTree method = maybeMethod.get();
+    if (method.instructions().isEmpty()) {
+      Log.getLogger().warning(method.asLocation() + " has no instructions");
+      return Collections.emptyList();
+    }
 
     //  give up if our matcher thinks loop is already infinite
     if (infiniteLoopMatcher().matches(method.instructions())) {


### PR DESCRIPTION
It appears to be possible for the pitest filters to be passed methods without instructions. It is not yet clear how this situation arises, so this change adds logging along with a check.