### PR TITLE
Add token permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches-ignore:
       - 'release'
+permissions:
+  contents: read
+  actions: read
+  checks: read
 jobs:
   supported-jdk:
     name: ${{ matrix.title }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - release/**
+permissions:
+  contents: write
+  actions: read
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+  actions: read
 jobs:
   snapshot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To fulfil the OSSF scorecard check for using tokens with least privileges, this PR adds permissions to the three workflow files for ci, snapshot and release.

This page explains the ossf scorecard check for token permissions: [link](https://github.com/ossf/scorecard/blob/80ee3ecfedf8b19ab8991713a9fdb2e7dcd7262e/docs/checks.md#token-permissions) 