### PR TITLE
Pin dependencies in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout from Git'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - name: 'Display JDK version'
         run: java -version
       - name: Cache local Maven repository
-        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout from Git'
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
       - name: 'Display JDK version'
         run: java -version
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
           cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - name: Checkout project
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Cache local Maven repository
-        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java JDK
-        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
           cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
         with:
           java-version: 11
           distribution: temurin

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Cache local Maven repository
-        uses: actions/cache@d4323d4df104b026a6e5435f29a0af381010bb5a # v4.2.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java JDK
-        uses: actions/setup-java@5d7b214878a63ef0089e24024c084e31e5066927 # v4.5.0
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: 11
           distribution: temurin


### PR DESCRIPTION
With this PR the "external" actions used in the workflows for CI, release and snapshot are pinned to specific hashes. By doing this we fulfil the scorecard check. Additionally I bumped the version for actions/checkout and actions/cache from v3 to v4.

See scorecard results: 
| 10 / 10 | Pinned-Dependencies    | all dependencies are pinned                                | Info:   9 out of   9 GitHub-owned GitHubAction dependencies pinned                                                | https://github.com/ossf/scorecard/blob/80ee3ecfedf8b19ab8991713a9fdb2e7dcd7262e/docs/checks.md#pinned-dependencies    |

You can do a full scorecard run on your local machine with
> cd pitest 
> scorecard --local $(pwd) --show-details  