### PR TITLE
disable filters with empty method checks for interfaces

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
@@ -61,6 +61,13 @@ public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
   @Override
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
+
+    // skip for mutations to annotations on interfaces
+    // to avoid generating empty method warnings.
+    if (this.currentClass.isInterface()) {
+      return mutations;
+    }
+
    final List<MutationDetails> doNotTouch = mutations.stream()
            .filter(inEqualsMethod().negate())
            .collect(Collectors.toList());

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
@@ -184,6 +184,13 @@ public class ForEachLoopFilter implements MutationInterceptor {
   @Override
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
+
+    // skip for mutations to annotations on interfaces
+    // to avoid generating empty method warnings.
+    if (this.currentClass.isInterface()) {
+      return mutations;
+    }
+
     return mutations.stream().filter(mutatesIteratorLoopPlumbing().negate())
             .collect(Collectors.toList());
   }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
@@ -49,7 +49,7 @@ import org.pitest.sequence.SlotWrite;
 import org.pitest.util.Log;
 
 /**
- * Removes mutants that affect for loop counters as these have
+ * Removes mutants that effect for loop counters as these have
  * a high chance of timing out.
  */
 public class AvoidForLoopCounterFilter implements MutationInterceptor {
@@ -152,6 +152,13 @@ public class AvoidForLoopCounterFilter implements MutationInterceptor {
   @Override
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
+
+    // skip for mutations to annotations on interfaces
+    // to avoid generating empty method warnings.
+    if (this.currentClass.isInterface()) {
+      return mutations;
+    }
+
     return mutations.stream()
             .filter(mutatesAForLoopCounter().negate())
             .collect(Collectors.toList());

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
@@ -43,6 +43,13 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
   @Override
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
+
+    // skip for mutations to annotations on interfaces
+    // to avoid generating empty method warnings.
+    if (this.currentClass.isInterface()) {
+      return mutations;
+    }
+
     final Map<Location,Collection<MutationDetails>> buckets = FCollection.bucket(mutations, mutationToLocation());
 
     final List<MutationDetails> willTimeout = new ArrayList<>();


### PR DESCRIPTION
Third party plugins now support mutating annotations, so it is now possible for mutations to be applied to interfaces. This results in warnings in the logs from some filters that expect non empty methods. An explicit checks for interfaces will prevent the majority of these messages (though they may still occur for annotations on abstract methods).