### PR TITLE
revert performance regression

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/equivalent/EqualsPerformanceShortcutFilter.java
@@ -26,7 +26,6 @@ import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.sequence.QueryParams;
 import org.pitest.sequence.QueryStart;
 import org.pitest.sequence.SequenceMatcher;
-import org.pitest.util.Log;
 
 public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
 
@@ -62,12 +61,6 @@ public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
 
-    // skip for mutations to annotations on interfaces
-    // to avoid generating empty method warnings.
-    if (this.currentClass.isInterface()) {
-      return mutations;
-    }
-
    final List<MutationDetails> doNotTouch = mutations.stream()
            .filter(inEqualsMethod().negate())
            .collect(Collectors.toList());
@@ -101,7 +94,7 @@ public class EqualsPerformanceShortcutFilter implements MutationInterceptor {
 
   private boolean shortCutEquals(MethodTree tree, MutationDetails a, Mutater m) {
     if (tree.instructions().isEmpty()) {
-      Log.getLogger().warning(tree.asLocation() + " has no instructions");
+      // occurs for mutations to annotations on interfaces
       return false;
     }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/javafeatures/ForEachLoopFilter.java
@@ -49,7 +49,6 @@ import org.pitest.sequence.QueryStart;
 import org.pitest.sequence.SequenceMatcher;
 import org.pitest.sequence.SequenceQuery;
 import org.pitest.sequence.Slot;
-import org.pitest.util.Log;
 
 public class ForEachLoopFilter implements MutationInterceptor {
 
@@ -185,12 +184,6 @@ public class ForEachLoopFilter implements MutationInterceptor {
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
 
-    // skip for mutations to annotations on interfaces
-    // to avoid generating empty method warnings.
-    if (this.currentClass.isInterface()) {
-      return mutations;
-    }
-
     return mutations.stream().filter(mutatesIteratorLoopPlumbing().negate())
             .collect(Collectors.toList());
   }
@@ -205,7 +198,7 @@ public class ForEachLoopFilter implements MutationInterceptor {
       MethodTree method = maybeMethod.get();
 
       if (method.instructions().isEmpty()) {
-        Log.getLogger().warning(method.asLocation() + " has no instructions");
+        // occurs for mutations to annotations on interfaces
         return false;
       }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/AvoidForLoopCounterFilter.java
@@ -46,7 +46,6 @@ import org.pitest.sequence.SequenceMatcher;
 import org.pitest.sequence.SequenceQuery;
 import org.pitest.sequence.Slot;
 import org.pitest.sequence.SlotWrite;
-import org.pitest.util.Log;
 
 /**
  * Removes mutants that effect for loop counters as these have
@@ -153,12 +152,6 @@ public class AvoidForLoopCounterFilter implements MutationInterceptor {
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
 
-    // skip for mutations to annotations on interfaces
-    // to avoid generating empty method warnings.
-    if (this.currentClass.isInterface()) {
-      return mutations;
-    }
-
     return mutations.stream()
             .filter(mutatesAForLoopCounter().negate())
             .collect(Collectors.toList());
@@ -173,7 +166,7 @@ public class AvoidForLoopCounterFilter implements MutationInterceptor {
       }
       MethodTree method = maybeMethod.get();
       if (method.instructions().isEmpty()) {
-        Log.getLogger().warning(method.asLocation() + " has no instructions");
+        // occurs for mutations to annotations on interfaces
         return false;
       }
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/build/intercept/timeout/InfiniteLoopFilter.java
@@ -21,7 +21,6 @@ import org.pitest.mutationtest.engine.Location;
 import org.pitest.mutationtest.engine.Mutater;
 import org.pitest.mutationtest.engine.MutationDetails;
 import org.pitest.sequence.SequenceMatcher;
-import org.pitest.util.Log;
 
 public abstract class InfiniteLoopFilter implements MutationInterceptor {
 
@@ -44,12 +43,6 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
   public Collection<MutationDetails> intercept(
       Collection<MutationDetails> mutations, Mutater m) {
 
-    // skip for mutations to annotations on interfaces
-    // to avoid generating empty method warnings.
-    if (this.currentClass.isInterface()) {
-      return mutations;
-    }
-
     final Map<Location,Collection<MutationDetails>> buckets = FCollection.bucket(mutations, mutationToLocation());
 
     final List<MutationDetails> willTimeout = new ArrayList<>();
@@ -69,7 +62,7 @@ public abstract class InfiniteLoopFilter implements MutationInterceptor {
     }
     MethodTree method = maybeMethod.get();
     if (method.instructions().isEmpty()) {
-      Log.getLogger().warning(method.asLocation() + " has no instructions");
+      // occurs for mutations to annotations on interfaces
       return Collections.emptyList();
     }
 


### PR DESCRIPTION
Filters still required for interfaces due to default and static methods