### PR TITLE
Auto-configure JUnit Jupiter dependencies

### DIFF
--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -417,9 +417,12 @@ public class MojoToReportOptionsConverter {
       classPath.add(dependency.getFile().getAbsolutePath());
     }
 
-    // If the user as explicitly added junit platform classes to the pitest classpath, trust that they
-    // know what they're doing and add them in
-    this.mojo.getPluginArtifactMap().values().stream().filter(a -> a.getGroupId().equals("org.junit.platform"))
+    // If the user as explicitly added junit platform or jupiter dependencies to the pitest classpath,
+    // trust that they know what they're doing and add them in
+    this.mojo.getPluginArtifactMap().values().stream()
+            .filter(a -> a.getGroupId().equals("org.junit.platform") || a.getGroupId().equals("org.junit.jupiter"))
+            .peek(a -> this.log.info("Adding JUnit " + a.getGroupId() + ":"
+                    + a.getArtifactId() + " to SUT classpath"))
             .forEach(dependency -> classPath.add(dependency.getFile().getAbsolutePath()));
   }
 

--- a/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/BasePitMojoTest.java
@@ -65,6 +65,8 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
   Properties properties = new Properties();
 
+  Map<String, Artifact> pluginArtifacts = new HashMap<>();
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
@@ -121,7 +123,6 @@ public abstract class BasePitMojoTest extends AbstractMojoTestCase {
 
     configureMojo(pitMojo, pluginConfiguration);
 
-    final Map<String, Artifact> pluginArtifacts = new HashMap<>();
     setVariableValueToObject(pitMojo, "pluginArtifactMap", pluginArtifacts);
 
     setVariableValueToObject(pitMojo, "project", this.project);

--- a/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
+++ b/pitest-maven/src/test/java/org/pitest/maven/MojoToReportOptionsConverterTest.java
@@ -404,13 +404,17 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
   public void testAutoAddsJunitPlatformDependencies() {
     final ArtifactHandler artifactHandler = Mockito.mock(ArtifactHandler.class);
     final Artifact junitArtifact = new DefaultArtifact("org.junit.platform", "junit-platform-engine", "1.12.2", "test", "jar", null, artifactHandler);
-    final String artifactPath = String.format("/home/user/.m2/repository/%s/%s/%s/%s-%s.jar",
-          junitArtifact.getGroupId().replace(".", "/"), junitArtifact.getArtifactId(), junitArtifact.getVersion(), junitArtifact.getArtifactId(), junitArtifact.getVersion());
-    junitArtifact.setFile(new File(artifactPath));
+    final File artifactFile = new File(String.format("/home/user/.m2/repository/%s/%s/%s/%s-%s.jar",
+            junitArtifact.getGroupId().replace(".", "/"),
+            junitArtifact.getArtifactId(),
+            junitArtifact.getVersion(),
+            junitArtifact.getArtifactId(),
+            junitArtifact.getVersion())).getAbsoluteFile();
+    junitArtifact.setFile(artifactFile);
     pluginArtifacts.put("junit-platform", junitArtifact);
 
     final ReportOptions actual = parseConfig("");
-    assertThat(actual.getClassPathElements()).contains(artifactPath);
+    assertThat(actual.getClassPathElements()).contains(artifactFile.toString());
   }
 
   public void testAutoAddsJunitJupiterDependencies() {
@@ -419,11 +423,15 @@ public class MojoToReportOptionsConverterTest extends BasePitMojoTest {
     final Artifact junitParamsArtifact = new DefaultArtifact("org.junit.jupiter", "junit-jupiter-params", "5.12.2", "test", "jar", null, artifactHandler);
     final List<String> expectedArtifactPaths = new ArrayList<>();
     for (Artifact artifact : Arrays.asList(junitEngineArtifact, junitParamsArtifact)) {
-        final String artifactPath = String.format("/home/user/.m2/repository/%s/%s/%s/%s-%s.jar",
-                artifact.getGroupId().replace(".", "/"), artifact.getArtifactId(), artifact.getVersion(), artifact.getArtifactId(), artifact.getVersion());
-        artifact.setFile(new File(artifactPath));
+        final File artifactFile = new File(String.format("/home/user/.m2/repository/%s/%s/%s/%s-%s.jar",
+                artifact.getGroupId().replace(".", "/"),
+                artifact.getArtifactId(),
+                artifact.getVersion(),
+                artifact.getArtifactId(),
+                artifact.getVersion())).getAbsoluteFile();
+        artifact.setFile(artifactFile);
         pluginArtifacts.put(artifact.getArtifactId(), artifact);
-        expectedArtifactPaths.add(artifactPath);
+        expectedArtifactPaths.add(artifactFile.toString());
     }
 
     final ReportOptions actual = parseConfig("");


### PR DESCRIPTION
In our large multi-module monorepo we found ourselves having to add the `junit-jupiter-engine` dependency to modules so that pitest can run mutation tests, but ideally we'd love to just add the engine dependency to the pitest plugin execution instead as Surefire/Failsafe doesn't need it.

Our current workaround is to add the engine dependency _and_ configure the additional classpath, but it would be nice if that happened automatically (like it does for the platform jars already).

```xml
<additionalClasspathElements>
    ${settings.localRepository}/org/junit/jupiter/junit-jupiter-engine/${junit5.version}/junit-jupiter-engine-${junit5.version}.jar
</additionalClasspathElements>
```