### PR TITLE
chore(deps): bump org.apache.commons:commons-text to 1.14.0 (fix CVE-2025-48924)

### DIFF
--- a/pitest-entry/pom.xml
+++ b/pitest-entry/pom.xml
@@ -133,7 +133,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.13.1</version>
+			<version>1.14.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bump commons-text to fix the vulnerability: https://www.mend.io/vulnerability-database/CVE-2025-48924?utm_source=JetBrains