### PR TITLE
fix(Java9Process): remove stale args file cache

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/process/Java9Process.java
+++ b/pitest-entry/src/main/java/org/pitest/process/Java9Process.java
@@ -9,9 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -19,8 +17,6 @@ import java.util.stream.Collectors;
  * Process for java 9+, using file to pass all parameters
  */
 public class Java9Process implements WrappingProcess {
-
-    private static final Map<Optional<String>, Path> CACHE = new ConcurrentHashMap<>();
 
     private final int         port;
     private final ProcessArgs processArgs;
@@ -81,7 +77,7 @@ public class Java9Process implements WrappingProcess {
         removeJacocoAgent(fileArgs);
 
         // All arguments are passed via a temporary file, thereby avoiding command line length limits
-        Path argsFile = CACHE.computeIfAbsent(javaAgent.getJarLocation(), j -> createArgsFile(fileArgs));
+        Path argsFile = createArgsFile(fileArgs);
 
         List<String> cmd = new ArrayList<>();
         cmd.add(javaProc);


### PR DESCRIPTION
The `CACHE` in `Java9Process` keys on `javaAgent.getJarLocation()` but caches the full args file — which includes classpath, JVM options, and mutation targets that differ between minion invocations. A second minion launched with a different classpath or config silently reuses the first minion's args file and runs with the wrong arguments.

Removing the cache is the safe fix. `createArgsFile()` writes a small temp file and isn't on the hot path — the cache was not buying anything meaningful here.

Happy to close this if there's a reason for the cache I'm not seeing — you know this codebase far better than I do.