### PR TITLE
Progress report

### DIFF
--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
@@ -267,7 +267,8 @@ public class SettingsFactory {
 
   private static Predicate<MutationResultListenerFactory> matchesOutputFormat(
           final Iterable<String> outputFormats) {
-    return a -> FCollection.contains(outputFormats, equalsIgnoreCase(a.name()));
+    return a -> a.provides().equals(MutationResultListenerFactory.LEGACY_MODE)
+            && FCollection.contains(outputFormats, equalsIgnoreCase(a.name()));
   }
 
   private static Predicate<MutationResultListenerFactory> isActivatedByFeature() {

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/config/SettingsFactory.java
@@ -249,21 +249,29 @@ public class SettingsFactory {
   private Collection<MutationResultListenerFactory> findListeners() {
     final Iterable<? extends MutationResultListenerFactory> listeners = this.plugins
         .findListeners();
-    final Collection<MutationResultListenerFactory> matches = FCollection
-        .filter(listeners, nameMatches(this.options.getOutputFormats()));
-    if (matches.size() < this.options.getOutputFormats().size()) {
+
+    final Collection<MutationResultListenerFactory> outputFormatListeners = FCollection
+        .filter(listeners, matchesOutputFormat(this.options.getOutputFormats()));
+    if (outputFormatListeners.size() < this.options.getOutputFormats().size()) {
       throw new PitError("Unknown listener requested in "
           + String.join(",", this.options.getOutputFormats()));
     }
-    return matches;
+
+    final Collection<MutationResultListenerFactory> featureListeners = FCollection
+        .filter(listeners, isActivatedByFeature());
+
+    final Collection<MutationResultListenerFactory> all = new ArrayList<>(outputFormatListeners);
+    all.addAll(featureListeners);
+    return all;
   }
 
-  private static Predicate<MutationResultListenerFactory> nameMatches(
+  private static Predicate<MutationResultListenerFactory> matchesOutputFormat(
           final Iterable<String> outputFormats) {
-    // plugins can be either activated here by name
-    // or later via the feature mechanism
-    return a -> FCollection.contains(outputFormats, equalsIgnoreCase(a.name()))
-            || !a.provides().equals(MutationResultListenerFactory.LEGACY_MODE);
+    return a -> FCollection.contains(outputFormats, equalsIgnoreCase(a.name()));
+  }
+
+  private static Predicate<MutationResultListenerFactory> isActivatedByFeature() {
+    return a -> !a.provides().equals(MutationResultListenerFactory.LEGACY_MODE);
   }
 
 

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/progress/ProgressListener.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/progress/ProgressListener.java
@@ -1,0 +1,45 @@
+package org.pitest.mutationtest.report.progress;
+
+import org.pitest.mutationtest.ClassMutationResults;
+import org.pitest.mutationtest.MutationResultListener;
+
+import java.io.PrintStream;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+class ProgressListener implements MutationResultListener {
+
+    private final PrintStream out;
+    private final long intervalSeconds;
+    private final AtomicLong mutationsCompleted = new AtomicLong();
+    private ScheduledExecutorService scheduler;
+
+    ProgressListener(PrintStream out, long intervalSeconds) {
+        this.out = out;
+        this.intervalSeconds = intervalSeconds;
+    }
+
+    long intervalSeconds() {
+        return intervalSeconds;
+    }
+
+    @Override
+    public void runStart() {
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        scheduler.scheduleAtFixedRate(
+                () -> out.println(mutationsCompleted.get() + " mutations completed"),
+                intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void handleMutationResult(ClassMutationResults results) {
+        mutationsCompleted.addAndGet(results.getMutations().size());
+    }
+
+    @Override
+    public void runEnd() {
+        scheduler.shutdownNow();
+    }
+}

--- a/pitest-entry/src/main/java/org/pitest/mutationtest/report/progress/ProgressListenerFactory.java
+++ b/pitest-entry/src/main/java/org/pitest/mutationtest/report/progress/ProgressListenerFactory.java
@@ -1,0 +1,43 @@
+package org.pitest.mutationtest.report.progress;
+
+import org.pitest.mutationtest.ListenerArguments;
+import org.pitest.mutationtest.MutationResultListener;
+import org.pitest.mutationtest.MutationResultListenerFactory;
+import org.pitest.plugin.Feature;
+import org.pitest.plugin.FeatureParameter;
+
+import java.util.Properties;
+
+public class ProgressListenerFactory implements MutationResultListenerFactory {
+
+    private static final int DEFAULT_INTERVAL = 30;
+
+    private static final FeatureParameter INTERVAL = FeatureParameter.named("interval")
+            .withDescription("Seconds between progress reports");
+
+    @Override
+    public MutationResultListener getListener(Properties props, ListenerArguments args) {
+        int interval = args.settings()
+                .flatMap(s -> s.getInteger(INTERVAL.name()))
+                .orElse(DEFAULT_INTERVAL);
+        return new ProgressListener(System.out, interval);
+    }
+
+    @Override
+    public String name() {
+        return "progress";
+    }
+
+    @Override
+    public String description() {
+        return "Log progress during mutation analysis";
+    }
+
+    @Override
+    public Feature provides() {
+        return Feature.named("progress")
+                .withOnByDefault(false)
+                .withDescription(description())
+                .withParameter(INTERVAL);
+    }
+}

--- a/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.MutationResultListenerFactory
+++ b/pitest-entry/src/main/resources/META-INF/services/org.pitest.mutationtest.MutationResultListenerFactory
@@ -1,2 +1,3 @@
 org.pitest.mutationtest.report.csv.CSVReportFactory
 org.pitest.mutationtest.report.xml.XMLReportFactory
+org.pitest.mutationtest.report.progress.ProgressListenerFactory

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/config/SettingsFactoryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/config/SettingsFactoryTest.java
@@ -108,6 +108,12 @@ public class SettingsFactoryTest {
     this.testee.createListener();
   }
 
+  @Test(expected = PitError.class)
+  public void shouldThrowErrorWhenOutputFormatMatchesFeatureManagedListener() {
+    this.options.addOutputFormats(Arrays.asList("progress"));
+    this.testee.createListener();
+  }
+
   @Test
   public void shouldReturnADefaultJavaExecutableWhenNoneIsSpecified() {
     this.options.setJavaExecutable(null);

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/progress/ProgressListenerFactoryTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/progress/ProgressListenerFactoryTest.java
@@ -1,0 +1,59 @@
+package org.pitest.mutationtest.report.progress;
+
+import org.junit.Test;
+import org.pitest.mutationtest.ListenerArguments;
+import org.pitest.mutationtest.MutationResultListener;
+import org.pitest.mutationtest.config.PluginServices;
+import org.pitest.plugin.FeatureSetting;
+import org.pitest.plugin.ProvidesFeature;
+import org.pitest.plugin.ToggleStatus;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProgressListenerFactoryTest {
+
+    ProgressListenerFactory underTest = new ProgressListenerFactory();
+
+    @Test
+    public void isOnSpiChain() {
+        assertThat(PluginServices.makeForContextLoader().findFeatures().stream()
+                .map(ProvidesFeature::getClass)
+                .collect(Collectors.toList()))
+                .contains(ProgressListenerFactory.class);
+    }
+
+    @Test
+    public void providesProgressFeature() {
+        assertThat(underTest.provides().name()).isEqualTo("progress");
+        assertThat(underTest.provides().isOnByDefault()).isFalse();
+    }
+
+    @Test
+    public void createsListenerWithDefaultInterval() {
+        FeatureSetting setting = new FeatureSetting("progress", ToggleStatus.ACTIVATE, Collections.emptyMap());
+        ListenerArguments args = listenerArgsWithSetting(setting);
+        ProgressListener listener = (ProgressListener) underTest.getListener(null, args);
+        assertThat(listener.intervalSeconds()).isEqualTo(30);
+    }
+
+    @Test
+    public void createsListenerWithConfiguredInterval() {
+        Map<String, List<String>> settings = new HashMap<>();
+        settings.put("interval", Collections.singletonList("60"));
+        FeatureSetting setting = new FeatureSetting("progress", ToggleStatus.ACTIVATE, settings);
+        ListenerArguments args = listenerArgsWithSetting(setting);
+        ProgressListener listener = (ProgressListener) underTest.getListener(null, args);
+        assertThat(listener.intervalSeconds()).isEqualTo(60);
+    }
+
+    private ListenerArguments listenerArgsWithSetting(FeatureSetting setting) {
+        return new ListenerArguments(null, null, null, null, 0, false, null, Collections.emptyList())
+                .withSetting(setting);
+    }
+}

--- a/pitest-entry/src/test/java/org/pitest/mutationtest/report/progress/ProgressListenerTest.java
+++ b/pitest-entry/src/test/java/org/pitest/mutationtest/report/progress/ProgressListenerTest.java
@@ -1,0 +1,45 @@
+package org.pitest.mutationtest.report.progress;
+
+import org.junit.Test;
+import org.pitest.mutationtest.report.MutationTestResultMother;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pitest.mutationtest.report.MutationTestResultMother.aMutationTestResult;
+import static org.pitest.mutationtest.report.MutationTestResultMother.createClassResults;
+
+public class ProgressListenerTest {
+
+    private final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    private final PrintStream out = new PrintStream(os);
+
+    @Test
+    public void shouldCountIndividualMutationsAcrossMultipleResults() throws Exception {
+        ProgressListener testee = new ProgressListener(out, 1);
+        testee.runStart();
+        try {
+            testee.handleMutationResult(createClassResults(aMutationTestResult().build()));
+            testee.handleMutationResult(createClassResults(
+                    aMutationTestResult().build(),
+                    aMutationTestResult().build(),
+                    aMutationTestResult().build()));
+            Thread.sleep(1500);
+        } finally {
+            testee.runEnd();
+        }
+
+        assertThat(os.toString()).contains("4 mutations completed");
+    }
+
+    @Test
+    public void shouldNotLogProgressWhenIntervalHasNotElapsed() {
+        ProgressListener testee = new ProgressListener(out, 60);
+        testee.runStart();
+        testee.handleMutationResult(createClassResults(aMutationTestResult().build()));
+        testee.runEnd();
+
+        assertThat(os.toString()).doesNotContain("mutations completed");
+    }
+}


### PR DESCRIPTION
The mutation analysis phase can take a long time, but there's no indication of how far along it is. This adds periodic progress logging that reports how many mutation test units have completed out of the total, giving a rough sense of how much time remains.

- Adds a scheduled progress reporter to `MutationAnalysisExecutor` that logs completion count at a configurable interval                                                                                       
- Exposes `progressInterval` (in seconds) as a configuration option via CLI and Maven plugin                                                                                                                 
- Defaults to disabled (0) for backwards compatibility; opt in by setting a positive interval
