### PR TITLE
silent mode

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -58,6 +58,7 @@ import org.pitest.util.Timings;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -99,7 +100,7 @@ public class MutationCoverage {
 
   public CombinedStatistics runReport() throws IOException {
 
-    if (!this.data.getVerbosity().showMinionOutput()) {
+    if (this.data.getVerbosity().writeToStandardOut() && !this.data.getVerbosity().showMinionOutput()) {
       LOG.info("Verbose logging is disabled. If you encounter a problem, please enable it before reporting an issue.");
     }
     Log.setVerbose(this.data.getVerbosity());
@@ -295,7 +296,7 @@ public class MutationCoverage {
 
   private void printStats(CombinedStatistics combinedStatistics) {
     MutationStatistics stats = combinedStatistics.getMutationStatistics();
-    final PrintStream ps = System.out;
+    final PrintStream ps = pickOutputSteam();
 
     ps.println(StringUtil.separatorLine('='));
     ps.println("- Mutators");
@@ -328,6 +329,13 @@ public class MutationCoverage {
       ps.println("Build messages:- ");
       combinedStatistics.getIssues().forEach(m -> ps.println("* " + m));
     }
+  }
+
+  private PrintStream pickOutputSteam() {
+    if (this.data.getVerbosity().writeToStandardOut()) {
+      return System.out;
+    }
+    return new PrintStream(OutputStream.nullOutputStream());
   }
 
   private List<MutationAnalysisUnit> buildMutationTests(CoverageDatabase coverageData,

--- a/pitest/src/main/java/org/pitest/util/Verbosity.java
+++ b/pitest/src/main/java/org/pitest/util/Verbosity.java
@@ -3,6 +3,7 @@ package org.pitest.util;
 import java.util.logging.Level;
 
 public enum Verbosity {
+    SILENT(MinionLogging.DONT_SHOW, false, Level.OFF),
     QUIET(MinionLogging.DONT_SHOW, false, Level.SEVERE),
     QUIET_WITH_PROGRESS(MinionLogging.DONT_SHOW, true, Level.SEVERE),
     DEFAULT(MinionLogging.DONT_SHOW, true, Level.INFO),
@@ -29,6 +30,10 @@ public enum Verbosity {
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException("Unrecognised verbosity " + verbosity);
         }
+    }
+
+    public boolean writeToStandardOut() {
+        return this != SILENT;
     }
 
     public boolean showMinionOutput() {

--- a/pitest/src/test/java/org/pitest/util/VerbosityTest.java
+++ b/pitest/src/test/java/org/pitest/util/VerbosityTest.java
@@ -24,4 +24,15 @@ public class VerbosityTest {
         assertThatCode(() -> Verbosity.fromString("rubbish"))
                 .hasMessageStartingWith("Unrecognised verbosity rubbish");
     }
+
+    @Test
+    public void doesntWriteToStandardOutWhenSilent() {
+        assertThat(Verbosity.SILENT.writeToStandardOut()).isFalse();
+    }
+
+    @Test
+    public void writesToStandardOutWhenNotSilent() {
+        assertThat(QUIET.writeToStandardOut()).isTrue();
+    }
+
 }


### PR DESCRIPTION
Extra verbosity mode to disable all output by pitest itself. Logging will still happen at the build tool level, but a completely silent output can be achieved with eg

mvn -q -Dverbosity=SILENT -Ppitest test-compile