### PR TITLE
prevent re-evaluation of suite classes

### DIFF
--- a/pitest/src/main/java/org/pitest/testapi/execute/FindTestUnits.java
+++ b/pitest/src/main/java/org/pitest/testapi/execute/FindTestUnits.java
@@ -1,10 +1,9 @@
 package org.pitest.testapi.execute;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.pitest.testapi.Configuration;
 import org.pitest.testapi.NullExecutionListener;
@@ -13,7 +12,6 @@ import org.pitest.testapi.TestUnitExecutionListener;
 
 /**
  * Scans classes to discover TestUnits
- *
  */
 public class FindTestUnits {
 
@@ -30,42 +28,11 @@ public class FindTestUnits {
   }
 
   public List<TestUnit> findTestUnitsForAllSuppliedClasses(Iterable<Class<?>> classes) {
-    final List<TestUnit> testUnits = new ArrayList<>();
-
-    for (final Class<?> c : classes) {
-      final Collection<TestUnit> testUnitsFromClass = getTestUnits(c);
-      testUnits.addAll(testUnitsFromClass);
-    }
-
-    return testUnits;
-
-  }
-
-  private Collection<TestUnit> getTestUnits(final Class<?> suiteClass) {
-    final List<TestUnit> tus = new ArrayList<>();
-    final Set<Class<?>> visitedClasses = new HashSet<>();
-    findTestUnits(tus, visitedClasses, suiteClass);
-    return tus;
-  }
-
-  private void findTestUnits(final List<TestUnit> tus,
-      final Set<Class<?>> visitedClasses, final Class<?> suiteClass) {
-    visitedClasses.add(suiteClass);
-    final Collection<Class<?>> tcs = this.config.testSuiteFinder().apply(
-        suiteClass);
-
-    for (final Class<?> tc : tcs) {
-      if (!visitedClasses.contains(tc)) {
-        findTestUnits(tus, visitedClasses, tc);
-      }
-    }
-
-    final List<TestUnit> testsInThisClass = this.config.testUnitFinder()
-        .findTestUnits(suiteClass, listener);
-    if (!testsInThisClass.isEmpty()) {
-      tus.addAll(testsInThisClass);
-    }
-
+    return StreamSupport.stream(classes.spliterator(), false)
+            .flatMap(c -> Stream.concat(Stream.of(c), this.config.testSuiteFinder().apply(c).stream()))
+            .distinct()
+            .flatMap(c -> this.config.testUnitFinder().findTestUnits(c, listener).stream())
+            .collect(Collectors.toList());
   }
 
 }

--- a/pitest/src/test/java/org/pitest/testapi/execute/FindTestUnitsTest.java
+++ b/pitest/src/test/java/org/pitest/testapi/execute/FindTestUnitsTest.java
@@ -1,0 +1,67 @@
+package org.pitest.testapi.execute;
+
+import org.junit.Test;
+import org.pitest.help.PitHelpError;
+import org.pitest.testapi.Configuration;
+import org.pitest.testapi.Description;
+import org.pitest.testapi.ResultCollector;
+import org.pitest.testapi.TestSuiteFinder;
+import org.pitest.testapi.TestUnit;
+import org.pitest.testapi.TestUnitFinder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FindTestUnitsTest {
+
+    @Test
+    public void doesNotDuplicateTestsWhenClassesReintroducedViaSuite() {
+        Configuration config = new Configuration() {
+            @Override
+            public TestUnitFinder testUnitFinder() {
+                return (c,n) -> {
+                    if (c.getName().contains("ATest")) {
+                        return List.of(new FakeTestUnit());
+                    }
+                    return List.of();
+                };
+            }
+
+            @Override
+            public TestSuiteFinder testSuiteFinder() {
+                return c -> List.of(ATest.class, ATest2.class);
+            }
+
+            @Override
+            public Optional<PitHelpError> verifyEnvironment() {
+                return Optional.empty();
+            }
+        };
+        FindTestUnits underTest = new FindTestUnits(config);
+
+        List<TestUnit> actual = underTest.findTestUnitsForAllSuppliedClasses(List.of(ATest2.class, ATest.class));
+        assertThat(actual).hasSize(2);
+    }
+}
+
+class ATest {
+
+}
+
+class ATest2 {
+
+}
+
+class FakeTestUnit implements TestUnit {
+    @Override
+    public void execute(ResultCollector rc) {
+
+    }
+
+    @Override
+    public Description getDescription() {
+        return null;
+    }
+}


### PR DESCRIPTION
If a test class matched both target classes, and was also returned from a suite, it was being scanned twice.