### PR TITLE
Add support for configurable decimal precision

### DIFF
--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/AggregationResult.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/AggregationResult.java
@@ -1,13 +1,14 @@
 package org.pitest.aggregate;
 
+import java.math.BigDecimal;
+
 public class AggregationResult {
   private final long mutations;
   private final long mutationsSurvived;
-  private final int  mutationCoverage;
+  private final BigDecimal mutationCoverage;
+  private final BigDecimal testStrength;
 
-  private final int testStrength;
-
-  public AggregationResult(long mutations, long mutationsSurvived, int mutationCoverage, int testStrength) {
+  public AggregationResult(long mutations, long mutationsSurvived, BigDecimal mutationCoverage, BigDecimal testStrength) {
     this.mutations = mutations;
     this.mutationsSurvived = mutationsSurvived;
     this.mutationCoverage = mutationCoverage;
@@ -22,11 +23,11 @@ public class AggregationResult {
     return mutationsSurvived;
   }
 
-  public int getMutationCoverage() {
+  public BigDecimal getMutationCoverage() {
     return mutationCoverage;
   }
 
-  public int getTestStrength() {
+  public BigDecimal getTestStrength() {
     return testStrength;
   }
 }

--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregator.java
@@ -48,6 +48,7 @@ public final class ReportAggregator {
   private final CodeSourceAggregator       codeSourceAggregator;
   private final Charset inputCharset;
   private final Charset outputCharset;
+  private final int thresholdPrecision;
 
   private ReportAggregator(SettingsFactory settings,
                            ResultOutputStrategy resultOutputStrategy,
@@ -56,7 +57,8 @@ public final class ReportAggregator {
                            Set<File> sourceCodeDirs,
                            Set<File> compiledCodeDirs,
                            Charset inputCharset,
-                           Charset outputCharset) {
+                           Charset outputCharset,
+                           int thresholdPrecision) {
     this.settings = settings;
     this.resultOutputStrategy = resultOutputStrategy;
     this.blockCoverageLoader = new BlockCoverageDataLoader(lineCoverageFiles);
@@ -65,6 +67,7 @@ public final class ReportAggregator {
     this.codeSourceAggregator = new CodeSourceAggregator(settings, new HashSet<>(compiledCodeDirs));
     this.inputCharset = inputCharset;
     this.outputCharset = outputCharset;
+    this.thresholdPrecision = thresholdPrecision;
   }
 
   public AggregationResult aggregateReport() throws ReportAggregationException {
@@ -73,7 +76,7 @@ public final class ReportAggregator {
     boolean partialCoverage = scanForPartialCoverageFlag(mutationFiles);
 
     final MutationResultListener mutationResultListener = createResultListener(sourceLocator, Collections.emptySet(), partialCoverage);
-    final ReportAggregatorResultListener reportAggregatorResultListener = new ReportAggregatorResultListener();
+    final ReportAggregatorResultListener reportAggregatorResultListener = new ReportAggregatorResultListener(thresholdPrecision);
 
     reportAggregatorResultListener.runStart();
     mutationResultListener.runStart();
@@ -124,6 +127,7 @@ public final class ReportAggregator {
             partialCoverage,
             Collections.emptyList(),
             true,
+            thresholdPrecision,
             sourceLocator);
   }
 
@@ -168,6 +172,7 @@ public final class ReportAggregator {
     private final Set<File>      compiledCodeDirectories = new HashSet<>();
     private Charset inputCharset = Charset.defaultCharset();
     private Charset outputCharset = Charset.defaultCharset();
+    private int thresholdPrecision = 0;
 
     public Builder inputCharSet(Charset inputCharset) {
       this.inputCharset = inputCharset;
@@ -176,6 +181,11 @@ public final class ReportAggregator {
 
     public Builder outputCharset(Charset outputCharset) {
       this.outputCharset = outputCharset;
+      return this;
+    }
+
+    public Builder thresholdPrecision(int thresholdPrecision) {
+      this.thresholdPrecision = thresholdPrecision;
       return this;
     }
 
@@ -291,7 +301,8 @@ public final class ReportAggregator {
               this.sourceCodeDirectories,
               this.compiledCodeDirectories,
               inputCharset,
-              outputCharset);
+              outputCharset,
+              thresholdPrecision);
     }
 
     /*

--- a/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregatorResultListener.java
+++ b/pitest-aggregator/src/main/java/org/pitest/aggregate/ReportAggregatorResultListener.java
@@ -6,10 +6,14 @@ import org.pitest.mutationtest.report.html.MutationTotals;
 
 public class ReportAggregatorResultListener implements MutationResultListener {
   MutationTotals totals = new MutationTotals();
+  private final int thresholdPrecision;
+
+  public ReportAggregatorResultListener(int thresholdPrecision) {
+    this.thresholdPrecision = thresholdPrecision;
+  }
 
   @Override
   public void runStart() {
-    // nothing to do here
   }
 
   @Override
@@ -22,11 +26,10 @@ public class ReportAggregatorResultListener implements MutationResultListener {
 
   @Override
   public void runEnd() {
-    // nothing to do here
   }
 
   public AggregationResult result() {
     return new AggregationResult(totals.getNumberOfMutations(), totals.getNumberOfMutations() - totals.getNumberOfMutationsDetected(),
-        totals.getMutationCoverage(), totals.getTestStrength());
+        totals.getMutationCoverage(thresholdPrecision), totals.getTestStrength(thresholdPrecision));
   }
 }

--- a/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
+++ b/pitest-ant/src/main/java/org/pitest/ant/PitestTask.java
@@ -244,6 +244,10 @@ public class PitestTask extends Task { // NO_UCD (test only)
     this.setOption(ConfigOption.COVERAGE_THRESHOLD, value);
   }
 
+  public void setThresholdPrecision(final String value) {
+    this.setOption(ConfigOption.THRESHOLD_PRECISION, value);
+  }
+
   public void setMutationEngine(String value) {
     this.setOption(ConfigOption.MUTATION_ENGINE, value);
   }

--- a/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
+++ b/pitest-ant/src/test/java/org/pitest/ant/PitestTaskTest.java
@@ -455,6 +455,13 @@ public class PitestTaskTest {
   }
 
   @Test
+  public void shouldPassThresholdPrecisionToJavaTask() {
+    this.pitestTask.setThresholdPrecision("2");
+    this.pitestTask.execute(this.java);
+    verify(this.arg).setValue("--thresholdPrecision=2");
+  }
+
+  @Test
   public void shouldPassMutationEngineToJavaTask() {
     this.pitestTask.setMutationEngine("foo");
     this.pitestTask.execute(this.java);

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/MutationCoverageReport.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/MutationCoverageReport.java
@@ -23,6 +23,7 @@ import org.pitest.mutationtest.tooling.CombinedStatistics;
 import org.pitest.mutationtest.tooling.EntryPoint;
 import org.pitest.util.Unchecked;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 
 /**
@@ -44,40 +45,50 @@ public class MutationCoverageReport {
 
       final CombinedStatistics stats = runReport(data, plugins);
 
+      int precision = data.getThresholdPrecision();
       throwErrorIfScoreBelowCoverageThreshold(stats.getCoverageSummary(),
-          data.getCoverageThreshold());
+          data.getCoverageThreshold(), precision);
       throwErrorIfScoreBelowTestStrengthThreshold(stats.getMutationStatistics(),
-              data.getTestStrengthThreshold());
+              data.getTestStrengthThreshold(), precision);
       throwErrorIfScoreBelowMutationThreshold(stats.getMutationStatistics(),
-          data.getMutationThreshold());
+          data.getMutationThreshold(), precision);
       throwErrorIfMoreThanMaxSurvivingMutants(stats.getMutationStatistics(), data.getMaximumAllowedSurvivors());
     }
 
   }
 
   private static void throwErrorIfScoreBelowCoverageThreshold(
-      CoverageSummary stats, int threshold) {
-    if ((threshold != 0) && (stats.getCoverage() < threshold)) {
-      throw new RuntimeException("Line coverage of " + stats.getCoverage()
-          + " is below threshold of " + threshold);
+      CoverageSummary stats, BigDecimal threshold, int precision) {
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = stats.getCoverage(precision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new RuntimeException("Line coverage of " + actual
+            + " is below threshold of " + threshold);
+      }
     }
   }
 
   private static void throwErrorIfScoreBelowMutationThreshold(
-      final MutationStatistics stats, final int threshold) {
-    if ((threshold != 0) && (stats.getPercentageDetected() < threshold)) {
-      throw new RuntimeException("Mutation score of "
-          + stats.getPercentageDetected() + " is below threshold of "
-          + threshold);
+      final MutationStatistics stats, final BigDecimal threshold, int precision) {
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = stats.getPercentageDetected(precision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new RuntimeException("Mutation score of "
+            + actual + " is below threshold of "
+            + threshold);
+      }
     }
   }
 
   private static void throwErrorIfScoreBelowTestStrengthThreshold(
-          final MutationStatistics stats, final int threshold) {
-    if ((threshold != 0) && (stats.getTestStrength() < threshold)) {
-      throw new RuntimeException("Test strength score of "
-              + stats.getTestStrength() + " is below threshold of "
-              + threshold);
+          final MutationStatistics stats, final BigDecimal threshold, int precision) {
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = stats.getTestStrength(precision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new RuntimeException("Test strength score of "
+                + actual + " is below threshold of "
+                + threshold);
+      }
     }
   }
 

--- a/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
+++ b/pitest-command-line/src/main/java/org/pitest/mutationtest/commandline/OptionsParser.java
@@ -36,6 +36,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -90,6 +91,7 @@ import static org.pitest.mutationtest.config.ConfigOption.TARGET_CLASSES;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_FILTER;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_PLUGIN;
 import static org.pitest.mutationtest.config.ConfigOption.TEST_STRENGTH_THRESHOLD;
+import static org.pitest.mutationtest.config.ConfigOption.THRESHOLD_PRECISION;
 import static org.pitest.mutationtest.config.ConfigOption.THREADS;
 import static org.pitest.mutationtest.config.ConfigOption.TIMEOUT_CONST;
 import static org.pitest.mutationtest.config.ConfigOption.TIMEOUT_FACTOR;
@@ -142,9 +144,10 @@ public class OptionsParser {
   private final OptionSpec<Integer>                  mutationUnitSizeSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> timestampedReportsSpec;
   private final ArgumentAcceptingOptionSpec<Boolean> detectInlinedCode;
-  private final ArgumentAcceptingOptionSpec<Integer> mutationThreshHoldSpec;
-  private final ArgumentAcceptingOptionSpec<Integer> testStrengthThreshHoldSpec;
-  private final ArgumentAcceptingOptionSpec<Integer> coverageThreshHoldSpec;
+  private final ArgumentAcceptingOptionSpec<String> mutationThreshHoldSpec;
+  private final ArgumentAcceptingOptionSpec<String> testStrengthThreshHoldSpec;
+  private final ArgumentAcceptingOptionSpec<String> coverageThreshHoldSpec;
+  private final ArgumentAcceptingOptionSpec<Integer> thresholdPrecisionSpec;
   private final ArgumentAcceptingOptionSpec<Integer> maxSurvivingSpec;
   private final OptionSpec<String>                   mutationEngine;
   private final ArgumentAcceptingOptionSpec<Boolean> exportLineCoverageSpec;
@@ -378,14 +381,14 @@ public class OptionsParser {
         .describedAs("File to write history to for incremental analysis");
 
     this.mutationThreshHoldSpec = parserAccepts(MUTATION_THRESHOLD)
-        .withRequiredArg().ofType(Integer.class)
+        .withRequiredArg().ofType(String.class)
         .describedAs("Mutation score below which to throw an error")
-        .defaultsTo(MUTATION_THRESHOLD.getDefault(Integer.class));
+        .defaultsTo("0");
 
     this.testStrengthThreshHoldSpec = parserAccepts(TEST_STRENGTH_THRESHOLD)
-            .withRequiredArg().ofType(Integer.class)
+            .withRequiredArg().ofType(String.class)
             .describedAs("Test strength score below which to throw an error")
-            .defaultsTo(TEST_STRENGTH_THRESHOLD.getDefault(Integer.class));
+            .defaultsTo("0");
 
     this.maxSurvivingSpec = parserAccepts(MAX_SURVIVING)
         .withRequiredArg().ofType(Integer.class)
@@ -393,9 +396,14 @@ public class OptionsParser {
         .defaultsTo(MAX_SURVIVING.getDefault(Integer.class));
 
     this.coverageThreshHoldSpec = parserAccepts(COVERAGE_THRESHOLD)
-        .withRequiredArg().ofType(Integer.class)
+        .withRequiredArg().ofType(String.class)
         .describedAs("Line coverage below which to throw an error")
-        .defaultsTo(COVERAGE_THRESHOLD.getDefault(Integer.class));
+        .defaultsTo("0");
+
+    this.thresholdPrecisionSpec = parserAccepts(THRESHOLD_PRECISION)
+        .withRequiredArg().ofType(Integer.class)
+        .describedAs("Number of decimal places for threshold comparisons")
+        .defaultsTo(THRESHOLD_PRECISION.getDefault(Integer.class));
 
     this.mutationEngine = parserAccepts(MUTATION_ENGINE).withRequiredArg()
         .ofType(String.class).describedAs("mutation engine to use")
@@ -496,10 +504,11 @@ public class OptionsParser {
     data.setMutationUnitSize(this.mutationUnitSizeSpec.value(userArgs));
     data.setHistoryInputLocation(this.historyInputSpec.value(userArgs));
     data.setHistoryOutputLocation(this.historyOutputSpec.value(userArgs));
-    data.setMutationThreshold(this.mutationThreshHoldSpec.value(userArgs));
-    data.setTestStrengthThreshold(this.testStrengthThreshHoldSpec.value(userArgs));
+    data.setMutationThreshold(new BigDecimal(this.mutationThreshHoldSpec.value(userArgs)));
+    data.setTestStrengthThreshold(new BigDecimal(this.testStrengthThreshHoldSpec.value(userArgs)));
     data.setMaximumAllowedSurvivors(this.maxSurvivingSpec.value(userArgs));
-    data.setCoverageThreshold(this.coverageThreshHoldSpec.value(userArgs));
+    data.setCoverageThreshold(new BigDecimal(this.coverageThreshHoldSpec.value(userArgs)));
+    data.setThresholdPrecision(this.thresholdPrecisionSpec.value(userArgs));
     data.setMutationEngine(this.mutationEngine.value(userArgs));
     data.setFreeFormProperties(listToProperties(this.pluginPropertiesSpec.values(userArgs)));
     data.setExportLineCoverage(booleanValue(exportLineCoverageSpec, userArgs));

--- a/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
+++ b/pitest-command-line/src/test/java/org/pitest/mutationtest/commandline/OptionsParserTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -472,14 +473,14 @@ public class OptionsParserTest {
   public void shouldParseMutationThreshold() {
     final ReportOptions actual = parseAddingRequiredArgs("--mutationThreshold",
         "42");
-    assertThat(actual.getMutationThreshold()).isEqualTo(42);
+    assertThat(actual.getMutationThreshold()).isEqualByComparingTo(new BigDecimal("42"));
   }
 
   @Test
   public void shouldParseTestStrengthThreshold() {
     final ReportOptions actual = parseAddingRequiredArgs("--testStrengthThreshold",
             "50");
-    assertThat(actual.getTestStrengthThreshold()).isEqualTo(50);
+    assertThat(actual.getTestStrengthThreshold()).isEqualByComparingTo(new BigDecimal("50"));
   }
 
   @Test
@@ -493,7 +494,19 @@ public class OptionsParserTest {
   public void shouldParseCoverageThreshold() {
     final ReportOptions actual = parseAddingRequiredArgs("--coverageThreshold",
         "42");
-    assertThat(actual.getCoverageThreshold()).isEqualTo(42);
+    assertThat(actual.getCoverageThreshold()).isEqualByComparingTo(new BigDecimal("42"));
+  }
+
+  @Test
+  public void shouldParseDecimalCoverageThreshold() {
+    final ReportOptions actual = parseAddingRequiredArgs("--coverageThreshold", "61.47");
+    assertThat(actual.getCoverageThreshold()).isEqualByComparingTo(new BigDecimal("61.47"));
+  }
+
+  @Test
+  public void shouldParseThresholdPrecision() {
+    final ReportOptions actual = parseAddingRequiredArgs("--thresholdPrecision", "2");
+    assertThat(actual.getThresholdPrecision()).isEqualTo(2);
   }
 
   @Test

--- a/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
+++ b/pitest-entry/src/main/java/org/pitest/coverage/CoverageSummary.java
@@ -1,5 +1,7 @@
 package org.pitest.coverage;
 
+import java.math.BigDecimal;
+
 import static org.pitest.util.PercentageCalculator.getPercentage;
 
 /**
@@ -31,6 +33,10 @@ public final class CoverageSummary {
 
   public int getCoverage() {
     return getPercentage(numberOfLines, numberOfCoveredLines);
+  }
+
+  public BigDecimal getCoverage(int precision) {
+    return getPercentage(numberOfLines, numberOfCoveredLines, precision);
   }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ConfigOption.java
@@ -213,6 +213,11 @@ public enum ConfigOption {
   COVERAGE_THRESHOLD("coverageThreshold", 0),
 
   /**
+   * Number of decimal places for threshold percentage comparisons
+   */
+  THRESHOLD_PRECISION("thresholdPrecision", 0),
+
+  /**
    * Mutation engine to use
    */
   MUTATION_ENGINE("mutationEngine", "gregor"),

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/ReportOptions.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -126,9 +127,10 @@ public class ReportOptions {
   private boolean                        shouldCreateTimestampedReports = true;
   private boolean                        detectInlinedCode              = false;
   private boolean                        exportLineCoverage             = false;
-  private int                            mutationThreshold;
-  private int                            coverageThreshold;
-  private int                            testStrengthThreshold;
+  private BigDecimal                     mutationThreshold              = BigDecimal.ZERO;
+  private BigDecimal                     coverageThreshold              = BigDecimal.ZERO;
+  private BigDecimal                     testStrengthThreshold          = BigDecimal.ZERO;
+  private int                            thresholdPrecision;
 
   private String                         mutationEngine                 = "gregor";
 
@@ -537,11 +539,11 @@ public class ReportOptions {
     return this.exportLineCoverage;
   }
 
-  public int getMutationThreshold() {
+  public BigDecimal getMutationThreshold() {
     return this.mutationThreshold;
   }
 
-  public void setMutationThreshold(final int value) {
+  public void setMutationThreshold(final BigDecimal value) {
     this.mutationThreshold = value;
   }
 
@@ -553,22 +555,29 @@ public class ReportOptions {
     this.mutationEngine = mutationEngine;
   }
 
-  public int getCoverageThreshold() {
+  public BigDecimal getCoverageThreshold() {
     return this.coverageThreshold;
   }
 
-  public void setCoverageThreshold(final int coverageThreshold) {
+  public void setCoverageThreshold(final BigDecimal coverageThreshold) {
     this.coverageThreshold = coverageThreshold;
   }
 
-  public int getTestStrengthThreshold() {
+  public BigDecimal getTestStrengthThreshold() {
     return this.testStrengthThreshold;
   }
 
-  public void setTestStrengthThreshold(final int testStrengthThreshold) {
+  public void setTestStrengthThreshold(final BigDecimal testStrengthThreshold) {
     this.testStrengthThreshold = testStrengthThreshold;
   }
 
+  public int getThresholdPrecision() {
+    return this.thresholdPrecision;
+  }
+
+  public void setThresholdPrecision(final int thresholdPrecision) {
+    this.thresholdPrecision = thresholdPrecision;
+  }
 
   public String getJavaExecutable() {
     return this.javaExecutable;
@@ -714,6 +723,7 @@ public class ReportOptions {
             .add("mutationThreshold=" + mutationThreshold)
             .add("coverageThreshold=" + coverageThreshold)
             .add("testStrengthThreshold=" + testStrengthThreshold)
+            .add("thresholdPrecision=" + thresholdPrecision)
             .add("mutationEngine='" + mutationEngine + "'")
             .add("javaExecutable='" + javaExecutable + "'")
             .add("includeLaunchClasspath=" + includeLaunchClasspath)

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/MutationStatistics.java
@@ -17,6 +17,7 @@ package org.pitest.mutationtest.statistics;
 import org.pitest.classinfo.ClassName;
 
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
@@ -32,6 +33,7 @@ public final class MutationStatistics {
   private final long totalWithCoverage;
 
   private final Set<ClassName> mutatedClasses;
+  private int thresholdPrecision;
 
   public MutationStatistics(Iterable<Score> scores,
                             long totalMutations,
@@ -83,12 +85,27 @@ public final class MutationStatistics {
     return getPercentage(getTotalMutations(), getTotalDetectedMutations());
   }
 
+  public BigDecimal getPercentageDetected(int precision) {
+    return getPercentage(getTotalMutations(), getTotalDetectedMutations(), precision);
+  }
+
+  public void setThresholdPrecision(int thresholdPrecision) {
+    this.thresholdPrecision = thresholdPrecision;
+  }
+
   public void report(final PrintStream out) {
+    String detected = thresholdPrecision > 0
+        ? getPercentageDetected(thresholdPrecision).toPlainString()
+        : String.valueOf(getPercentageDetected());
+    String strength = thresholdPrecision > 0
+        ? getTestStrength(thresholdPrecision).toPlainString()
+        : String.valueOf(getTestStrength());
+
     out.println(">> Generated " + this.getTotalMutations()
         + " mutations Killed " + this.getTotalDetectedMutations() + " ("
-        + this.getPercentageDetected() + "%)");
+        + detected + "%)");
     out.println(">> Mutations with no coverage " + this.getTotalMutationsWithoutCoverage()
-            + ". Test strength " + this.getTestStrength() + "%");
+            + ". Test strength " + strength + "%");
     out.println(">> Ran " + this.numberOfTestsRun + " tests ("
         + getTestsPerMutation() + " tests per mutation)");
 
@@ -108,5 +125,9 @@ public final class MutationStatistics {
 
   public int getTestStrength() {
     return getPercentage(getTotalMutationsWithCoverage(), getTotalDetectedMutations());
+  }
+
+  public BigDecimal getTestStrength(int precision) {
+    return getPercentage(getTotalMutationsWithCoverage(), getTotalDetectedMutations(), precision);
   }
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/statistics/Score.java
@@ -15,6 +15,7 @@
 package org.pitest.mutationtest.statistics;
 
 import java.io.PrintStream;
+import java.math.BigDecimal;
 
 import static org.pitest.util.PercentageCalculator.getPercentage;
 
@@ -70,6 +71,10 @@ public final class Score {
 
   public int getPercentageDetected() {
     return getPercentage(getTotalMutations(), getTotalDetectedMutations());
+  }
+
+  public BigDecimal getPercentageDetected(int precision) {
+    return getPercentage(getTotalMutations(), getTotalDetectedMutations(), precision);
   }
 
 }

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/tooling/MutationCoverage.java
@@ -321,11 +321,16 @@ public class MutationCoverage {
 
     final CoverageSummary coverage = combinedStatistics.getCoverageSummary();
     if (coverage != null) {
-      ps.printf(">> Line Coverage (for mutated classes only): %d/%d (%d%%)%n", coverage.getNumberOfCoveredLines(),
-              coverage.getNumberOfLines(), coverage.getCoverage());
+      int precision = this.data.getThresholdPrecision();
+      String coverageDisplay = precision > 0
+          ? coverage.getCoverage(precision).toPlainString()
+          : String.valueOf(coverage.getCoverage());
+      ps.printf(">> Line Coverage (for mutated classes only): %d/%d (%s%%)%n", coverage.getNumberOfCoveredLines(),
+              coverage.getNumberOfLines(), coverageDisplay);
       ps.printf(">> %d tests examined%n", coverage.getNumberOfTests());
     }
 
+    stats.setThresholdPrecision(this.data.getThresholdPrecision());
     stats.report(ps);
 
     if (!combinedStatistics.getIssues().isEmpty()) {

--- a/pitest-entry/src/main/java/org/pitest/util/PercentageCalculator.java
+++ b/pitest-entry/src/main/java/org/pitest/util/PercentageCalculator.java
@@ -1,5 +1,8 @@
 package org.pitest.util;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 public class PercentageCalculator {
   public static int getPercentage(long total, long actual) {
     if (total == 0) {
@@ -15,5 +18,28 @@ public class PercentageCalculator {
     }
 
     return Math.min(99, Math.round((100f / total) * actual));
+  }
+
+  public static BigDecimal getPercentage(long total, long actual, int precision) {
+    if (total == 0) {
+      return new BigDecimal(100).setScale(precision, RoundingMode.UNNECESSARY);
+    }
+
+    if (actual == 0) {
+      return BigDecimal.ZERO.setScale(precision, RoundingMode.UNNECESSARY);
+    }
+
+    if (total == actual) {
+      return new BigDecimal(100).setScale(precision, RoundingMode.UNNECESSARY);
+    }
+
+    BigDecimal result = BigDecimal.valueOf(actual)
+        .multiply(BigDecimal.valueOf(100))
+        .divide(BigDecimal.valueOf(total), precision, RoundingMode.HALF_UP);
+
+    BigDecimal cap = new BigDecimal(100)
+        .subtract(BigDecimal.ONE.movePointLeft(precision))
+        .setScale(precision, RoundingMode.UNNECESSARY);
+    return result.min(cap);
   }
 }

--- a/pitest-entry/src/test/java/org/pitest/coverage/CoverageSummaryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/coverage/CoverageSummaryTest.java
@@ -2,6 +2,8 @@ package org.pitest.coverage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 public class CoverageSummaryTest {
@@ -24,6 +26,18 @@ public class CoverageSummaryTest {
   @Test
   public void shouldCorrectlyCalculateLineCoverageWhenPartiallyCovered() {
     assertThat(new CoverageSummary(100, 50, 0).getCoverage()).isEqualTo(50);
+  }
+
+  @Test
+  public void shouldCalculatePreciseCoverageAtPrecisionTwo() {
+    assertThat(new CoverageSummary(1295, 796, 0).getCoverage(2))
+        .isEqualByComparingTo(new BigDecimal("61.47"));
+  }
+
+  @Test
+  public void shouldCalculatePreciseCoverageAtPrecisionZero() {
+    assertThat(new CoverageSummary(100, 50, 0).getCoverage(0))
+        .isEqualByComparingTo(new BigDecimal("50"));
   }
 
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/statistics/MutationStatisticsTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/statistics/MutationStatisticsTest.java
@@ -16,6 +16,8 @@ package org.pitest.mutationtest.statistics;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MutationStatisticsTest {
@@ -33,6 +35,18 @@ public class MutationStatisticsTest {
   @Test
   public void shouldHaveHundredPercentIfNoMutations() {
     assertThat(new MutationStatistics(null, 0, 0, 0, 0, null).getPercentageDetected()).isEqualTo(100);
+  }
+
+  @Test
+  public void shouldCalculatePrecisePercentageDetected() {
+    assertThat(new MutationStatistics(null, 413, 324, 1, 1, null).getPercentageDetected(2))
+        .isEqualByComparingTo(new BigDecimal("78.45"));
+  }
+
+  @Test
+  public void shouldCalculatePreciseTestStrength() {
+    assertThat(new MutationStatistics(null, 413, 324, 335, 1, null).getTestStrength(2))
+        .isEqualByComparingTo(new BigDecimal("96.72"));
   }
 
 }

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/statistics/ScoreTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/statistics/ScoreTest.java
@@ -22,8 +22,10 @@ import org.pitest.util.StringUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.util.function.Predicate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -126,6 +128,14 @@ public class ScoreTest {
   public void shouldCalculatePercentageDetectedWhenAllDetected() {
     registerResults(DetectionStatus.KILLED, 8);
     assertEquals(100, this.testee.toScore().getPercentageDetected());
+  }
+
+  @Test
+  public void shouldCalculatePrecisePercentageDetected() {
+    registerResults(DetectionStatus.SURVIVED, 2);
+    registerResults(DetectionStatus.KILLED, 1);
+    assertThat(this.testee.toScore().getPercentageDetected(2))
+        .isEqualByComparingTo(new BigDecimal("33.33"));
   }
 
   private void registerResults(final DetectionStatus status, final int times) {

--- a/pitest-entry/src/test/java/org/pitest/util/PercentageCalculatorTest.java
+++ b/pitest-entry/src/test/java/org/pitest/util/PercentageCalculatorTest.java
@@ -2,6 +2,8 @@ package org.pitest.util;
 
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.pitest.util.PercentageCalculator.getPercentage;
 
@@ -19,5 +21,42 @@ public class PercentageCalculatorTest {
   @Test
   public void shouldHaveHundredPercentIfNoTotal() {
     assertThat(getPercentage(0, 0)).isEqualTo(100);
+  }
+
+  @Test
+  public void shouldReturnBigDecimalMatchingIntAtPrecisionZero() {
+    assertThat(getPercentage(1295, 796, 0)).isEqualByComparingTo(new BigDecimal("61"));
+  }
+
+  @Test
+  public void shouldReturnPreciseBigDecimalAtPrecisionTwo() {
+    assertThat(getPercentage(1295, 796, 2)).isEqualByComparingTo(new BigDecimal("61.47"));
+  }
+
+  @Test
+  public void shouldCapAtScaledMaxWhenNotTrulyHundredPercent() {
+    assertThat(getPercentage(2000, 1999, 0)).isEqualByComparingTo(new BigDecimal("99"));
+    assertThat(getPercentage(2000, 1999, 2)).isEqualByComparingTo(new BigDecimal("99.95"));
+  }
+
+  @Test
+  public void shouldReturnHundredAtPrecisionWhenAllCovered() {
+    assertThat(getPercentage(2000, 2000, 2)).isEqualByComparingTo(new BigDecimal("100.00"));
+  }
+
+  @Test
+  public void shouldReturnHundredAtPrecisionWhenTotalIsZero() {
+    assertThat(getPercentage(0, 0, 2)).isEqualByComparingTo(new BigDecimal("100.00"));
+  }
+
+  @Test
+  public void shouldReturnZeroAtPrecisionWhenActualIsZero() {
+    assertThat(getPercentage(100, 0, 2)).isEqualByComparingTo(new BigDecimal("0.00"));
+  }
+
+  @Test
+  public void shouldWorkWithHighPrecision() {
+    BigDecimal result = getPercentage(1295, 796, 7);
+    assertThat(result).isEqualByComparingTo(new BigDecimal("61.4671815"));
   }
 }

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/HtmlReportFactory.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/HtmlReportFactory.java
@@ -28,7 +28,7 @@ public class HtmlReportFactory implements MutationResultListenerFactory {
       ListenerArguments args) {
     return new MutationHtmlReportListener(args.data().getOutputEncoding(), args.getCoverage(),
         args.getOutputStrategy(), args.getEngine().getMutatorNames(), args.data().shouldReportCoverage(),
-            args.issues(), args.data().isArcmutateMissing(), args.getLocator());
+            args.issues(), args.data().isArcmutateMissing(), args.data().getThresholdPrecision(), args.getLocator());
   }
 
   @Override

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationHtmlReportListener.java
@@ -64,6 +64,8 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
   private final boolean arcmutateMissing;
 
+  private final int thresholdPrecision;
+
   public MutationHtmlReportListener(Charset outputCharset,
                                     ReportCoverage coverage,
                                     ResultOutputStrategy outputStrategy,
@@ -71,6 +73,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
                                     boolean reportCoverage,
                                     List<BuildMessage> messages,
                                     boolean arcmutateMissing,
+                                    int thresholdPrecision,
                                     SourceLocator... locators) {
     this.outputCharset = outputCharset;
     this.coverage = coverage;
@@ -81,6 +84,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
     this.reportCoverage = reportCoverage;
     this.messages = messages;
     this.arcmutateMissing = arcmutateMissing;
+    this.thresholdPrecision = thresholdPrecision;
   }
 
   private String loadCss() {
@@ -138,8 +142,10 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
     final List<ClassLines> lines = asList(this.coverage.getCodeLinesForClass(data.getMutatedClass()));
 
-    return new MutationTestSummaryData(data.getFileName(), data.getMutations(),
+    MutationTestSummaryData summaryData = new MutationTestSummaryData(data.getFileName(), data.getMutations(),
         this.mutatorNames, lines, coverage.getCoveredLines(data.getMutatedClass()).size());
+    summaryData.setThresholdPrecision(this.thresholdPrecision);
+    return summaryData;
   }
 
   private SourceFile createAnnotatedSourceFile(
@@ -218,6 +224,7 @@ public class MutationHtmlReportListener implements MutationResultListener {
 
     final Writer writer = this.outputStrategy.createWriterForFile("index.html");
     final MutationTotals totals = new MutationTotals();
+    totals.setThresholdPrecision(this.thresholdPrecision);
 
     final List<PackageSummaryData> psd = new ArrayList<>(
         this.packageSummaryData.values());

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTestSummaryData.java
@@ -42,6 +42,8 @@ public class MutationTestSummaryData {
 
   private long                             numberOfCoveredLines;
 
+  private int thresholdPrecision;
+
   public MutationTestSummaryData(final String fileName,
       final Collection<MutationResult> results,
       final Collection<String> mutators, final Collection<ClassLines> classes,
@@ -55,6 +57,7 @@ public class MutationTestSummaryData {
 
   public MutationTotals getTotals() {
     final MutationTotals mt = new MutationTotals();
+    mt.setThresholdPrecision(this.thresholdPrecision);
     mt.addFiles(1);
     mt.addMutations(this.getNumberOfMutations());
     mt.addMutationsDetetcted(this.getNumberOfMutationsDetected());
@@ -149,5 +152,8 @@ public class MutationTestSummaryData {
     return results.stream().collect(Collectors.toMap(mr -> mr.getDetails().getId(), Function.identity()));
   }
 
+  public void setThresholdPrecision(int thresholdPrecision) {
+    this.thresholdPrecision = thresholdPrecision;
+  }
 
 }

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -2,6 +2,8 @@ package org.pitest.mutationtest.report.html;
 
 import static org.pitest.util.PercentageCalculator.getPercentage;
 
+import java.math.BigDecimal;
+
 public class MutationTotals {
 
   private long numberOfFiles                 = 0;
@@ -10,6 +12,7 @@ public class MutationTotals {
   private long numberOfMutations             = 0;
   private long numberOfMutationsDetected     = 0;
   private long numberOfMutationsWithCoverage = 0;
+  private int thresholdPrecision = 0;
 
   public long getNumberOfFiles() {
     return this.numberOfFiles;
@@ -69,6 +72,43 @@ public class MutationTotals {
 
   public long getNumberOfMutationsWithCoverage() {
     return this.numberOfMutationsWithCoverage;
+  }
+
+  public void setThresholdPrecision(int thresholdPrecision) {
+    this.thresholdPrecision = thresholdPrecision;
+  }
+
+  public BigDecimal getLineCoverage(int precision) {
+    return getPercentage(numberOfLines, numberOfLinesCovered, precision);
+  }
+
+  public BigDecimal getMutationCoverage(int precision) {
+    return getPercentage(numberOfMutations, numberOfMutationsDetected, precision);
+  }
+
+  public BigDecimal getTestStrength(int precision) {
+    return getPercentage(numberOfMutationsWithCoverage, numberOfMutationsDetected, precision);
+  }
+
+  public String getLineCoverageLabel() {
+    if (thresholdPrecision == 0) {
+      return String.valueOf(getLineCoverage());
+    }
+    return getLineCoverage(thresholdPrecision).toPlainString();
+  }
+
+  public String getMutationCoverageLabel() {
+    if (thresholdPrecision == 0) {
+      return String.valueOf(getMutationCoverage());
+    }
+    return getMutationCoverage(thresholdPrecision).toPlainString();
+  }
+
+  public String getTestStrengthLabel() {
+    if (thresholdPrecision == 0) {
+      return String.valueOf(getTestStrength());
+    }
+    return getTestStrength(thresholdPrecision).toPlainString();
   }
 
   public void add(final MutationTotals data) {

--- a/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
+++ b/pitest-html-report/src/main/java/org/pitest/mutationtest/report/html/MutationTotals.java
@@ -122,5 +122,8 @@ public class MutationTotals {
     this.addMutations(data.getNumberOfMutations());
     this.addMutationsDetetcted(data.getNumberOfMutationsDetected());
     this.addMutationsWithCoverage(data.getNumberOfMutationsWithCoverage());
+    if (data.thresholdPrecision > 0) {
+      this.thresholdPrecision = data.thresholdPrecision;
+    }
   }
 }

--- a/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/mutation_package_index.st
@@ -21,11 +21,11 @@
     <tbody>
         <tr>
             <td>$totals.numberOfFiles$</td>
-            $if(showCoverage)$ <td>$totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$ <td>$totals.lineCoverageLabel$% <div class="coverage_bar"><div class="coverage_complete width-$totals.lineCoverage$"></div><div class="coverage_legend">$totals.numberOfLinesCovered$/$totals.numberOfLines$</div></div></td>
             $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
             $endif$
-            <td>$totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$totals.mutationCoverage$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
-            <td>$totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$totals.testStrength$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>$totals.mutationCoverageLabel$% <div class="coverage_bar"><div class="coverage_complete width-$totals.mutationCoverage$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutations$</div></div></td>
+            <td>$totals.testStrengthLabel$% <div class="coverage_bar"><div class="coverage_complete width-$totals.testStrength$"></div><div class="coverage_legend">$totals.numberOfMutationsDetected$/$totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
     </tbody>
 </table>
@@ -47,11 +47,11 @@ $packageSummaries:{ summary |
         <tr>
             <td><a href="./$summary.packageDirectory$/index.html">$summary.packageName$</a></td>
             <td>$summary.totals.numberOfFiles$</td>
-            $if(showCoverage)$ <td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$ <td><div class="coverage_percentage">$summary.totals.lineCoverageLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
             $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
             $endif$
-            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
-            <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.mutationCoverageLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.testStrengthLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
 }$
      </tbody>

--- a/pitest-html-report/src/main/resources/templates/mutation/package_index.st
+++ b/pitest-html-report/src/main/resources/templates/mutation/package_index.st
@@ -21,11 +21,11 @@
     <tbody>
         <tr>
             <td>$packageData.totals.numberOfFiles$</td>
-            $if(showCoverage)$<td>$packageData.totals.lineCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$<td>$packageData.totals.lineCoverageLabel$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.lineCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfLinesCovered$/$packageData.totals.numberOfLines$</div></div></td>
             $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
             $endif$
-            <td>$packageData.totals.mutationCoverage$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.mutationCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
-            <td>$packageData.totals.testStrength$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.testStrength$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td>$packageData.totals.mutationCoverageLabel$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.mutationCoverage$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutations$</div></div></td>
+            <td>$packageData.totals.testStrengthLabel$% <div class="coverage_bar"><div class="coverage_complete width-$packageData.totals.testStrength$"></div><div class="coverage_legend">$packageData.totals.numberOfMutationsDetected$/$packageData.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
     </tbody>
 </table>
@@ -45,11 +45,11 @@
 $packageData.summaryData:{ summary | 
         <tr>
             <td><a href="./$summary.fileName$.html">$summary.fileName$</a></td>
-            $if(showCoverage)$<td><div class="coverage_percentage">$summary.totals.lineCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
+            $if(showCoverage)$<td><div class="coverage_percentage">$summary.totals.lineCoverageLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.lineCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfLinesCovered$/$summary.totals.numberOfLines$</div></div></td>
             $else$<td><div class="coverage_bar"><div class="coverage_complete width-100"></div><div class="coverage_legend">n/a</div></div></td>
             $endif$
-            <td><div class="coverage_percentage">$summary.totals.mutationCoverage$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
-            <td><div class="coverage_percentage">$summary.totals.testStrength$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.mutationCoverageLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.mutationCoverage$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutations$</div></div></td>
+            <td><div class="coverage_percentage">$summary.totals.testStrengthLabel$% </div><div class="coverage_bar"><div class="coverage_complete width-$summary.totals.testStrength$"></div><div class="coverage_legend">$summary.totals.numberOfMutationsDetected$/$summary.totals.numberOfMutationsWithCoverage$</div></div></td>
         </tr>
 }$
      </tbody>

--- a/pitest-html-report/src/main/resources/templates/mutation/style.css
+++ b/pitest-html-report/src/main/resources/templates/mutation/style.css
@@ -121,7 +121,7 @@ body{
 
 .coverage_percentage {
     display: inline-block;
-    width: 3em;
+    min-width: 3em;
     text-align: right;
 }
 

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationHtmlReportListenerTest.java
@@ -69,7 +69,7 @@ public class MutationHtmlReportListenerTest {
         this.classInfo);
 
     this.testee = new MutationHtmlReportListener(StandardCharsets.UTF_8, this.coverageDb,
-        this.outputStrategy, Collections.<String>emptyList(), true, Collections.emptyList(), true, this.sourceLocator);
+        this.outputStrategy, Collections.<String>emptyList(), true, Collections.emptyList(), true, 0, this.sourceLocator);
   }
 
   @Test

--- a/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
+++ b/pitest-html-report/src/test/java/org/pitest/mutationtest/report/html/MutationTotalsTest.java
@@ -107,4 +107,38 @@ public class MutationTotalsTest {
     assertEquals(50, this.testee.getTestStrength());
   }
 
+  @Test
+  public void shouldReturnIntegerLineCoverageLabelAtDefaultPrecision() {
+    this.testee.addLines(1295);
+    this.testee.addLinesCovered(796);
+    assertEquals("61", this.testee.getLineCoverageLabel());
+  }
+
+  @Test
+  public void shouldReturnDecimalLineCoverageLabelWhenPrecisionSet() {
+    MutationTotals totals = new MutationTotals();
+    totals.setThresholdPrecision(2);
+    totals.addLines(1295);
+    totals.addLinesCovered(796);
+    assertEquals("61.47", totals.getLineCoverageLabel());
+  }
+
+  @Test
+  public void shouldReturnDecimalMutationCoverageLabelWhenPrecisionSet() {
+    MutationTotals totals = new MutationTotals();
+    totals.setThresholdPrecision(2);
+    totals.addMutations(413);
+    totals.addMutationsDetetcted(324);
+    assertEquals("78.45", totals.getMutationCoverageLabel());
+  }
+
+  @Test
+  public void shouldReturnDecimalTestStrengthLabelWhenPrecisionSet() {
+    MutationTotals totals = new MutationTotals();
+    totals.setThresholdPrecision(2);
+    totals.addMutationsWithCoverage(335);
+    totals.addMutationsDetetcted(324);
+    assertEquals("96.72", totals.getTestStrengthLabel());
+  }
+
 }

--- a/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/MojoToReportOptionsConverter.java
@@ -327,6 +327,8 @@ public class MojoToReportOptionsConverter {
 
     data.setSkipFailingTests(this.mojo.skipFailingTests());
 
+    data.setThresholdPrecision(this.mojo.getThresholdPrecision());
+
     data.setInputEncoding(this.mojo.getSourceEncoding());
     data.setOutputEncoding(this.mojo.getOutputEncoding());
 

--- a/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/PitMojo.java
@@ -24,6 +24,7 @@ import uk.org.lidalia.sysoutslf4j.context.SysOutOverSLF4J;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -265,25 +266,31 @@ public final class PitMojo extends AbstractMojo {
    * Mutation score threshold at which to fail build
    */
   @Parameter(defaultValue = "0", property = "mutationThreshold")
-  private int                         mutationThreshold;
+  private String                      mutationThreshold = "0";
 
   /**
    * Test strength score threshold at which to fail build
    */
   @Parameter(defaultValue = "0", property = "testStrengthThreshold")
-  private int                         testStrengthThreshold;
+  private String                      testStrengthThreshold = "0";
 
   /**
    * Maximum surviving mutants to allow
    */
   @Parameter(defaultValue = "-1", property = "maxSurviving")
   private int                         maxSurviving = -1;
-    
+
   /**
    * Line coverage threshold at which to fail build
    */
   @Parameter(defaultValue = "0", property = "coverageThreshold")
-  private int                         coverageThreshold;
+  private String                      coverageThreshold = "0";
+
+  /**
+   * Number of decimal places to use when comparing threshold values
+   */
+  @Parameter(defaultValue = "0", property = "thresholdPrecision")
+  private int                         thresholdPrecision;
 
   /**
    * Path to java executable to use when running tests. Will default to
@@ -533,33 +540,42 @@ public final class PitMojo extends AbstractMojo {
 
   private void throwErrorIfCoverageBelowThreshold(
       final CoverageSummary coverageSummary) throws MojoFailureException {
-    if ((this.coverageThreshold != 0)
-        && (coverageSummary.getCoverage() < this.coverageThreshold)) {
-      throw new MojoFailureException("Line coverage of "
-          + coverageSummary.getCoverage() + "("
-          + coverageSummary.getNumberOfCoveredLines() + "/"
-          + coverageSummary.getNumberOfLines() + ") is below threshold of "
-          + this.coverageThreshold);
+    BigDecimal threshold = new BigDecimal(this.coverageThreshold);
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = coverageSummary.getCoverage(this.thresholdPrecision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new MojoFailureException("Line coverage of "
+            + actual + "("
+            + coverageSummary.getNumberOfCoveredLines() + "/"
+            + coverageSummary.getNumberOfLines() + ") is below threshold of "
+            + threshold);
+      }
     }
   }
 
   private void throwErrorIfScoreBelowThreshold(final MutationStatistics result)
       throws MojoFailureException {
-    if ((this.mutationThreshold != 0)
-        && (result.getPercentageDetected() < this.mutationThreshold)) {
-      throw new MojoFailureException("Mutation score of "
-          + result.getPercentageDetected() + " is below threshold of "
-          + this.mutationThreshold);
+    BigDecimal threshold = new BigDecimal(this.mutationThreshold);
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = result.getPercentageDetected(this.thresholdPrecision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new MojoFailureException("Mutation score of "
+            + actual + " is below threshold of "
+            + threshold);
+      }
     }
   }
 
   private void throwErrorIfTestStrengthBelowThreshold(final MutationStatistics result)
           throws MojoFailureException {
-    if ((this.testStrengthThreshold != 0)
-            && (result.getTestStrength() < this.testStrengthThreshold)) {
-      throw new MojoFailureException("Test strength score of "
-              + result.getTestStrength() + " is below threshold of "
-              + this.testStrengthThreshold);
+    BigDecimal threshold = new BigDecimal(this.testStrengthThreshold);
+    if (threshold.compareTo(BigDecimal.ZERO) != 0) {
+      BigDecimal actual = result.getTestStrength(this.thresholdPrecision);
+      if (actual.compareTo(threshold) < 0) {
+        throw new MojoFailureException("Test strength score of "
+                + actual + " is below threshold of "
+                + threshold);
+      }
     }
   }
   
@@ -855,6 +871,10 @@ public final class PitMojo extends AbstractMojo {
 
   public boolean isDryRun() {
     return this.dryRun;
+  }
+
+  public int getThresholdPrecision() {
+    return this.thresholdPrecision;
   }
 
     static class RunDecision {

--- a/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
+++ b/pitest-maven/src/main/java/org/pitest/maven/report/AbstractPitAggregationReportMojo.java
@@ -16,6 +16,7 @@ import org.pitest.mutationtest.config.UndatedReportDirCreationStrategy;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,19 +44,22 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
    * Mutation score threshold at which to fail build
    */
   @Parameter(defaultValue = "0", property = "aggregatedMutationThreshold")
-  private int aggregatedMutationThreshold;
+  private String aggregatedMutationThreshold = "0";
 
   /**
    * Test strength score threshold at which to fail build
    */
   @Parameter(defaultValue = "0", property = "aggregatedTestStrengthThreshold")
-  private int aggregatedTestStrengthThreshold;
+  private String aggregatedTestStrengthThreshold = "0";
 
   /**
    * Maximum surviving mutants to allow
    */
   @Parameter(defaultValue = "-1", property = "aggregatedMaxSurviving")
   private int aggregatedMaxSurviving = -1;
+
+  @Parameter(defaultValue = "0", property = "aggregatedThresholdPrecision")
+  private int aggregatedThresholdPrecision;
 
   private final ReportSourceLocator reportSourceLocator = new ReportSourceLocator();
 
@@ -92,6 +96,7 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
           .resultOutputStrategy(new DirectoryResultOutputStrategy(
               getReportsDirectory().getAbsolutePath(),
               new UndatedReportDirCreationStrategy()))
+          .thresholdPrecision(this.aggregatedThresholdPrecision)
           .build();
 
       AggregationResult result = reportAggregator.aggregateReport();
@@ -176,23 +181,25 @@ abstract class AbstractPitAggregationReportMojo extends PitReportMojo {
         sourceRoots);
   }
 
-  private void throwErrorIfScoreBelowThreshold(final int mutationCoverage)
+  private void throwErrorIfScoreBelowThreshold(final BigDecimal mutationCoverage)
       throws MojoFailureException {
-    if ((this.aggregatedMutationThreshold != 0)
-        && (mutationCoverage < this.aggregatedMutationThreshold)) {
+    BigDecimal threshold = new BigDecimal(this.aggregatedMutationThreshold);
+    if (threshold.compareTo(BigDecimal.ZERO) != 0
+        && mutationCoverage.compareTo(threshold) < 0) {
       throw new MojoFailureException("Mutation score of "
           + mutationCoverage + " is below threshold of "
-          + this.aggregatedMutationThreshold);
+          + threshold);
     }
   }
 
-  private void throwErrorIfTestStrengthBelowThreshold(final int testStrength)
+  private void throwErrorIfTestStrengthBelowThreshold(final BigDecimal testStrength)
       throws MojoFailureException {
-    if ((this.aggregatedTestStrengthThreshold != 0)
-        && (testStrength < this.aggregatedTestStrengthThreshold)) {
+    BigDecimal threshold = new BigDecimal(this.aggregatedTestStrengthThreshold);
+    if (threshold.compareTo(BigDecimal.ZERO) != 0
+        && testStrength.compareTo(threshold) < 0) {
       throw new MojoFailureException("Test strength score of "
           + testStrength + " is below threshold of "
-          + this.aggregatedTestStrengthThreshold);
+          + threshold);
     }
   }
 


### PR DESCRIPTION
This change adds a `thresholdPrecision` parameter (default 0, fully backward compatible) that controls how many decimal places are used when computing and comparing coverage and mutation thresholds. 
With integer only thresholds, there is an unavoidable `~1` percentage point blind spot where coverage can silently regress without triggering a build failure.   
  
For example, a project with coverageThreshold=61 won't catch a drop from 61.8% to 61.1% (i.e., both round to 61%).                                                                    
                                                                                                                                                                                     
Moreover, rather than maintaining two parallel APIs (i.e., one returning `int`, another `BigDecimal`) the thresholds were changed to BigDecimal throughout. A single path with `precision` set to `0` produces identical results to the old integer behaviour, so the dual-API approach would add complexity without any behaviour benefit.

Closing #1464. 

I have tested local build with my project, and it seems to work fine without any issues. Let me know what you think about it @hcoles. Hopefully I didn't forgot anything. 

This is project view I had to make a few CSS/HTLM tweaks but eventually get it worked. 
#### Project view: 

<img width="995" height="360" alt="project_view" src="https://github.com/user-attachments/assets/8bc2c309-c48b-4f34-be33-a749c896f11c" />

#### Package view:
<img width="975" height="374" alt="package_view" src="https://github.com/user-attachments/assets/13d3ac12-bcd5-479a-96d8-560bf8afdf52" />
